### PR TITLE
turn on strict null checks and fix issues

### DIFF
--- a/ts/client/src/accounts/bank.ts
+++ b/ts/client/src/accounts/bank.ts
@@ -25,8 +25,8 @@ export class Bank {
   public rate1: I80F48;
   public util0: I80F48;
   public util1: I80F48;
-  public price: I80F48;
-  public uiPrice: number;
+  public price: I80F48 | undefined;
+  public uiPrice: number | undefined;
   public collectedFeesNative: I80F48;
   public loanFeeRate: I80F48;
   public loanOriginationFeeRate: I80F48;
@@ -198,7 +198,7 @@ export class Bank {
       '\n oracle - ' +
       this.oracle.toBase58() +
       '\n price - ' +
-      this.price.toNumber() +
+      this.price?.toNumber() +
       '\n uiPrice - ' +
       this.uiPrice +
       '\n deposit index - ' +

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -91,14 +91,14 @@ export class Group {
     } else if (client.idsSource === 'static') {
       ids = Id.fromIdsByPk(this.publicKey);
     } else {
-      ids = null;
+      ids = undefined;
     }
 
     // console.time('group.reload');
     await Promise.all([
       this.reloadBanks(client, ids).then(() =>
         Promise.all([
-          this.reloadBankPrices(client, ids),
+          this.reloadBankPrices(client),
           this.reloadVaults(client, ids),
         ]),
       ),
@@ -130,9 +130,9 @@ export class Group {
     for (const bank of banks) {
       const mintId = bank.mint.toString();
       if (this.banksMapByMint.has(mintId)) {
-        this.banksMapByMint.get(mintId).push(bank);
-        this.banksMapByName.get(bank.name).push(bank);
-        this.banksMapByTokenIndex.get(bank.tokenIndex).push(bank);
+        this.banksMapByMint.get(mintId)?.push(bank);
+        this.banksMapByName.get(bank.name)?.push(bank);
+        this.banksMapByTokenIndex.get(bank.tokenIndex)?.push(bank);
       } else {
         this.banksMapByMint.set(mintId, [bank]);
         this.banksMapByName.set(bank.name, [bank]);
@@ -224,8 +224,11 @@ export class Group {
     );
   }
 
-  public async reloadBankPrices(client: MangoClient, ids?: Id): Promise<void> {
-    const banks = Array.from(this?.banksMapByMint, ([, value]) => value);
+  public async reloadBankPrices(client: MangoClient): Promise<void> {
+    const banks: Bank[][] = Array.from(
+      this.banksMapByMint,
+      ([, value]) => value,
+    );
     const oracles = banks.map((b) => b[0].oracle);
     const prices =
       await client.program.provider.connection.getMultipleAccountsInfo(oracles);
@@ -238,6 +241,8 @@ export class Group {
           bank.uiPrice = 1;
         } else {
           // TODO: Implement switchboard oracle type
+          if (!price)
+            throw new Error('Undefined price object in reloadBankPrices');
           if (
             !BorshAccountsCoder.accountDiscriminator('stubOracle').compare(
               price.data.slice(0, 8),
@@ -248,21 +253,21 @@ export class Group {
             bank.uiPrice = this?.toUiPrice(
               bank.price,
               bank.mint,
-              this?.insuranceMint,
+              this.insuranceMint,
             );
           } else if (isPythOracle(price)) {
             bank.uiPrice = parsePriceData(price.data).previousPrice;
             bank.price = this?.toNativePrice(
               bank.uiPrice,
               bank.mint,
-              this?.insuranceMint,
+              this.insuranceMint,
             );
           } else if (isSwitchboardOracle(price)) {
             bank.uiPrice = await parseSwitchboardOracle(price);
             bank.price = this?.toNativePrice(
               bank.uiPrice,
               bank.mint,
-              this?.insuranceMint,
+              this.insuranceMint,
             );
           } else {
             throw new Error(
@@ -278,28 +283,40 @@ export class Group {
     const vaultPks = Array.from(this.banksMapByMint.values())
       .flat()
       .map((bank) => bank.vault);
+    const vaultAccounts =
+      await client.program.provider.connection.getMultipleAccountsInfo(
+        vaultPks,
+      );
+
     this.vaultAmountsMap = new Map(
-      (
-        await client.program.provider.connection.getMultipleAccountsInfo(
-          vaultPks,
-        )
-      ).map((vaultAi, i) => [
-        vaultPks[i].toBase58(),
-        coder().accounts.decode('token', vaultAi.data).amount.toNumber(),
-      ]),
+      vaultAccounts.map((vaultAi, i) => {
+        if (!vaultAi) throw new Error('Missing vault account info');
+        const vaultAmount = coder()
+          .accounts.decode('token', vaultAi.data)
+          .amount.toNumber();
+        return [vaultPks[i].toBase58(), vaultAmount];
+      }),
     );
   }
 
   public getMintDecimals(mintPk: PublicKey) {
-    return this.banksMapByMint.get(mintPk.toString())[0].mintDecimals;
+    const banks = this.banksMapByMint.get(mintPk.toString());
+    if (!banks)
+      throw new Error(`Unable to find mint decimals for ${mintPk.toString()}`);
+    return banks[0].mintDecimals;
   }
 
   public getFirstBankByMint(mintPk: PublicKey) {
-    return this.banksMapByMint.get(mintPk.toString())![0];
+    const banks = this.banksMapByMint.get(mintPk.toString());
+    if (!banks) throw new Error(`Unable to find bank for ${mintPk.toString()}`);
+    return banks[0];
   }
 
-  public getFirstBankByTokenIndex(tokenIndex: number) {
-    return this.banksMapByTokenIndex.get(tokenIndex)[0];
+  public getFirstBankByTokenIndex(tokenIndex: number): Bank {
+    const banks = this.banksMapByTokenIndex.get(tokenIndex);
+    if (!banks)
+      throw new Error(`Unable to find banks for tokenIndex ${tokenIndex}`);
+    return banks[0];
   }
 
   /**
@@ -309,11 +326,18 @@ export class Group {
    */
   public getTokenVaultBalanceByMint(mintPk: PublicKey): I80F48 {
     const banks = this.banksMapByMint.get(mintPk.toBase58());
-    let amount = 0;
+    if (!banks)
+      throw new Error(
+        `Mint does not exist in getTokenVaultBalanceByMint ${mintPk.toString()}`,
+      );
+    let totalAmount = 0;
     for (const bank of banks) {
-      amount += this.vaultAmountsMap.get(bank.vault.toBase58());
+      const amount = this.vaultAmountsMap.get(bank.vault.toBase58());
+      if (amount) {
+        totalAmount += amount;
+      }
     }
-    return I80F48.fromNumber(amount);
+    return I80F48.fromNumber(totalAmount);
   }
 
   /**
@@ -322,10 +346,10 @@ export class Group {
    * @returns sum of ui balances of vaults for all banks for a token
    */
   public getTokenVaultBalanceByMintUi(mintPk: PublicKey): number {
-    return toUiDecimals(
-      this.getTokenVaultBalanceByMint(mintPk),
-      this.getMintDecimals(mintPk),
-    );
+    const vaultBalance = this.getTokenVaultBalanceByMint(mintPk);
+    const mintDecimals = this.getMintDecimals(mintPk);
+
+    return toUiDecimals(vaultBalance, mintDecimals);
   }
 
   public consoleLogBanks() {
@@ -379,7 +403,7 @@ export class Group {
         )
         .join(', ');
 
-    const banks = [];
+    const banks: Bank[] = [];
     for (const tokenBanks of this.banksMapByMint.values()) {
       for (const bank of tokenBanks) {
         banks.push(bank);

--- a/ts/client/src/accounts/healthCache.ts
+++ b/ts/client/src/accounts/healthCache.ts
@@ -205,6 +205,10 @@ export class HealthCache {
     for (const change of nativeTokenChanges) {
       const bank: Bank = group.getFirstBankByMint(change.mintPk);
       const changeIndex = adjustedCache.getOrCreateTokenInfoIndex(bank);
+      if (!bank.price)
+        throw new Error(
+          `Oracle price not loaded for ${change.mintPk.toString()}`,
+        );
       adjustedCache.tokenInfos[changeIndex].balance = adjustedCache.tokenInfos[
         changeIndex
       ].balance.add(change.nativeTokenAmount.mul(bank.price));
@@ -435,6 +439,10 @@ export class TokenInfo {
   }
 
   static emptyFromBank(bank: Bank): TokenInfo {
+    if (!bank.price)
+      throw new Error(
+        `Failed to create TokenInfo. Bank price unavailable. ${bank.mint.toString()}`,
+      );
     return new TokenInfo(
       bank.tokenIndex,
       bank.maintAssetWeight,

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -101,6 +101,8 @@ export async function parseSwitchboardOracle(
   ) {
     return parseSwitcboardOracleV1(accountInfo);
   }
+
+  throw new Error(`Unable to parse switchboard oracle ${accountInfo.owner}`);
 }
 
 export function isSwitchboardOracle(accountInfo: AccountInfo<Buffer>): boolean {

--- a/ts/client/src/ids.ts
+++ b/ts/client/src/ids.ts
@@ -51,6 +51,7 @@ export class Id {
 
   static fromIdsByName(name: string): Id {
     const groupConfig = ids.groups.find((id) => id['name'] === name);
+    if (!groupConfig) throw new Error(`Unable to find group config ${name}`);
     return new Id(
       groupConfig.cluster as Cluster,
       groupConfig.name,
@@ -69,6 +70,8 @@ export class Id {
     const groupConfig = ids.groups.find(
       (id) => id['publicKey'] === groupPk.toString(),
     );
+    if (!groupConfig)
+      throw new Error(`Unable to find group config ${groupPk.toString()}`);
     return new Id(
       groupConfig.cluster as Cluster,
       groupConfig.name,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,15 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "skipLibCheck": true,
-    "target": "es2019"
+    "target": "es2019",
+    "strictNullChecks": true
   },
   "include": ["ts/client/src", "ts/client/scripts", "ts/client/scripts"],
   "exclude": [
     "./ts/**/*.test.js",
     "node_modules",
     "**/node_modules",
-    "./ts/client/src/scripts"
+    "./ts/client/src/scripts",
+    "./ts/client/src/debug-scripts"
   ]
 }


### PR DESCRIPTION
When setting up the tsconfig.json and package.json so that we could pull the client into the UI, the `strictNullChecks` flag was turned off accidentally.

This flag should be on to help us write fewer bugs in the client. The issue became most notable because our rpc call to simulate health and set `accountData` will fail occasionally. However, there are a bunch of places in the client that assume the accountData exists. Turning on `strictNullChecks` helps prevent us from making those assumptions.

I now either throw an Error or return undefined in the places that typescript complained aobut. However, we might want different logic in some of these places. For example, all of the MangoAccount class functions that read `accountData` just return undefined if it's not set. I might have a better idea after trying to integrate these changes into the UI.