### PR TITLE
ts: simplify getOrCreateMangoAccount

### DIFF
--- a/ts/client/src/scripts/archive/example1-create-liquidation-candidate.ts
+++ b/ts/client/src/scripts/archive/example1-create-liquidation-candidate.ts
@@ -1,7 +1,6 @@
 import { AnchorProvider, Wallet } from '@project-serum/anchor';
 import { Connection, Keypair } from '@solana/web3.js';
 import fs from 'fs';
-import { AccountSize } from '../../accounts/mangoAccount';
 import { MangoClient } from '../../client';
 import { MANGO_V4_ID } from '../../constants';
 
@@ -45,10 +44,7 @@ async function main() {
   const group = await user1Client.getGroupForAdmin(admin.publicKey, GROUP_NUM);
   console.log(`Found group ${group.publicKey.toBase58()}`);
 
-  const user1MangoAccount = await user1Client.getOrCreateMangoAccount(
-    group,
-    user1.publicKey,
-  );
+  const user1MangoAccount = await user1Client.getOrCreateMangoAccount(group);
 
   console.log(`...mangoAccount1 ${user1MangoAccount.publicKey}`);
 
@@ -75,10 +71,7 @@ async function main() {
   );
   console.log(`user2 ${user2Wallet.publicKey.toBase58()}`);
 
-  const user2MangoAccount = await user2Client.getOrCreateMangoAccount(
-    group,
-    user2.publicKey,
-  );
+  const user2MangoAccount = await user2Client.getOrCreateMangoAccount(group);
   console.log(`...mangoAccount2 ${user2MangoAccount.publicKey}`);
 
   /// Increase usdc price temporarily to allow lots of borrows

--- a/ts/client/src/scripts/archive/example1-flash-loan.ts
+++ b/ts/client/src/scripts/archive/example1-flash-loan.ts
@@ -48,10 +48,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
   console.log(mangoAccount.toString());
 

--- a/ts/client/src/scripts/archive/example1-ob.ts
+++ b/ts/client/src/scripts/archive/example1-ob.ts
@@ -42,10 +42,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
 
   // logging serum3 open orders for user

--- a/ts/client/src/scripts/archive/example1-user-account.ts
+++ b/ts/client/src/scripts/archive/example1-user-account.ts
@@ -43,10 +43,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
 
   // log users tokens

--- a/ts/client/src/scripts/archive/example1-user2.ts
+++ b/ts/client/src/scripts/archive/example1-user2.ts
@@ -48,10 +48,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
   console.log(mangoAccount.toString());
 

--- a/ts/client/src/scripts/archive/mb-flash-loan.ts
+++ b/ts/client/src/scripts/archive/mb-flash-loan.ts
@@ -53,10 +53,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
   console.log(`start balance \n${mangoAccount.toString(group)}`);
 

--- a/ts/client/src/scripts/devnet-user-2.ts
+++ b/ts/client/src/scripts/devnet-user-2.ts
@@ -71,10 +71,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
   console.log(mangoAccount.toString(group));
 

--- a/ts/client/src/scripts/devnet-user.ts
+++ b/ts/client/src/scripts/devnet-user.ts
@@ -68,10 +68,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  let mangoAccount = (await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  ))!;
+  let mangoAccount = (await client.getOrCreateMangoAccount(group))!;
   if (!mangoAccount) {
     throw new Error(`MangoAccount not found for user ${user.publicKey}`);
   }

--- a/ts/client/src/scripts/mb-example1-admin.ts
+++ b/ts/client/src/scripts/mb-example1-admin.ts
@@ -337,10 +337,7 @@ async function createUser(userKeypair: string) {
   const user = result[2];
 
   console.log(`Creating MangoAccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   if (!mangoAccount) {
     throw new Error(`MangoAccount not found for user ${user.publicKey}`);
   }

--- a/ts/client/src/scripts/mb-example1-user.ts
+++ b/ts/client/src/scripts/mb-example1-user.ts
@@ -34,10 +34,7 @@ async function main() {
 
   // create + fetch account
   console.log(`Creating mangoaccount...`);
-  const mangoAccount = await client.getOrCreateMangoAccount(
-    group,
-    user.publicKey,
-  );
+  const mangoAccount = await client.getOrCreateMangoAccount(group);
   console.log(`...created/found mangoAccount ${mangoAccount.publicKey}`);
   console.log(mangoAccount.toString(group));
 


### PR DESCRIPTION
I checked this is not in UI, I just simplified the function.

We could also just kill it in and put it in helper scripts or whatver. But this simplification suffices for now imo.

Also if no key is passed in we always use the Clients Keyapairs Publickey, lmk if you prefer to make that explicit to all client functions, but that would be a bigger change imo.

Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>