### PR TITLE
Add moving average price update to token_update_index_and_rate

### DIFF
--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -89,6 +89,9 @@ pub fn token_register(
     maint_liab_weight: f32,
     init_liab_weight: f32,
     liquidation_fee: f32,
+    ma_window: i64,
+    ma_price_upper_bound_factor: f32,
+    ma_price_lower_bound_factor: f32,
 ) -> Result<()> {
     // Require token 0 to be in the insurance token
     if token_index == QUOTE_TOKEN_INDEX {
@@ -137,7 +140,11 @@ pub fn token_register(
         bump: *ctx.bumps.get("bank").ok_or(MangoError::SomeError)?,
         mint_decimals: ctx.accounts.mint.decimals,
         bank_num: 0,
-        reserved: [0; 2560],
+        ma_window,
+        ma_price: I80F48::from_num(0),
+        ma_price_upper_bound_factor,
+        ma_price_lower_bound_factor,
+        reserved: [0; 2528],
     };
     require_gt!(bank.max_rate, MINIMUM_MAX_RATE);
 

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -112,7 +112,11 @@ pub fn token_register_trustless(
         bump: *ctx.bumps.get("bank").ok_or(MangoError::SomeError)?,
         mint_decimals: ctx.accounts.mint.decimals,
         bank_num: 0,
-        reserved: [0; 2560],
+        ma_window: 30 * 60, // 30 minutes
+        ma_price: I80F48::from_num(0),
+        ma_price_upper_bound_factor: 1.05,
+        ma_price_lower_bound_factor: 0.95,
+        reserved: [0; 2528],
     };
     require_gt!(bank.max_rate, MINIMUM_MAX_RATE);
 

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -78,6 +78,9 @@ pub mod mango_v4 {
         maint_liab_weight: f32,
         init_liab_weight: f32,
         liquidation_fee: f32,
+        ma_window: i64,
+        ma_price_upper_bound_factor: f32,
+        ma_price_lower_bound_factor: f32,
     ) -> Result<()> {
         instructions::token_register(
             ctx,
@@ -92,6 +95,9 @@ pub mod mango_v4 {
             maint_liab_weight,
             init_liab_weight,
             liquidation_fee,
+            ma_window,
+            ma_price_upper_bound_factor,
+            ma_price_lower_bound_factor,
         )
     }
 

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -134,6 +134,7 @@ pub struct UpdateIndexLog {
     pub borrow_index: i128,    // I80F48
     pub avg_utilization: i128, // I80F48
     pub price: i128,           // I80F48
+    pub ma_price: i128,        // I80F48
     pub collected_fees: i128,  // I80F48
     pub loan_fee_rate: i128,   // I80F48
     pub total_borrows: i128,

--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -101,12 +101,32 @@ pub struct Bank {
 
     pub bank_num: u32,
 
+    pub ma_window: i64,
+    pub ma_price: I80F48,
+    pub ma_price_upper_bound_factor: f32,
+    pub ma_price_lower_bound_factor: f32,
+
     #[derivative(Debug = "ignore")]
-    pub reserved: [u8; 2560],
+    pub reserved: [u8; 2528],
 }
 const_assert_eq!(
     size_of::<Bank>(),
-    32 + 16 + 32 * 3 + 16 + 16 * 6 + 8 * 2 + 16 * 16 + 8 * 2 + 2 + 1 + 1 + 4 + 2560
+    32 + 16
+        + 32 * 3
+        + 16
+        + 16 * 6
+        + 8 * 2
+        + 16 * 16
+        + 8 * 2
+        + 2
+        + 1
+        + 1
+        + 4
+        + 8
+        + 16
+        + 4
+        + 4
+        + 2528
 );
 const_assert_eq!(size_of::<Bank>() % 8, 0);
 
@@ -159,7 +179,11 @@ impl Bank {
             liquidation_fee: existing_bank.liquidation_fee,
             token_index: existing_bank.token_index,
             mint_decimals: existing_bank.mint_decimals,
-            reserved: [0; 2560],
+            ma_window: existing_bank.ma_window,
+            ma_price: existing_bank.ma_price,
+            ma_price_upper_bound_factor: existing_bank.ma_price_upper_bound_factor,
+            ma_price_lower_bound_factor: existing_bank.ma_price_lower_bound_factor,
+            reserved: [0; 2528],
         }
     }
 

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -760,6 +760,9 @@ impl ClientInstruction for TokenRegisterInstruction {
             maint_liab_weight: self.maint_liab_weight,
             init_liab_weight: self.init_liab_weight,
             liquidation_fee: self.liquidation_fee,
+            ma_window: 30 * 60, // 30 mins
+            ma_price_upper_bound_factor: 1.05,
+            ma_price_lower_bound_factor: 0.95,
         };
 
         let bank = Pubkey::find_program_address(


### PR DESCRIPTION
Update the ma price within the token_update_index_and_rate instruction.
MA prices are stored on the banks.
There are a few new fields on the banks too - parameters for the MA update.