### PR TITLE
Remove is_bankrupt

### DIFF
--- a/programs/mango-v4/src/instructions/account_close.rs
+++ b/programs/mango-v4/src/instructions/account_close.rs
@@ -33,7 +33,6 @@ pub fn account_close(ctx: Context<AccountClose>) -> Result<()> {
         // don't perform checks if group is just testing
         if group.testing == 0 {
             require!(!account.fixed.being_liquidated(), MangoError::SomeError);
-            require!(!account.fixed.is_bankrupt(), MangoError::SomeError);
             require_eq!(account.fixed.delegate, Pubkey::default());
             for ele in account.token_iter() {
                 require_eq!(ele.is_active(), false);

--- a/programs/mango-v4/src/instructions/account_create.rs
+++ b/programs/mango-v4/src/instructions/account_create.rs
@@ -48,7 +48,6 @@ pub fn account_create(
     account.fixed.bump = *ctx.bumps.get("account").ok_or(MangoError::SomeError)?;
     account.fixed.delegate = Pubkey::default();
     account.fixed.set_being_liquidated(false);
-    account.fixed.set_bankrupt(false);
 
     account.expand_dynamic_content(token_count, serum3_count, perp_count, perp_oo_count)?;
 

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -184,8 +184,6 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
     let mut account = ctx.accounts.account.load_mut()?;
     let group = account.fixed.group;
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     // Find index at which vaults start
     let vaults_index = ctx
         .remaining_accounts

--- a/programs/mango-v4/src/instructions/perp_cancel_all_orders.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_all_orders.rs
@@ -31,8 +31,6 @@ pub fn perp_cancel_all_orders(ctx: Context<PerpCancelAllOrders>, limit: u8) -> R
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let mut perp_market = ctx.accounts.perp_market.load_mut()?;
     let bids = ctx.accounts.bids.load_mut()?;
     let asks = ctx.accounts.asks.load_mut()?;

--- a/programs/mango-v4/src/instructions/perp_cancel_all_orders_by_side.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_all_orders_by_side.rs
@@ -36,8 +36,6 @@ pub fn perp_cancel_all_orders_by_side(
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let mut perp_market = ctx.accounts.perp_market.load_mut()?;
     let bids = ctx.accounts.bids.load_mut()?;
     let asks = ctx.accounts.asks.load_mut()?;

--- a/programs/mango-v4/src/instructions/perp_cancel_order.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_order.rs
@@ -31,8 +31,6 @@ pub fn perp_cancel_order(ctx: Context<PerpCancelOrder>, order_id: i128) -> Resul
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let perp_market = ctx.accounts.perp_market.load_mut()?;
     let bids = ctx.accounts.bids.load_mut()?;
     let asks = ctx.accounts.asks.load_mut()?;

--- a/programs/mango-v4/src/instructions/perp_cancel_order_by_client_order_id.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_order_by_client_order_id.rs
@@ -34,8 +34,6 @@ pub fn perp_cancel_order_by_client_order_id(
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let perp_market = ctx.accounts.perp_market.load_mut()?;
     let bids = ctx.accounts.bids.load_mut()?;
     let asks = ctx.accounts.asks.load_mut()?;

--- a/programs/mango-v4/src/instructions/perp_place_order.rs
+++ b/programs/mango-v4/src/instructions/perp_place_order.rs
@@ -81,7 +81,6 @@ pub fn perp_place_order(
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
     let account_pk = ctx.accounts.account.key();
 
     {

--- a/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
@@ -51,8 +51,6 @@ pub fn serum3_cancel_all_orders(ctx: Context<Serum3CancelAllOrders>, limit: u8) 
             MangoError::SomeError
         );
 
-        require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
         let serum_market = ctx.accounts.serum_market.load()?;
 
         // Validate open_orders

--- a/programs/mango-v4/src/instructions/serum3_cancel_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_order.rs
@@ -64,8 +64,6 @@ pub fn serum3_cancel_order(
             MangoError::SomeError
         );
 
-        require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
         // Validate open_orders
         require!(
             account

--- a/programs/mango-v4/src/instructions/serum3_close_open_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_close_open_orders.rs
@@ -41,8 +41,6 @@ pub fn serum3_close_open_orders(ctx: Context<Serum3CloseOpenOrders>) -> Result<(
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let serum_market = ctx.accounts.serum_market.load()?;
 
     // Validate open_orders

--- a/programs/mango-v4/src/instructions/serum3_create_open_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_create_open_orders.rs
@@ -53,8 +53,6 @@ pub fn serum3_create_open_orders(ctx: Context<Serum3CreateOpenOrders>) -> Result
         MangoError::SomeError
     );
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
     let serum_account = account.serum3_create(serum_market.market_index)?;
     serum_account.open_orders = ctx.accounts.open_orders.key();
     serum_account.base_token_index = serum_market.base_token_index;

--- a/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
@@ -70,7 +70,6 @@ pub fn serum3_liq_force_cancel_orders(
     //
     {
         let account = ctx.accounts.account.load()?;
-        require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
         let serum_market = ctx.accounts.serum_market.load()?;
 
         // Validate open_orders

--- a/programs/mango-v4/src/instructions/serum3_place_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_place_order.rs
@@ -168,7 +168,6 @@ pub fn serum3_place_order(
             account.fixed.is_owner_or_delegate(ctx.accounts.owner.key()),
             MangoError::SomeError
         );
-        require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
 
         // Validate open_orders
         require!(

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -78,8 +78,6 @@ pub fn serum3_settle_funds(ctx: Context<Serum3SettleFunds>) -> Result<()> {
             MangoError::SomeError
         );
 
-        require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
-
         // Validate open_orders
         require!(
             account

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -61,7 +61,6 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
     // Get the account's position for that token index
     let mut account = ctx.accounts.account.load_mut()?;
 
-    require!(!account.fixed.is_bankrupt(), MangoError::IsBankrupt);
     let (position, raw_token_index, active_token_index) =
         account.token_get_mut_or_create(token_index)?;
 

--- a/programs/mango-v4/src/state/health.rs
+++ b/programs/mango-v4/src/state/health.rs
@@ -16,7 +16,7 @@ use crate::util::checked_math as cm;
 
 use super::MangoAccountRef;
 
-const BANKRUPTCY_DUST_THRESHOLD: I80F48 = I80F48!(0.000001);
+const ONE_NATIVE_USDC_IN_USD: I80F48 = I80F48!(0.000001);
 
 /// This trait abstracts how to find accounts needed for the health computation.
 ///
@@ -565,13 +565,14 @@ impl HealthCache {
     }
 
     pub fn has_liquidatable_assets(&self) -> bool {
-        let spot_liquidatable = self.token_infos.iter().any(|ti| {
-            ti.balance > BANKRUPTCY_DUST_THRESHOLD || ti.serum3_max_reserved.is_positive()
-        });
+        let spot_liquidatable = self
+            .token_infos
+            .iter()
+            .any(|ti| ti.balance.is_positive() || ti.serum3_max_reserved.is_positive());
         let perp_liquidatable = self
             .perp_infos
             .iter()
-            .any(|p| p.base != 0 || p.quote > BANKRUPTCY_DUST_THRESHOLD);
+            .any(|p| p.base != 0 || p.quote > ONE_NATIVE_USDC_IN_USD);
         spot_liquidatable || perp_liquidatable
     }
 

--- a/programs/mango-v4/tests/test_bankrupt_tokens.rs
+++ b/programs/mango-v4/tests/test_bankrupt_tokens.rs
@@ -220,7 +220,6 @@ async fn test_bankrupt_tokens_socialize_loss() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     // eat collateral2, leaving the account bankrupt
     send_tx(
@@ -246,7 +245,6 @@ async fn test_bankrupt_tokens_socialize_loss() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(liqee.is_bankrupt());
 
     //
     // TEST: socialize loss on borrow1 and 2
@@ -272,7 +270,6 @@ async fn test_bankrupt_tokens_socialize_loss() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(liqee.is_bankrupt());
     assert!(account_position_closed(solana, account, borrow_token1.bank).await);
     // both bank's borrows were completely wiped: no one else borrowed
     let borrow1_bank0: Bank = solana.get_account(borrow_token1.bank).await;
@@ -299,7 +296,6 @@ async fn test_bankrupt_tokens_socialize_loss() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(!liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
     assert!(account_position_closed(solana, account, borrow_token2.bank).await);
 
     Ok(())
@@ -531,7 +527,6 @@ async fn test_bankrupt_tokens_insurance_fund() -> Result<(), TransportError> {
     assert!(account_position_closed(solana, account, collateral_token1.bank).await);
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     // eat collateral2, leaving the account bankrupt
     send_tx(
@@ -552,7 +547,6 @@ async fn test_bankrupt_tokens_insurance_fund() -> Result<(), TransportError> {
     assert!(account_position_closed(solana, account, collateral_token2.bank).await,);
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(liqee.is_bankrupt());
 
     //
     // TEST: use the insurance fund to liquidate borrow1 and borrow2
@@ -577,7 +571,6 @@ async fn test_bankrupt_tokens_insurance_fund() -> Result<(), TransportError> {
     .unwrap();
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(liqee.is_bankrupt());
     assert!(account_position_closed(solana, account, borrow_token1.bank).await);
     assert_eq!(
         solana.token_account_balance(insurance_vault).await,
@@ -610,7 +603,6 @@ async fn test_bankrupt_tokens_insurance_fund() -> Result<(), TransportError> {
     .unwrap();
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(liqee.is_bankrupt());
     assert!(account_position_closed(solana, account, borrow_token1.bank).await);
     assert_eq!(
         account_position(solana, account, borrow_token2.bank).await,
@@ -645,7 +637,6 @@ async fn test_bankrupt_tokens_insurance_fund() -> Result<(), TransportError> {
     .unwrap();
     let liqee = get_mango_account(solana, account).await;
     assert!(!liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
     assert!(account_position_closed(solana, account, borrow_token1.bank).await);
     assert!(account_position_closed(solana, account, borrow_token2.bank).await);
     assert_eq!(solana.token_account_balance(insurance_vault).await, 0);

--- a/programs/mango-v4/tests/test_liq_tokens.rs
+++ b/programs/mango-v4/tests/test_liq_tokens.rs
@@ -406,7 +406,6 @@ async fn test_liq_tokens_with_token() -> Result<(), TransportError> {
     assert!(account_position_closed(solana, account, collateral_token2.bank).await,);
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     //
     // TEST: liquidate the remaining borrow2 against collateral1,
@@ -436,7 +435,6 @@ async fn test_liq_tokens_with_token() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     //
     // TEST: liquidate borrow1 with collateral1, but place a limit
@@ -468,7 +466,6 @@ async fn test_liq_tokens_with_token() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     //
     // TEST: liquidate borrow1 with collateral1, making the account healthy again
@@ -503,7 +500,6 @@ async fn test_liq_tokens_with_token() -> Result<(), TransportError> {
     );
     let liqee = get_mango_account(solana, account).await;
     assert!(!liqee.being_liquidated());
-    assert!(!liqee.is_bankrupt());
 
     //
     // TEST: bankruptcy when collateral is dusted
@@ -567,11 +563,12 @@ async fn test_liq_tokens_with_token() -> Result<(), TransportError> {
     .await
     .unwrap();
 
-    // Liqee's remaining collateral got dusted, only borrows remain: bankrupt
+    // Liqee's remaining collateral got dusted, only borrows remain
+    // but the borrow amount is so tiny, that being_liquidated is already switched off
     let liqee = get_mango_account(solana, account).await;
     assert_eq!(liqee.token_iter_active().count(), 1);
-    assert!(liqee.is_bankrupt());
-    assert!(liqee.being_liquidated());
+    assert!(account_position_f64(solana, account, borrow_token1.bank).await > -1.0);
+    assert!(!liqee.being_liquidated());
 
     Ok(())
 }

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -21,7 +21,6 @@ export class MangoAccount {
       name: number[];
       delegate: PublicKey;
       beingLiquidated: number;
-      isBankrupt: number;
       accountNum: number;
       bump: number;
       netDeposits: number;
@@ -40,7 +39,6 @@ export class MangoAccount {
       obj.name,
       obj.delegate,
       obj.beingLiquidated,
-      obj.isBankrupt,
       obj.accountNum,
       obj.bump,
       obj.netDeposits,
@@ -61,7 +59,6 @@ export class MangoAccount {
     name: number[],
     public delegate: PublicKey,
     beingLiquidated: number,
-    isBankrupt: number,
     public accountNum: number,
     bump: number,
     netDeposits: number,

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -3007,10 +3007,7 @@ export type MangoV4 = {
             "type": "u8"
           },
           {
-            "name": "isBankrupt",
-            "docs": [
-              "This account cannot do anything except go through `resolve_bankruptcy`"
-            ],
+            "name": "padding5",
             "type": "u8"
           },
           {
@@ -8054,10 +8051,7 @@ export const IDL: MangoV4 = {
             "type": "u8"
           },
           {
-            "name": "isBankrupt",
-            "docs": [
-              "This account cannot do anything except go through `resolve_bankruptcy`"
-            ],
+            "name": "padding5",
             "type": "u8"
           },
           {


### PR DESCRIPTION
Instead, check for any liquidatable assets in liq_token_bankruptcy.

Bankrupt accounts may use the same operations as any other
negative-health account.