### PR TITLE
Liquidation: Ignore dust balances and perp pnl

### DIFF
--- a/liquidator/src/liquidate.rs
+++ b/liquidator/src/liquidate.rs
@@ -264,6 +264,9 @@ impl<'a> LiquidateHelper<'a> {
                 } else {
                     return None;
                 };
+                if settleable_pnl.abs() < 1 {
+                    return None;
+                }
                 Some((pp.market_index, settleable_pnl))
             })
             .collect::<Vec<(PerpMarketIndex, I80F48)>>();

--- a/programs/mango-v4/src/health/cache.rs
+++ b/programs/mango-v4/src/health/cache.rs
@@ -442,7 +442,7 @@ impl HealthCache {
     pub fn has_spot_assets(&self) -> bool {
         self.token_infos.iter().any(|ti| {
             // can use token_liq_with_token
-            ti.balance_native.is_positive()
+            ti.balance_native >= 1
         })
     }
 
@@ -466,9 +466,7 @@ impl HealthCache {
     }
 
     pub fn has_spot_borrows(&self) -> bool {
-        self.token_infos
-            .iter()
-            .any(|ti| ti.balance_native.is_negative())
+        self.token_infos.iter().any(|ti| ti.balance_native < 0)
     }
 
     pub fn has_borrows(&self) -> bool {


### PR DESCRIPTION
Liquidation and perp pnl settlement may not bring spot amounts to exactly zero. Having a small spot amount < 1 native token can otherwise make the liquidation get stuck and not move one to the next phase.