### PR TITLE
close mango account without checks when testing flag is set on the group, workaround weird issues when all dust cant be withdraw

### DIFF
--- a/programs/mango-v4/src/instructions/close_account.rs
+++ b/programs/mango-v4/src/instructions/close_account.rs
@@ -5,9 +5,12 @@ use crate::state::*;
 
 #[derive(Accounts)]
 pub struct CloseAccount<'info> {
+    pub group: AccountLoader<'info, Group>,
+
     #[account(
         mut,
         has_one = owner,
+        has_one = group,
         close = sol_destination
     )]
     pub account: AccountLoader<'info, MangoAccount>,
@@ -21,6 +24,13 @@ pub struct CloseAccount<'info> {
 }
 
 pub fn close_account(ctx: Context<CloseAccount>) -> Result<()> {
+    let group = ctx.accounts.group.load()?;
+
+    // don't perform checks if group is just testing
+    if group.testing == 1 {
+        return Ok(());
+    }
+
     let account = ctx.accounts.account.load()?;
     require_eq!(account.being_liquidated, 0);
     require_eq!(account.delegate, Pubkey::default());

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -1297,6 +1297,7 @@ impl<'keypair> ClientInstruction for CreateAccountInstruction<'keypair> {
 }
 
 pub struct CloseAccountInstruction<'keypair> {
+    pub group: Pubkey,
     pub account: Pubkey,
     pub owner: &'keypair Keypair,
     pub sol_destination: Pubkey,
@@ -1313,6 +1314,7 @@ impl<'keypair> ClientInstruction for CloseAccountInstruction<'keypair> {
         let instruction = Self::Instruction {};
 
         let accounts = Self::Accounts {
+            group: self.group,
             owner: self.owner.pubkey(),
             account: self.account,
             sol_destination: self.sol_destination,

--- a/programs/mango-v4/tests/test_basic.rs
+++ b/programs/mango-v4/tests/test_basic.rs
@@ -169,6 +169,7 @@ async fn test_basic() -> Result<(), TransportError> {
     send_tx(
         solana,
         CloseAccountInstruction {
+            group,
             account,
             owner,
             sol_destination: payer.pubkey(),


### PR DESCRIPTION
Tyler had some issues withdrawing all tokens from account, we should investigate that at some point, this is a workaround for now.

Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>