### PR TITLE
ts: Fix toUiPrice()

### DIFF
--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -569,8 +569,8 @@ export class Group {
     }
   }
 
-  public toUiPrice(price: I80F48, baseDecimals: number): number {
-    return toUiDecimals(price, baseDecimals - this.getInsuranceMintDecimals());
+  public toUiPrice(price: I80F48 | number, baseDecimals: number): number {
+    return toUiDecimals(price, this.getInsuranceMintDecimals() - baseDecimals);
   }
 
   public toNativePrice(uiPrice: number, baseDecimals: number): I80F48 {


### PR DESCRIPTION
For example, the SOL native price of 0.0136 should become the ui price of 13.6 because SOL decimals are 9.