### PR TITLE
FlashLoan: Fix validation holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Update this for each mainnet deployment.
 ## not on mainnet
 
 - liq_token_bankruptcy: removed liab_token_index argument
+- flash_loan: both begin and end instructions now require the group to be passed as the final trailing remaining account
 
 ## mainnet
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1072,7 +1072,6 @@ impl MangoClient {
             accounts: {
                 let mut ams = anchor_lang::ToAccountMetas::to_account_metas(
                     &mango_v4::accounts::FlashLoanBegin {
-                        group: self.group(),
                         token_program: Token::id(),
                         instructions: solana_sdk::sysvar::instructions::id(),
                     },
@@ -1081,6 +1080,7 @@ impl MangoClient {
                 ams.extend(bank_ams);
                 ams.extend(vault_ams.clone());
                 ams.extend(token_ams.clone());
+                ams.push(to_readonly_account_meta(self.group()));
                 ams
             },
             data: anchor_lang::InstructionData::data(&mango_v4::instruction::FlashLoanBegin {
@@ -1104,6 +1104,7 @@ impl MangoClient {
                 ams.extend(health_ams);
                 ams.extend(vault_ams);
                 ams.extend(token_ams);
+                ams.push(to_readonly_account_meta(self.group()));
                 ams
             },
             data: anchor_lang::InstructionData::data(&mango_v4::instruction::FlashLoanEnd {}),

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -210,12 +210,10 @@ pub mod mango_v4 {
         instructions::stub_oracle_set(ctx, price)
     }
 
-    // NOTE: keep disc synced in token_update_index_and_rate ix
     pub fn token_deposit(ctx: Context<TokenDeposit>, amount: u64) -> Result<()> {
         instructions::token_deposit(ctx, amount)
     }
 
-    // NOTE: keep disc synced in token_update_index_and_rate ix
     pub fn token_withdraw(
         ctx: Context<TokenWithdraw>,
         amount: u64,
@@ -231,7 +229,6 @@ pub mod mango_v4 {
         instructions::flash_loan_begin(ctx, loan_amounts)
     }
 
-    // NOTE: keep disc synced in flash_loan.rs
     pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         ctx: Context<'key, 'accounts, 'remaining, 'info, FlashLoanEnd<'info>>,
     ) -> Result<()> {

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -342,7 +342,6 @@ impl ClientInstruction for FlashLoanBeginInstruction {
         let program_id = mango_v4::id();
 
         let accounts = Self::Accounts {
-            group: self.group,
             token_program: Token::id(),
             instructions: solana_program::sysvar::instructions::id(),
         };
@@ -365,6 +364,11 @@ impl ClientInstruction for FlashLoanBeginInstruction {
         instruction.accounts.push(AccountMeta {
             pubkey: self.target_token_account,
             is_writable: true,
+            is_signer: false,
+        });
+        instruction.accounts.push(AccountMeta {
+            pubkey: self.group,
+            is_writable: false,
             is_signer: false,
         });
 
@@ -424,6 +428,11 @@ impl<'keypair> ClientInstruction for FlashLoanEndInstruction<'keypair> {
         instruction.accounts.push(AccountMeta {
             pubkey: self.target_token_account,
             is_writable: true,
+            is_signer: false,
+        });
+        instruction.accounts.push(AccountMeta {
+            pubkey: account.fixed.group,
+            is_writable: false,
             is_signer: false,
         });
 

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -1575,6 +1575,11 @@ export class MangoClient {
       isWritable: false,
       isSigner: false,
     };
+    const groupAM = {
+      pubkey: group.publicKey,
+      isWritable: false,
+      isSigner: false,
+    };
 
     const flashLoanEndIx = await this.program.methods
       .flashLoanEnd()
@@ -1592,6 +1597,7 @@ export class MangoClient {
           pubkey: outputTokenAccountPk,
           isSigner: false,
         },
+        groupAM,
       ])
       .instruction();
 
@@ -1603,7 +1609,6 @@ export class MangoClient {
         ) /* we don't care about borrowing the target amount, this is just a dummy */,
       ])
       .accounts({
-        group: group.publicKey,
         instructions: SYSVAR_INSTRUCTIONS_PUBKEY,
       })
       .remainingAccounts([
@@ -1613,6 +1618,7 @@ export class MangoClient {
         outputBankVault,
         inputATA,
         outputATA,
+        groupAM,
       ])
       .instruction();
 

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -1183,11 +1183,6 @@ export type MangoV4 = {
       "name": "flashLoanBegin",
       "accounts": [
         {
-          "name": "group",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false
@@ -6214,11 +6209,6 @@ export const IDL: MangoV4 = {
     {
       "name": "flashLoanBegin",
       "accounts": [
-        {
-          "name": "group",
-          "isMut": false,
-          "isSigner": false
-        },
         {
           "name": "tokenProgram",
           "isMut": false,

--- a/ts/client/src/scripts/mb-flash-loan.ts
+++ b/ts/client/src/scripts/mb-flash-loan.ts
@@ -128,11 +128,12 @@ async function main() {
 
       // flash loan start ix - takes a loan for source token,
       // flash loan end ix - returns increase in all token account's amounts to respective vaults,
-      const healthRemainingAccounts = client.buildHealthRemainingAccounts(
-        group,
-        mangoAccount,
-        [sourceBank, targetBank], // we would be taking a sol loan potentially
-      );
+      const healthRemainingAccounts =
+        client.buildFixedAccountRetrieverHealthAccounts(
+          group,
+          mangoAccount,
+          [sourceBank, targetBank], // we would be taking a sol loan potentially
+        );
       // 1. build flash loan end ix
       const flashLoadnEndIx = await client.program.methods
         .flashLoanEnd()
@@ -175,6 +176,11 @@ async function main() {
             isWritable: true, // increase in this address amount is transferred back to the targetBank.vault above in this case whatever is result of swap
             isSigner: false,
           } as AccountMeta,
+          {
+            pubkey: group.publicKey,
+            isWritable: false,
+            isSigner: false,
+          } as AccountMeta,
         ])
         .instruction();
       instructions.push(flashLoadnEndIx);
@@ -188,7 +194,6 @@ async function main() {
             ) /* we don't care about borrowing the target amount, this is just a dummy */,
           ])
           .accounts({
-            group: group.publicKey,
             // for observing ixs in the entire tx,
             // e.g. apart from flash loan start and end no other ix should target mango v4 program
             // e.g. forbid FlashLoanBegin been called from CPI
@@ -229,6 +234,11 @@ async function main() {
                 mangoAccount.owner,
               ),
               isWritable: false, // this is a dummy, its just done so that we match flash loan start and end ix
+              isSigner: false,
+            } as AccountMeta,
+            {
+              pubkey: group.publicKey,
+              isWritable: false,
               isSigner: false,
             } as AccountMeta,
           ])


### PR DESCRIPTION
- Pass the group to Begin and End and ensure it is the same.
- Enforce target token accounts can't be group-owned.
- Now End can consistently derive the number of vaults/token accounts.