### PR TITLE
reload mango account with slot

### DIFF
--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -86,6 +86,16 @@ export class MangoAccount {
     return mangoAccount;
   }
 
+  async reloadWithSlot(
+    client: MangoClient,
+    group: Group,
+  ): Promise<{ value: MangoAccount; slot: number }> {
+    const resp = await client.getMangoAccountWithSlot(this.publicKey);
+    await resp?.value.reloadAccountData(client, group);
+    Object.assign(this, resp?.value);
+    return { value: resp!.value, slot: resp!.slot };
+  }
+
   async reloadAccountData(
     client: MangoClient,
     group: Group,

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -608,6 +608,20 @@ export class MangoClient {
     );
   }
 
+  public async getMangoAccountWithSlot(mangoAccountPk: PublicKey) {
+    const resp =
+      await this.program.provider.connection.getAccountInfoAndContext(
+        mangoAccountPk,
+      );
+    if (!resp?.value) return;
+    const decodedMangoAccount = this.program.coder.accounts.decode(
+      'mangoAccount',
+      resp.value.data,
+    );
+    const mangoAccount = MangoAccount.from(mangoAccountPk, decodedMangoAccount);
+    return { slot: resp.context.slot, value: mangoAccount };
+  }
+
   public async getMangoAccountForOwner(
     group: Group,
     ownerPk: PublicKey,


### PR DESCRIPTION
Need a fetch and reload function that returns the slot so client users can avoid stale rpc data from overwriting fresher rpc data.