### PR TITLE
refactor soteria workflow

### DIFF
--- a/.github/workflows/ci-soteria.yml
+++ b/.github/workflows/ci-soteria.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        program: [ 'programs/mango-v4' ]
+        program: [ 'programs/mango-v4', 'programs/margin-trade' ]
     env:
       PROGRAM_PATH: ${{ matrix.program }}
       
@@ -63,4 +63,3 @@ jobs:
           cd ${{ matrix.program }}
           soteria -analyzeAll .
         shell: bash
-        


### PR DESCRIPTION
Problem: Soteria is running against the root, including non-Solana programs causing errors

Solution: Change Soteria to run as matrix job against Solana programs. The jobs run in parallel and can leverage same cache, so shouldn't be material performance changes