### PR TITLE
Tests: Auto-advance the slot after sending a transaction

### DIFF
--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -329,7 +329,6 @@ pub async fn check_prev_instruction_post_health(solana: &SolanaCookie, account: 
         .unwrap();
     let post_health = post_health_str.parse::<f64>().unwrap();
 
-    solana.advance_by_slots(1).await; // ugly, just to avoid sending the same tx next
     send_tx(solana, ComputeAccountDataInstruction { account })
         .await
         .unwrap();

--- a/programs/mango-v4/tests/program_test/solana.rs
+++ b/programs/mango-v4/tests/program_test/solana.rs
@@ -67,6 +67,11 @@ impl SolanaCookie {
         *self.last_transaction_log.borrow_mut() = self.logger_capture.read().unwrap().clone();
 
         drop(tx_log_lock);
+        drop(context);
+
+        // This makes sure every transaction gets a new blockhash, avoiding issues where sending
+        // the same transaction again would lead to it being skipped.
+        self.advance_by_slots(1).await;
 
         result
     }

--- a/programs/mango-v4/tests/test_perp_settle.rs
+++ b/programs/mango-v4/tests/test_perp_settle.rs
@@ -522,8 +522,6 @@ async fn test_perp_settle_pnl() -> Result<(), TransportError> {
         );
     }
 
-    solana.advance_clock().await;
-
     // Partially execute the settle
     let partial_settle_amount = I80F48::from(200);
     send_tx(
@@ -587,8 +585,6 @@ async fn test_perp_settle_pnl() -> Result<(), TransportError> {
         );
     }
 
-    solana.advance_clock().await;
-
     // Fully execute the settle
     send_tx(
         solana,
@@ -651,8 +647,6 @@ async fn test_perp_settle_pnl() -> Result<(), TransportError> {
         );
     }
 
-    solana.advance_clock().await;
-
     // Change the oracle to a reasonable price in other direction
     send_tx(
         solana,
@@ -683,8 +677,6 @@ async fn test_perp_settle_pnl() -> Result<(), TransportError> {
             expected_pnl_1
         );
     }
-
-    solana.advance_clock().await;
 
     // Fully execute the settle
     send_tx(

--- a/programs/mango-v4/tests/test_perp_settle_fees.rs
+++ b/programs/mango-v4/tests/test_perp_settle_fees.rs
@@ -490,8 +490,6 @@ async fn test_perp_settle_fees() -> Result<(), TransportError> {
         );
     }
 
-    solana.advance_clock().await;
-
     // Check the fees accrued
     let initial_fees = I80F48::from(20);
     {
@@ -562,8 +560,6 @@ async fn test_perp_settle_fees() -> Result<(), TransportError> {
             "Fees have been partially settled"
         );
     }
-
-    solana.advance_clock().await;
 
     // Fully execute the settle
     send_tx(

--- a/programs/mango-v4/tests/test_serum.rs
+++ b/programs/mango-v4/tests/test_serum.rs
@@ -119,8 +119,6 @@ impl SerumOrderPlacer {
     }
 
     async fn settle(&self) {
-        // to avoid multiple settles looking like the same tx
-        self.solana.advance_by_slots(1).await;
         send_tx(
             &self.solana,
             Serum3SettleFundsInstruction {


### PR DESCRIPTION
This fixes a recurring error where it would look as if a transaction you
send would not be processed at all.