### PR TITLE
ScanningAccountRetriever: Don't mut-borrow oracles

### DIFF
--- a/programs/mango-v4/src/accounts_zerocopy.rs
+++ b/programs/mango-v4/src/accounts_zerocopy.rs
@@ -38,6 +38,10 @@ impl<'a, 'info: 'a> AccountInfoRef<'a, 'info> {
             //data: account_info.try_borrow_data()?,
         })
     }
+
+    pub fn borrow_slice(ais: &'a [AccountInfo<'info>]) -> Result<Vec<Self>> {
+        ais.iter().map(Self::borrow).collect()
+    }
 }
 
 pub struct AccountInfoRefMut<'a, 'info: 'a> {
@@ -56,6 +60,10 @@ impl<'a, 'info: 'a> AccountInfoRefMut<'a, 'info> {
                 .try_borrow_mut()
                 .map_err(|_| ProgramError::AccountBorrowFailed)?,
         })
+    }
+
+    pub fn borrow_slice(ais: &'a [AccountInfo<'info>]) -> Result<Vec<Self>> {
+        ais.iter().map(Self::borrow).collect()
     }
 }
 


### PR DESCRIPTION
This allows using the same oracle for different banks, like for ETH and
soETH.