### PR TITLE
Perp: Api cleanups

### DIFF
--- a/programs/mango-v4/src/instructions/perp_cancel_all_orders.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_all_orders.rs
@@ -36,7 +36,7 @@ pub fn perp_cancel_all_orders(ctx: Context<PerpCancelAllOrders>, limit: u8) -> R
     let asks = ctx.accounts.asks.load_mut()?;
     let mut book = Book::new(bids, asks);
 
-    book.cancel_all_order(&mut account.borrow_mut(), &mut perp_market, limit, None)?;
+    book.cancel_all_orders(&mut account.borrow_mut(), &mut perp_market, limit, None)?;
 
     Ok(())
 }

--- a/programs/mango-v4/src/instructions/perp_cancel_all_orders_by_side.rs
+++ b/programs/mango-v4/src/instructions/perp_cancel_all_orders_by_side.rs
@@ -41,7 +41,7 @@ pub fn perp_cancel_all_orders_by_side(
     let asks = ctx.accounts.asks.load_mut()?;
     let mut book = Book::new(bids, asks);
 
-    book.cancel_all_order(
+    book.cancel_all_orders(
         &mut account.borrow_mut(),
         &mut perp_market,
         limit,

--- a/programs/mango-v4/src/state/mango_account_components.rs
+++ b/programs/mango-v4/src/state/mango_account_components.rs
@@ -308,7 +308,7 @@ impl PerpPosition {
     }
 
     /// Calculate the average entry price of the position
-    pub fn get_avg_entry_price(&self) -> I80F48 {
+    pub fn avg_entry_price(&self) -> I80F48 {
         if self.base_position_lots == 0 {
             return I80F48::ZERO; // TODO: What should this actually return? Error? NaN?
         }
@@ -316,7 +316,7 @@ impl PerpPosition {
     }
 
     /// Calculate the break even price of the position
-    pub fn get_break_even_price(&self) -> I80F48 {
+    pub fn break_even_price(&self) -> I80F48 {
         if self.base_position_lots == 0 {
             return I80F48::ZERO; // TODO: What should this actually return? Error? NaN?
         }
@@ -438,7 +438,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, 10, -100);
         assert_eq!(pos.quote_entry_native, -100);
         assert_eq!(pos.quote_running_native, -100);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(10));
+        assert_eq!(pos.avg_entry_price(), I80F48::from(10));
     }
 
     #[test]
@@ -449,7 +449,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, -10, 100);
         assert_eq!(pos.quote_entry_native, 100);
         assert_eq!(pos.quote_running_native, 100);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(10));
+        assert_eq!(pos.avg_entry_price(), I80F48::from(10));
     }
 
     #[test]
@@ -460,7 +460,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, 10, -300);
         assert_eq!(pos.quote_entry_native, -400);
         assert_eq!(pos.quote_running_native, -400);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(20));
+        assert_eq!(pos.avg_entry_price(), I80F48::from(20));
     }
 
     #[test]
@@ -471,7 +471,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, -10, 300);
         assert_eq!(pos.quote_entry_native, 400);
         assert_eq!(pos.quote_running_native, 400);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(20));
+        assert_eq!(pos.avg_entry_price(), I80F48::from(20));
     }
 
     #[test]
@@ -482,7 +482,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, 5, -250);
         assert_eq!(pos.quote_entry_native, 50);
         assert_eq!(pos.quote_running_native, -150);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(10)); // Entry price remains the same when decreasing
+        assert_eq!(pos.avg_entry_price(), I80F48::from(10)); // Entry price remains the same when decreasing
     }
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, -5, 250);
         assert_eq!(pos.quote_entry_native, -50);
         assert_eq!(pos.quote_running_native, 150);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(10)); // Entry price remains the same when decreasing
+        assert_eq!(pos.avg_entry_price(), I80F48::from(10)); // Entry price remains the same when decreasing
     }
 
     #[test]
@@ -504,7 +504,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, -10, 250);
         assert_eq!(pos.quote_entry_native, 0);
         assert_eq!(pos.quote_running_native, 150);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(0)); // Entry price zero when no position
+        assert_eq!(pos.avg_entry_price(), I80F48::from(0)); // Entry price zero when no position
     }
 
     #[test]
@@ -515,7 +515,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, 10, -250);
         assert_eq!(pos.quote_entry_native, 0);
         assert_eq!(pos.quote_running_native, -150);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(0)); // Entry price zero when no position
+        assert_eq!(pos.avg_entry_price(), I80F48::from(0)); // Entry price zero when no position
     }
 
     #[test]
@@ -526,7 +526,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, -15, 300);
         assert_eq!(pos.quote_entry_native, 100);
         assert_eq!(pos.quote_running_native, 200);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(20)); // Entry price zero when no position
+        assert_eq!(pos.avg_entry_price(), I80F48::from(20)); // Entry price zero when no position
     }
 
     #[test]
@@ -537,7 +537,7 @@ mod tests {
         pos.change_base_and_entry_positions(&mut market, 15, -300);
         assert_eq!(pos.quote_entry_native, -100);
         assert_eq!(pos.quote_running_native, -200);
-        assert_eq!(pos.get_avg_entry_price(), I80F48::from(20)); // Entry price zero when no position
+        assert_eq!(pos.avg_entry_price(), I80F48::from(20)); // Entry price zero when no position
     }
 
     #[test]
@@ -551,7 +551,7 @@ mod tests {
         assert_eq!(pos.quote_entry_native, -10 * 10_000);
         assert_eq!(pos.quote_running_native, -98_000);
         assert_eq!(pos.base_position_lots, 10);
-        assert_eq!(pos.get_break_even_price(), I80F48::from(9_800)); // We made 2k on the trade, so we can sell our contract up to a loss of 200 each
+        assert_eq!(pos.break_even_price(), I80F48::from(9_800)); // We made 2k on the trade, so we can sell our contract up to a loss of 200 each
     }
 
     #[test]

--- a/programs/mango-v4/src/state/orderbook/book.rs
+++ b/programs/mango-v4/src/state/orderbook/book.rs
@@ -3,7 +3,7 @@ use std::cell::RefMut;
 use crate::accounts_zerocopy::*;
 use crate::state::MangoAccountRefMut;
 use crate::{
-    error::MangoError,
+    error::*,
     state::{
         orderbook::{bookside::BookSide, nodes::LeafNode},
         EventQueue, PerpMarket, FREE_ORDER_SLOT,
@@ -64,7 +64,7 @@ impl<'a> Book<'a> {
         ))
     }
 
-    pub fn get_bookside(&mut self, side: Side) -> &mut BookSide {
+    pub fn bookside(&mut self, side: Side) -> &mut BookSide {
         match side {
             Side::Bid => &mut self.bids,
             Side::Ask => &mut self.asks,
@@ -72,24 +72,24 @@ impl<'a> Book<'a> {
     }
 
     /// Returns best valid bid
-    pub fn get_best_bid_price(&self, now_ts: u64) -> Option<i64> {
+    pub fn best_bid_price(&self, now_ts: u64) -> Option<i64> {
         Some(self.bids.iter_valid(now_ts).next()?.1.price())
     }
 
     /// Returns best valid ask
-    pub fn get_best_ask_price(&self, now_ts: u64) -> Option<i64> {
+    pub fn best_ask_price(&self, now_ts: u64) -> Option<i64> {
         Some(self.asks.iter_valid(now_ts).next()?.1.price())
     }
 
-    pub fn get_best_price(&self, now_ts: u64, side: Side) -> Option<i64> {
+    pub fn best_price(&self, now_ts: u64, side: Side) -> Option<i64> {
         match side {
-            Side::Bid => self.get_best_bid_price(now_ts),
-            Side::Ask => self.get_best_ask_price(now_ts),
+            Side::Bid => self.best_bid_price(now_ts),
+            Side::Ask => self.best_ask_price(now_ts),
         }
     }
 
     /// Get the quantity of valid bids above and including the price
-    pub fn get_bids_size_above(&self, price: i64, max_depth: i64, now_ts: u64) -> i64 {
+    pub fn bids_size_above(&self, price: i64, max_depth: i64, now_ts: u64) -> i64 {
         let mut sum: i64 = 0;
         for (_, bid) in self.bids.iter_valid(now_ts) {
             if price > bid.price() || sum >= max_depth {
@@ -102,7 +102,7 @@ impl<'a> Book<'a> {
 
     /// Walk up the book `quantity` units and return the price at that level. If `quantity` units
     /// not on book, return None
-    pub fn get_impact_price(&self, side: Side, quantity: i64, now_ts: u64) -> Option<i64> {
+    pub fn impact_price(&self, side: Side, quantity: i64, now_ts: u64) -> Option<i64> {
         let mut sum: i64 = 0;
         let book_side = match side {
             Side::Bid => self.bids.iter_valid(now_ts),
@@ -118,7 +118,7 @@ impl<'a> Book<'a> {
     }
 
     /// Get the quantity of valid asks below and including the price
-    pub fn get_asks_size_below(&self, price: i64, max_depth: i64, now_ts: u64) -> i64 {
+    pub fn asks_size_below(&self, price: i64, max_depth: i64, now_ts: u64) -> i64 {
         let mut s = 0;
         for (_, ask) in self.asks.iter_valid(now_ts) {
             if price < ask.price() || s >= max_depth {
@@ -129,7 +129,7 @@ impl<'a> Book<'a> {
         s.min(max_depth)
     }
     /// Get the quantity of valid bids above this order id. Will return full size of book if order id not found
-    pub fn get_bids_size_above_order(&self, order_id: i128, max_depth: i64, now_ts: u64) -> i64 {
+    pub fn bids_size_above_order(&self, order_id: i128, max_depth: i64, now_ts: u64) -> i64 {
         let mut s = 0;
         for (_, bid) in self.bids.iter_valid(now_ts) {
             if bid.key == order_id || s >= max_depth {
@@ -141,7 +141,7 @@ impl<'a> Book<'a> {
     }
 
     /// Get the quantity of valid asks above this order id. Will return full size of book if order id not found
-    pub fn get_asks_size_below_order(&self, order_id: i128, max_depth: i64, now_ts: u64) -> i64 {
+    pub fn asks_size_below_order(&self, order_id: i128, max_depth: i64, now_ts: u64) -> i64 {
         let mut s = 0;
         for (_, ask) in self.asks.iter_valid(now_ts) {
             if ask.key == order_id || s >= max_depth {
@@ -178,8 +178,7 @@ impl<'a> Book<'a> {
             OrderType::PostOnly => (true, true, price_lots),
             OrderType::Market => (false, false, market_order_limit_for_side(side)),
             OrderType::PostOnlySlide => {
-                let price = if let Some(best_other_price) = self.get_best_price(now_ts, other_side)
-                {
+                let price = if let Some(best_other_price) = self.best_price(now_ts, other_side) {
                     post_only_slide_limit(side, best_other_price, price_lots)
                 } else {
                     price_lots
@@ -209,7 +208,7 @@ impl<'a> Book<'a> {
         let mut matched_order_changes: Vec<(NodeHandle, i64)> = vec![];
         let mut matched_order_deletes: Vec<i128> = vec![];
         let mut number_of_dropped_expired_orders = 0;
-        let opposing_bookside = self.get_bookside(other_side);
+        let opposing_bookside = self.bookside(other_side);
         for (best_opposing_h, best_opposing) in opposing_bookside.iter_all_including_invalid() {
             if !best_opposing.is_valid(now_ts) {
                 // Remove the order from the book unless we've done that enough
@@ -299,7 +298,7 @@ impl<'a> Book<'a> {
         // Apply changes to matched asks (handles invalidate on delete!)
         for (handle, new_quantity) in matched_order_changes {
             opposing_bookside
-                .get_mut(handle)
+                .node_mut(handle)
                 .unwrap()
                 .as_leaf_mut()
                 .unwrap()
@@ -314,7 +313,7 @@ impl<'a> Book<'a> {
         msg!("{:?}", post_allowed);
         if post_allowed && book_base_quantity > 0 {
             // Drop an expired order if possible
-            let bookside = self.get_bookside(side);
+            let bookside = self.bookside(side);
             if let Some(expired_order) = bookside.remove_one_expired(now_ts) {
                 let event = OutEvent::new(
                     side,
@@ -383,7 +382,10 @@ impl<'a> Book<'a> {
         Ok(())
     }
 
-    pub fn cancel_all_order(
+    /// Cancels up to `limit` orders that are listed on the mango account for the given perp market.
+    /// Optionally filters by `side_to_cancel_option`.
+    /// The orders are removed from the book and from the mango account open order list.
+    pub fn cancel_all_orders(
         &mut self,
         mango_account: &mut MangoAccountRefMut,
         perp_market: &mut PerpMarket,
@@ -398,19 +400,15 @@ impl<'a> Book<'a> {
                 continue;
             }
 
-            let order_id = oo.order_id;
             let order_side = oo.order_side;
-
             if let Some(side_to_cancel) = side_to_cancel_option {
                 if side_to_cancel != order_side {
                     continue;
                 }
             }
 
-            if let Ok(leaf_node) = self.cancel_order(order_id, order_side) {
-                mango_account
-                    .remove_perp_order(leaf_node.owner_slot as usize, leaf_node.quantity)?
-            };
+            let order_id = oo.order_id;
+            self.cancel_order(mango_account, order_id, order_side, None)?;
 
             limit -= 1;
             if limit == 0 {
@@ -421,17 +419,28 @@ impl<'a> Book<'a> {
         Ok(())
     }
 
-    pub fn cancel_order(&mut self, order_id: i128, side: Side) -> Result<LeafNode> {
-        match side {
-            Side::Bid => self
-                .bids
-                .remove_by_key(order_id)
-                .ok_or_else(|| error!(MangoError::SomeError)), // InvalidOrderId
-            Side::Ask => self
-                .asks
-                .remove_by_key(order_id)
-                .ok_or_else(|| error!(MangoError::SomeError)), // InvalidOrderId
+    /// Cancels an order on a side, removing it from the book and the mango account orders list
+    pub fn cancel_order(
+        &mut self,
+        mango_account: &mut MangoAccountRefMut,
+        order_id: i128,
+        side: Side,
+        expected_owner: Option<Pubkey>,
+    ) -> Result<LeafNode> {
+        let leaf_node =
+            match side {
+                Side::Bid => self.bids.remove_by_key(order_id).ok_or_else(|| {
+                    error_msg!("invalid perp order id {order_id} for side {side:?}")
+                }),
+                Side::Ask => self.asks.remove_by_key(order_id).ok_or_else(|| {
+                    error_msg!("invalid perp order id {order_id} for side {side:?}")
+                }),
+            }?;
+        if let Some(owner) = expected_owner {
+            require_keys_eq!(leaf_node.owner, owner);
         }
+        mango_account.remove_perp_order(leaf_node.owner_slot as usize, leaf_node.quantity)?;
+        Ok(leaf_node)
     }
 }
 

--- a/programs/mango-v4/src/state/orderbook/bookside_iterator.rs
+++ b/programs/mango-v4/src/state/orderbook/bookside_iterator.rs
@@ -45,7 +45,7 @@ impl<'a> BookSideIter<'a> {
     ) -> Option<(NodeHandle, &'a LeafNode)> {
         let mut current = start;
         loop {
-            match self.book_side.get(current).unwrap().case().unwrap() {
+            match self.book_side.node(current).unwrap().case().unwrap() {
                 NodeRef::Inner(inner) => {
                     self.stack.push(inner);
                     current = inner.children[self.left];

--- a/programs/mango-v4/src/state/orderbook/mod.rs
+++ b/programs/mango-v4/src/state/orderbook/mod.rs
@@ -150,25 +150,25 @@ mod tests {
             }
         }
         assert!(book.bids.is_full());
-        assert_eq!(book.bids.get_min().unwrap().price(), 1001);
+        assert_eq!(book.bids.min_leaf().unwrap().price(), 1001);
         assert_eq!(
-            book.bids.get_max().unwrap().price(),
+            book.bids.max_leaf().unwrap().price(),
             (1000 + book.bids.leaf_count) as i64
         );
 
         // add another bid at a higher price before expiry, replacing the lowest-price one (1001)
         new_order(&mut book, &mut event_queue, Side::Bid, 1005, 1000000 - 1);
-        assert_eq!(book.bids.get_min().unwrap().price(), 1002);
+        assert_eq!(book.bids.min_leaf().unwrap().price(), 1002);
         assert_eq!(event_queue.len(), 1);
 
         // adding another bid after expiry removes the soonest-expiring order (1005)
         new_order(&mut book, &mut event_queue, Side::Bid, 999, 2000000);
-        assert_eq!(book.bids.get_min().unwrap().price(), 999);
+        assert_eq!(book.bids.min_leaf().unwrap().price(), 999);
         assert!(!bookside_contains_key(&book.bids, 1005));
         assert_eq!(event_queue.len(), 2);
 
         // adding an ask will wipe up to three expired bids at the top of the book
-        let bids_max = book.bids.get_max().unwrap().price();
+        let bids_max = book.bids.max_leaf().unwrap().price();
         let bids_count = book.bids.leaf_count;
         new_order(&mut book, &mut event_queue, Side::Ask, 6000, 1500000);
         assert_eq!(book.bids.leaf_count, bids_count - 5);

--- a/programs/mango-v4/src/state/perp_market.rs
+++ b/programs/mango-v4/src/state/perp_market.rs
@@ -134,8 +134,8 @@ impl PerpMarket {
         let index_price = oracle_price;
 
         // Get current book price & compare it to index price
-        let bid = book.get_impact_price(Side::Bid, self.impact_quantity, now_ts);
-        let ask = book.get_impact_price(Side::Ask, self.impact_quantity, now_ts);
+        let bid = book.impact_price(Side::Bid, self.impact_quantity, now_ts);
+        let ask = book.impact_price(Side::Ask, self.impact_quantity, now_ts);
 
         let diff_price = match (bid, ask) {
             (Some(bid), Some(ask)) => {


### PR DESCRIPTION
- Clarification of close_order vs close_all_orders
- Remove of get_ prefixes
- Remove find_min/find_max/find_min_max, duplicated with
  min_leaf/max_leaf