### PR TITLE
Perp: Merge ordertrees for fixed and oracle_pegged

### DIFF
--- a/programs/mango-v4/src/state/orderbook/book.rs
+++ b/programs/mango-v4/src/state/orderbook/book.rs
@@ -25,15 +25,13 @@ const_assert_eq!(
     std::mem::size_of::<Orderbook>(),
     2 * std::mem::size_of::<BookSide>() + 2400
 );
-const_assert_eq!(std::mem::size_of::<Orderbook>(), 495040);
+const_assert_eq!(std::mem::size_of::<Orderbook>(), 249824);
 const_assert_eq!(std::mem::size_of::<Orderbook>() % 8, 0);
 
 impl Orderbook {
     pub fn init(&mut self) {
-        self.bids.fixed.order_tree_type = OrderTreeType::Bids.into();
-        self.bids.oracle_pegged.order_tree_type = OrderTreeType::Bids.into();
-        self.asks.fixed.order_tree_type = OrderTreeType::Asks.into();
-        self.asks.oracle_pegged.order_tree_type = OrderTreeType::Asks.into();
+        self.bids.nodes.order_tree_type = OrderTreeType::Bids.into();
+        self.asks.nodes.order_tree_type = OrderTreeType::Asks.into();
     }
 
     pub fn bookside_mut(&mut self, side: Side) -> &mut BookSide {
@@ -124,7 +122,7 @@ impl Orderbook {
         let opposing_bookside = self.bookside_mut(other_side);
         for best_opposing in opposing_bookside.iter_all_including_invalid(now_ts, oracle_price_lots)
         {
-            if !best_opposing.is_valid {
+            if !best_opposing.is_valid() {
                 // Remove the order from the book unless we've done that enough
                 if number_of_dropped_expired_orders < DROP_EXPIRED_ORDER_LIMIT {
                     number_of_dropped_expired_orders += 1;
@@ -212,7 +210,7 @@ impl Orderbook {
         // Apply changes to matched asks (handles invalidate on delete!)
         for (handle, new_quantity) in matched_order_changes {
             opposing_bookside
-                .node_mut(handle)
+                .node_mut(handle.node)
                 .unwrap()
                 .as_leaf_mut()
                 .unwrap()
@@ -229,10 +227,9 @@ impl Orderbook {
         }
         if let Some(order_tree_target) = post_target {
             let bookside = self.bookside_mut(side);
-            let order_tree = bookside.orders_mut(order_tree_target);
 
             // Drop an expired order if possible
-            if let Some(expired_order) = order_tree.remove_one_expired(now_ts) {
+            if let Some(expired_order) = bookside.remove_one_expired(order_tree_target, now_ts) {
                 let event = OutEvent::new(
                     side,
                     expired_order.owner_slot,
@@ -244,12 +241,13 @@ impl Orderbook {
                 event_queue.push_back(cast(event)).unwrap();
             }
 
-            if order_tree.is_full() {
+            if bookside.is_full() {
                 // If this bid is higher than lowest bid, boot that bid and insert this one
-                let worst_order = order_tree.remove_worst().unwrap();
+                let (worst_order, worst_price) =
+                    bookside.remove_worst(now_ts, oracle_price_lots).unwrap();
                 // MangoErrorCode::OutOfSpace
                 require!(
-                    side.is_price_data_better(price_data, worst_order.price_data()),
+                    side.is_price_better(price_lots, worst_price),
                     MangoError::SomeError
                 );
                 let event = OutEvent::new(
@@ -275,7 +273,7 @@ impl Orderbook {
                 order.time_in_force,
                 order.peg_limit(),
             );
-            let _result = order_tree.insert_leaf(&new_order)?;
+            let _result = bookside.insert_leaf(order_tree_target, &new_order)?;
 
             // TODO OPT remove if PlacePerpOrder needs more compute
             msg!(
@@ -357,8 +355,8 @@ impl Orderbook {
     ) -> Result<LeafNode> {
         let side = side_and_tree.side();
         let book_component = side_and_tree.order_tree();
-        let leaf_node = self.bookside_mut(side).orders_mut(book_component).
-        remove_by_key(order_id).ok_or_else(|| {
+        let leaf_node = self.bookside_mut(side).
+        remove_by_key(book_component, order_id).ok_or_else(|| {
                     error_msg!("invalid perp order id {order_id} for side {side:?} and component {book_component:?}")
                 })?;
         if let Some(owner) = expected_owner {

--- a/programs/mango-v4/src/state/orderbook/bookside.rs
+++ b/programs/mango-v4/src/state/orderbook/bookside.rs
@@ -17,8 +17,8 @@ use super::*;
 )]
 #[repr(u8)]
 pub enum BookSideOrderTree {
-    Fixed,
-    OraclePegged,
+    Fixed = 0,
+    OraclePegged = 1,
 }
 
 /// Reference to a node in a book side component
@@ -30,14 +30,16 @@ pub struct BookSideOrderHandle {
 #[zero_copy]
 #[derive(bytemuck::Pod, bytemuck::Zeroable)]
 pub struct BookSide {
-    pub fixed: OrderTree,
-    pub oracle_pegged: OrderTree,
+    pub roots: [OrderTreeRoot; 2],
+    pub reserved_roots: [OrderTreeRoot; 4],
+    pub reserved: [u8; 256],
+    pub nodes: OrderTreeNodes,
 }
 const_assert_eq!(
     std::mem::size_of::<BookSide>(),
-    std::mem::size_of::<OrderTree>() * 2
+    std::mem::size_of::<OrderTreeNodes>() + 6 * std::mem::size_of::<OrderTreeRoot>() + 256
 );
-const_assert_eq!(std::mem::size_of::<BookSide>(), 246320);
+const_assert_eq!(std::mem::size_of::<BookSide>(), 123712);
 const_assert_eq!(std::mem::size_of::<BookSide>() % 8, 0);
 
 impl BookSide {
@@ -50,7 +52,7 @@ impl BookSide {
         now_ts: u64,
         oracle_price_lots: i64,
     ) -> impl Iterator<Item = BookSideIterItem> {
-        BookSideIter::new(self, now_ts, oracle_price_lots).filter(|it| it.is_valid)
+        BookSideIter::new(self, now_ts, oracle_price_lots).filter(|it| it.is_valid())
     }
 
     /// Iterate over all entries, including invalid orders
@@ -58,43 +60,76 @@ impl BookSide {
         BookSideIter::new(self, now_ts, oracle_price_lots)
     }
 
-    pub fn orders(&self, component: BookSideOrderTree) -> &OrderTree {
-        match component {
-            BookSideOrderTree::Fixed => &self.fixed,
-            BookSideOrderTree::OraclePegged => &self.oracle_pegged,
-        }
+    pub fn node(&self, handle: NodeHandle) -> Option<&AnyNode> {
+        self.nodes.node(handle)
     }
 
-    pub fn orders_mut(&mut self, component: BookSideOrderTree) -> &mut OrderTree {
-        match component {
-            BookSideOrderTree::Fixed => &mut self.fixed,
-            BookSideOrderTree::OraclePegged => &mut self.oracle_pegged,
-        }
+    pub fn node_mut(&mut self, handle: NodeHandle) -> Option<&mut AnyNode> {
+        self.nodes.node_mut(handle)
     }
 
-    pub fn node(&self, key: BookSideOrderHandle) -> Option<&AnyNode> {
-        self.orders(key.order_tree).node(key.node)
+    pub fn root(&self, component: BookSideOrderTree) -> &OrderTreeRoot {
+        &self.roots[component as usize]
     }
 
-    pub fn node_mut(&mut self, key: BookSideOrderHandle) -> Option<&mut AnyNode> {
-        self.orders_mut(key.order_tree).node_mut(key.node)
+    pub fn root_mut(&mut self, component: BookSideOrderTree) -> &mut OrderTreeRoot {
+        &mut self.roots[component as usize]
     }
 
-    pub fn is_full(&self, component: BookSideOrderTree) -> bool {
-        self.orders(component).is_full()
+    pub fn is_full(&self) -> bool {
+        self.nodes.is_full()
     }
 
-    pub fn remove_worst(&mut self, component: BookSideOrderTree) -> Option<LeafNode> {
-        self.orders_mut(component).remove_worst()
+    pub fn insert_leaf(
+        &mut self,
+        component: BookSideOrderTree,
+        new_leaf: &LeafNode,
+    ) -> Result<(NodeHandle, Option<LeafNode>)> {
+        let root = &mut self.roots[component as usize];
+        self.nodes.insert_leaf(root, new_leaf)
     }
 
-    /// Remove the order with the lowest expiry timestamp, if that's < now_ts.
+    /// Remove the overall worst-price order.
+    pub fn remove_worst(&mut self, now_ts: u64, oracle_price_lots: i64) -> Option<(LeafNode, i64)> {
+        let worst_fixed = self.nodes.find_worst(&self.roots[0]);
+        let worst_pegged = self.nodes.find_worst(&self.roots[1]);
+        let side = match self.nodes.order_tree_type() {
+            OrderTreeType::Bids => Side::Bid,
+            OrderTreeType::Asks => Side::Ask,
+        };
+        let worse = rank_orders(
+            side,
+            worst_fixed,
+            worst_pegged,
+            true,
+            now_ts,
+            oracle_price_lots,
+        )?;
+        let price = worse.price_lots;
+        let key = worse.node.key;
+        let order_tree = worse.handle.order_tree;
+        let n = self.remove_by_key(order_tree, key)?;
+        Some((n, price))
+    }
+
+    /// Remove the order with the lowest expiry timestamp in the component, if that's < now_ts.
+    /// If there is none, try to remove the lowest expiry one from the other component.
     pub fn remove_one_expired(
         &mut self,
         component: BookSideOrderTree,
         now_ts: u64,
     ) -> Option<LeafNode> {
-        self.orders_mut(component).remove_one_expired(now_ts)
+        let root = &mut self.roots[component as usize];
+        if let Some(n) = self.nodes.remove_one_expired(root, now_ts) {
+            return Some(n);
+        }
+
+        let other_component = match component {
+            BookSideOrderTree::Fixed => BookSideOrderTree::OraclePegged,
+            BookSideOrderTree::OraclePegged => BookSideOrderTree::Fixed,
+        };
+        let other_root = &mut self.roots[other_component as usize];
+        self.nodes.remove_one_expired(other_root, now_ts)
     }
 
     pub fn remove_by_key(
@@ -102,11 +137,8 @@ impl BookSide {
         component: BookSideOrderTree,
         search_key: u128,
     ) -> Option<LeafNode> {
-        self.orders_mut(component).remove_by_key(search_key)
-    }
-
-    pub fn remove(&mut self, key: BookSideOrderHandle) -> Option<AnyNode> {
-        self.orders_mut(key.order_tree).remove(key.node)
+        let root = &mut self.roots[component as usize];
+        self.nodes.remove_by_key(root, search_key)
     }
 }
 
@@ -115,18 +147,10 @@ mod tests {
     use super::*;
     use bytemuck::Zeroable;
 
-    fn new_order_tree(order_tree_type: OrderTreeType) -> OrderTree {
-        OrderTree {
-            order_tree_type: order_tree_type.into(),
-            padding: [0u8; 3],
-            bump_index: 0,
-            free_list_len: 0,
-            free_list_head: 0,
-            root_node: 0,
-            leaf_count: 0,
-            nodes: [AnyNode::zeroed(); MAX_ORDERTREE_NODES],
-            reserved: [0; 256],
-        }
+    fn new_order_tree(order_tree_type: OrderTreeType) -> OrderTreeNodes {
+        let mut ot = OrderTreeNodes::zeroed();
+        ot.order_tree_type = order_tree_type.into();
+        ot
     }
 
     fn bookside_iteration_random_helper(side: Side) {
@@ -138,8 +162,9 @@ mod tests {
             Side::Ask => OrderTreeType::Asks,
         };
 
-        let mut fixed = new_order_tree(order_tree_type);
-        let mut oracle_pegged = new_order_tree(order_tree_type);
+        let mut order_tree = new_order_tree(order_tree_type);
+        let mut root_fixed = OrderTreeRoot::zeroed();
+        let mut root_pegged = OrderTreeRoot::zeroed();
         let new_leaf = |key: u128| {
             LeafNode::new(
                 0,
@@ -160,9 +185,11 @@ mod tests {
         // ensure at least one oracle pegged order visible even at oracle price 1
         let key = new_node_key(side, oracle_pegged_price_data(20), 0);
         keys.push(key);
-        oracle_pegged.insert_leaf(&new_leaf(key)).unwrap();
+        order_tree
+            .insert_leaf(&mut root_pegged, &new_leaf(key))
+            .unwrap();
 
-        while oracle_pegged.leaf_count < 100 {
+        while root_pegged.leaf_count < 100 {
             let price_data: u64 = oracle_pegged_price_data(rng.gen_range(-20..20));
             let seq_num: u64 = rng.gen_range(0..1000);
             let key = new_node_key(side, price_data, seq_num);
@@ -170,10 +197,12 @@ mod tests {
                 continue;
             }
             keys.push(key);
-            oracle_pegged.insert_leaf(&new_leaf(key)).unwrap();
+            order_tree
+                .insert_leaf(&mut root_pegged, &new_leaf(key))
+                .unwrap();
         }
 
-        while fixed.leaf_count < 100 {
+        while root_fixed.leaf_count < 100 {
             let price_data: u64 = rng.gen_range(1..50);
             let seq_num: u64 = rng.gen_range(0..1000);
             let key = new_node_key(side, price_data, seq_num);
@@ -181,12 +210,16 @@ mod tests {
                 continue;
             }
             keys.push(key);
-            fixed.insert_leaf(&new_leaf(key)).unwrap();
+            order_tree
+                .insert_leaf(&mut root_fixed, &new_leaf(key))
+                .unwrap();
         }
 
         let bookside = BookSide {
-            fixed,
-            oracle_pegged,
+            roots: [root_fixed, root_pegged],
+            reserved_roots: [OrderTreeRoot::zeroed(); 4],
+            reserved: [0; 256],
+            nodes: order_tree,
         };
 
         // verify iteration order for different oracle prices
@@ -219,13 +252,15 @@ mod tests {
         bookside_iteration_random_helper(Side::Ask);
     }
 
-    #[test]
-    fn bookside_order_filtering() {
+    fn bookside_setup() -> BookSide {
+        use std::cell::RefCell;
+
         let side = Side::Bid;
         let order_tree_type = OrderTreeType::Bids;
 
-        let mut fixed = new_order_tree(order_tree_type);
-        let mut oracle_pegged = new_order_tree(order_tree_type);
+        let order_tree = RefCell::new(new_order_tree(order_tree_type));
+        let mut root_fixed = OrderTreeRoot::zeroed();
+        let mut root_pegged = OrderTreeRoot::zeroed();
         let new_node = |key: u128, tif: u16, peg_limit: i64| {
             LeafNode::new(
                 0,
@@ -241,12 +276,16 @@ mod tests {
         };
         let mut add_fixed = |price: i64, tif: u16| {
             let key = new_node_key(side, fixed_price_data(price).unwrap(), 0);
-            fixed.insert_leaf(&new_node(key, tif, -1)).unwrap();
+            order_tree
+                .borrow_mut()
+                .insert_leaf(&mut root_fixed, &new_node(key, tif, -1))
+                .unwrap();
         };
         let mut add_pegged = |price_offset: i64, tif: u16, peg_limit: i64| {
             let key = new_node_key(side, oracle_pegged_price_data(price_offset), 0);
-            oracle_pegged
-                .insert_leaf(&new_node(key, tif, peg_limit))
+            order_tree
+                .borrow_mut()
+                .insert_leaf(&mut root_pegged, &new_node(key, tif, peg_limit))
                 .unwrap();
         };
 
@@ -256,10 +295,17 @@ mod tests {
         add_pegged(-15, 0, -1);
         add_pegged(-20, 7, 95);
 
-        let bookside = BookSide {
-            fixed,
-            oracle_pegged,
-        };
+        BookSide {
+            roots: [root_fixed, root_pegged],
+            reserved_roots: [OrderTreeRoot::zeroed(); 4],
+            reserved: [0; 256],
+            nodes: order_tree.into_inner(),
+        }
+    }
+
+    #[test]
+    fn bookside_order_filtering() {
+        let bookside = bookside_setup();
 
         let order_prices = |now_ts: u64, oracle: i64| -> Vec<i64> {
             bookside
@@ -279,5 +325,45 @@ mod tests {
         assert_eq!(order_prices(0, 116), vec![120, 101, 100]);
         assert_eq!(order_prices(0, 2015), vec![2000, 120, 100]);
         assert_eq!(order_prices(1010, 2015), vec![2000, 100]);
+    }
+
+    #[test]
+    fn bookside_remove_worst() {
+        use std::cell::RefCell;
+
+        let bookside = RefCell::new(bookside_setup());
+
+        let order_prices = |now_ts: u64, oracle: i64| -> Vec<i64> {
+            bookside
+                .borrow()
+                .iter_valid(now_ts, oracle)
+                .map(|it| it.price_lots)
+                .collect()
+        };
+
+        // remove pegged order
+        assert_eq!(order_prices(0, 100), vec![120, 100, 90, 85, 80]);
+        let (_, p) = bookside.borrow_mut().remove_worst(0, 100).unwrap();
+        assert_eq!(p, 80);
+        assert_eq!(order_prices(0, 100), vec![120, 100, 90, 85]);
+
+        // remove fixed order (order at 190=200-10 hits the peg limit)
+        assert_eq!(order_prices(0, 200), vec![185, 120, 100]);
+        let (_, p) = bookside.borrow_mut().remove_worst(0, 200).unwrap();
+        assert_eq!(p, 100);
+        assert_eq!(order_prices(0, 200), vec![185, 120]);
+
+        // remove until end
+
+        assert_eq!(order_prices(0, 100), vec![120, 90, 85]);
+        let (_, p) = bookside.borrow_mut().remove_worst(0, 100).unwrap();
+        assert_eq!(p, 85);
+        assert_eq!(order_prices(0, 100), vec![120, 90]);
+        let (_, p) = bookside.borrow_mut().remove_worst(0, 100).unwrap();
+        assert_eq!(p, 90);
+        assert_eq!(order_prices(0, 100), vec![120]);
+        let (_, p) = bookside.borrow_mut().remove_worst(0, 100).unwrap();
+        assert_eq!(p, 120);
+        assert_eq!(order_prices(0, 100), Vec::<i64>::new());
     }
 }

--- a/programs/mango-v4/src/state/orderbook/mod.rs
+++ b/programs/mango-v4/src/state/orderbook/mod.rs
@@ -27,28 +27,27 @@ mod tests {
     use fixed::types::I80F48;
     use solana_program::pubkey::Pubkey;
 
-    fn order_tree_leaf_by_key(order_tree: &OrderTree, key: u128) -> Option<&LeafNode> {
-        for (_, leaf) in order_tree.iter() {
-            if leaf.key == key {
-                return Some(leaf);
+    fn order_tree_leaf_by_key(bookside: &BookSide, key: u128) -> Option<&LeafNode> {
+        for component in [BookSideOrderTree::Fixed, BookSideOrderTree::OraclePegged] {
+            for (_, leaf) in bookside.nodes.iter(bookside.root(component)) {
+                if leaf.key == key {
+                    return Some(leaf);
+                }
             }
         }
         None
     }
 
-    fn order_tree_contains_key(order_tree: &OrderTree, key: u128) -> bool {
-        for (_, leaf) in order_tree.iter() {
-            if leaf.key == key {
-                return true;
-            }
-        }
-        false
+    fn order_tree_contains_key(bookside: &BookSide, key: u128) -> bool {
+        order_tree_leaf_by_key(bookside, key).is_some()
     }
 
-    fn order_tree_contains_price(order_tree: &OrderTree, price_data: u64) -> bool {
-        for (_, leaf) in order_tree.iter() {
-            if leaf.price_data() == price_data {
-                return true;
+    fn order_tree_contains_price(bookside: &BookSide, price_data: u64) -> bool {
+        for component in [BookSideOrderTree::Fixed, BookSideOrderTree::OraclePegged] {
+            for (_, leaf) in bookside.nodes.iter(bookside.root(component)) {
+                if leaf.price_data() == price_data {
+                    return true;
+                }
             }
         }
         false
@@ -137,41 +136,78 @@ mod tests {
                 1000 + i as i64,
                 1000011 as u64,
             );
-            if book.bids.fixed.is_full() {
+            if book.bids.is_full() {
                 break;
             }
         }
-        assert!(book.bids.fixed.is_full());
-        assert_eq!(book.bids.fixed.min_leaf().unwrap().price_data(), 1001);
+        assert!(book.bids.is_full());
         assert_eq!(
-            fixed_price_lots(book.bids.fixed.max_leaf().unwrap().price_data()),
-            (1000 + book.bids.fixed.leaf_count) as i64
+            book.bids
+                .nodes
+                .min_leaf(&book.bids.roots[0])
+                .unwrap()
+                .1
+                .price_data(),
+            1001
+        );
+        assert_eq!(
+            fixed_price_lots(
+                book.bids
+                    .nodes
+                    .max_leaf(&book.bids.roots[0])
+                    .unwrap()
+                    .1
+                    .price_data()
+            ),
+            (1000 + book.bids.roots[0].leaf_count) as i64
         );
 
         // add another bid at a higher price before expiry, replacing the lowest-price one (1001)
         new_order(&mut book, &mut event_queue, Side::Bid, 1005, 1000000 - 1);
-        assert_eq!(book.bids.fixed.min_leaf().unwrap().price_data(), 1002);
+        assert_eq!(
+            book.bids
+                .nodes
+                .min_leaf(&book.bids.roots[0])
+                .unwrap()
+                .1
+                .price_data(),
+            1002
+        );
         assert_eq!(event_queue.len(), 1);
 
         // adding another bid after expiry removes the soonest-expiring order (1005)
         new_order(&mut book, &mut event_queue, Side::Bid, 999, 2000000);
-        assert_eq!(book.bids.fixed.min_leaf().unwrap().price_data(), 999);
-        assert!(!order_tree_contains_key(&book.bids.fixed, 1005));
+        assert_eq!(
+            book.bids
+                .nodes
+                .min_leaf(&book.bids.roots[0])
+                .unwrap()
+                .1
+                .price_data(),
+            999
+        );
+        assert!(!order_tree_contains_key(&book.bids, 1005));
         assert_eq!(event_queue.len(), 2);
 
         // adding an ask will wipe up to three expired bids at the top of the book
-        let bids_max = book.bids.fixed.max_leaf().unwrap().price_data();
-        let bids_count = book.bids.fixed.leaf_count;
+        let bids_max = book
+            .bids
+            .nodes
+            .max_leaf(&book.bids.roots[0])
+            .unwrap()
+            .1
+            .price_data();
+        let bids_count = book.bids.roots[0].leaf_count;
         new_order(&mut book, &mut event_queue, Side::Ask, 6000, 1500000);
-        assert_eq!(book.bids.fixed.leaf_count, bids_count - 5);
-        assert_eq!(book.asks.fixed.leaf_count, 1);
+        assert_eq!(book.bids.roots[0].leaf_count, bids_count - 5);
+        assert_eq!(book.asks.roots[0].leaf_count, 1);
         assert_eq!(event_queue.len(), 2 + 5);
-        assert!(!order_tree_contains_price(&book.bids.fixed, bids_max));
-        assert!(!order_tree_contains_price(&book.bids.fixed, bids_max - 1));
-        assert!(!order_tree_contains_price(&book.bids.fixed, bids_max - 2));
-        assert!(!order_tree_contains_price(&book.bids.fixed, bids_max - 3));
-        assert!(!order_tree_contains_price(&book.bids.fixed, bids_max - 4));
-        assert!(order_tree_contains_price(&book.bids.fixed, bids_max - 5));
+        assert!(!order_tree_contains_price(&book.bids, bids_max));
+        assert!(!order_tree_contains_price(&book.bids, bids_max - 1));
+        assert!(!order_tree_contains_price(&book.bids, bids_max - 2));
+        assert!(!order_tree_contains_price(&book.bids, bids_max - 3));
+        assert!(!order_tree_contains_price(&book.bids, bids_max - 4));
+        assert!(order_tree_contains_price(&book.bids, bids_max - 5));
     }
 
     #[test]
@@ -236,13 +272,10 @@ mod tests {
             SideAndOrderTree::BidFixed
         );
         assert!(order_tree_contains_key(
-            &book.bids.fixed,
+            &book.bids,
             maker.perp_order_mut_by_raw_index(0).id
         ));
-        assert!(order_tree_contains_price(
-            &book.bids.fixed,
-            price_lots as u64
-        ));
+        assert!(order_tree_contains_price(&book.bids, price_lots as u64));
         assert_eq!(
             maker.perp_position_by_raw_index(0).bids_base_lots,
             bid_quantity
@@ -287,7 +320,7 @@ mod tests {
         // the remainder of the maker order is still on the book
         // (the maker account is unchanged: it was not even passed in)
         let order =
-            order_tree_leaf_by_key(&book.bids.fixed, maker.perp_order_by_raw_index(0).id).unwrap();
+            order_tree_leaf_by_key(&book.bids, maker.perp_order_by_raw_index(0).id).unwrap();
         assert_eq!(fixed_price_lots(order.price_data()), price_lots);
         assert_eq!(order.quantity, bid_quantity - match_quantity);
 

--- a/programs/mango-v4/src/state/orderbook/nodes.rs
+++ b/programs/mango-v4/src/state/orderbook/nodes.rs
@@ -203,8 +203,8 @@ impl LeafNode {
     }
 
     #[inline(always)]
-    pub fn is_not_expired(&self, now_ts: u64) -> bool {
-        self.time_in_force == 0 || now_ts < self.timestamp + self.time_in_force as u64
+    pub fn is_expired(&self, now_ts: u64) -> bool {
+        self.time_in_force > 0 && now_ts >= self.timestamp + self.time_in_force as u64
     }
 }
 

--- a/programs/mango-v4/src/state/orderbook/ordertree_iterator.rs
+++ b/programs/mango-v4/src/state/orderbook/ordertree_iterator.rs
@@ -2,7 +2,7 @@ use super::*;
 
 /// Iterate over orders in order (bids=descending, asks=ascending)
 pub struct OrderTreeIter<'a> {
-    order_tree: &'a OrderTree,
+    order_tree: &'a OrderTreeNodes,
     /// InnerNodes where the right side still needs to be iterated on
     stack: Vec<&'a InnerNode>,
     /// To be returned on `next()`
@@ -14,7 +14,7 @@ pub struct OrderTreeIter<'a> {
 }
 
 impl<'a> OrderTreeIter<'a> {
-    pub fn new(order_tree: &'a OrderTree) -> Self {
+    pub fn new(order_tree: &'a OrderTreeNodes, root: &OrderTreeRoot) -> Self {
         let (left, right) = if order_tree.order_tree_type() == OrderTreeType::Bids {
             (1, 0)
         } else {
@@ -29,8 +29,8 @@ impl<'a> OrderTreeIter<'a> {
             left,
             right,
         };
-        if order_tree.leaf_count != 0 {
-            iter.next_leaf = iter.find_leftmost_leaf(order_tree.root_node);
+        if let Some(r) = root.node() {
+            iter.next_leaf = iter.find_leftmost_leaf(r);
         }
         iter
     }

--- a/programs/mango-v4/tests/test_perp.rs
+++ b/programs/mango-v4/tests/test_perp.rs
@@ -119,7 +119,7 @@ async fn test_perp_fixed() -> Result<(), TransportError> {
     check_prev_instruction_post_health(&solana, account_0).await;
 
     let orderbook_data = solana.get_account_boxed::<Orderbook>(orderbook).await;
-    assert_eq!(orderbook_data.bids.fixed.leaf_count, 1);
+    assert_eq!(orderbook_data.bids.roots[0].leaf_count, 1);
     let order_id_to_cancel = solana
         .get_account::<MangoAccount>(account_0)
         .await
@@ -559,7 +559,7 @@ async fn test_perp_oracle_peg() -> Result<(), TransportError> {
     check_prev_instruction_post_health(&solana, account_0).await;
 
     let orderbook_data = solana.get_account_boxed::<Orderbook>(orderbook).await;
-    assert_eq!(orderbook_data.bids.oracle_pegged.leaf_count, 1);
+    assert_eq!(orderbook_data.bids.roots[1].leaf_count, 1);
     let perp_order = solana
         .get_account::<MangoAccount>(account_0)
         .await


### PR DESCRIPTION
By sharing the nodes list we're much less likely to grossly over-allocate space.