### PR TITLE
Disable cargo-chef in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.2
 # Base image containing all binaries, deployed to gcr.io/mango-markets/mango-v4:latest
 FROM rust:1.60 as base
-RUN cargo install cargo-chef --locked
+# RUN cargo install cargo-chef --locked
 RUN rustup component add rustfmt
 RUN apt-get update && apt-get -y install clang cmake
 WORKDIR /app
@@ -12,11 +12,12 @@ COPY . .
 RUN sed -i 's|lib/\*|lib/checked_math|' Cargo.toml
 # Hack to prevent local serum_dex manifests conflicting with cargo dependency
 RUN rm -rf anchor/tests
-RUN cargo chef prepare --bin keeper --recipe-path recipe-keeper.json
-RUN cargo chef prepare --bin liquidator --recipe-path recipe-liquidator.json
+# RUN cargo chef prepare --bin keeper --recipe-path recipe-keeper.json
+# RUN cargo chef prepare --bin liquidator --recipe-path recipe-liquidator.json
 
 FROM base as build
 COPY --from=plan /app/recipe-*.json .
+COPY . .
 # RUN cargo chef cook --release --recipe-path recipe-keeper.json --bin keeper
 # RUN cargo chef cook --release --recipe-path recipe-liquidator.json --bin liquidator
 RUN cargo build --release --bin keeper --bin liquidator


### PR DESCRIPTION
Cargo chef doesn't work with the anchor patches, disable it until we can remove them