### PR TITLE
Token deposit: limit while being_liquidated

### DIFF
--- a/programs/mango-v4/src/error.rs
+++ b/programs/mango-v4/src/error.rs
@@ -63,6 +63,8 @@ pub enum MangoError {
     BankNetBorrowsLimitReached,
     #[msg("token position does not exist")]
     TokenPositionDoesNotExist,
+    #[msg("token deposits into accounts that are being liquidated must bring their health above the init threshold")]
+    DepositsIntoLiquidatingMustRecover,
 }
 
 impl MangoError {

--- a/programs/mango-v4/src/instructions/token_deposit.rs
+++ b/programs/mango-v4/src/instructions/token_deposit.rs
@@ -156,7 +156,12 @@ impl<'a, 'info> DepositCommon<'a, 'info> {
             let health = compute_health(&account.borrow(), HealthType::Init, &retriever)
                 .context("post-deposit init health")?;
             msg!("health: {}", health);
-            account.fixed.maybe_recover_from_being_liquidated(health);
+            let was_being_liquidated = account.being_liquidated();
+            let recovered = account.fixed.maybe_recover_from_being_liquidated(health);
+            require!(
+                !was_being_liquidated || recovered,
+                MangoError::DepositsIntoLiquidatingMustRecover
+            );
         }
 
         //

--- a/programs/mango-v4/tests/test_liq_perps.rs
+++ b/programs/mango-v4/tests/test_liq_perps.rs
@@ -601,8 +601,11 @@ async fn test_liq_perps_base_position_and_bankruptcy() -> Result<(), TransportEr
 
     //
     // SETUP: We want pnl settling to cause a negative quote position,
-    // thus we deposit some base token collateral
+    // thus we deposit some base token collateral. To be able to do that,
+    // we need to temporarily raise health > 0, deposit, then bring health
+    // negative again for the test
     //
+    set_bank_stub_oracle_price(solana, group, quote_token, admin, 2.0).await;
     send_tx(
         solana,
         TokenDepositInstruction {
@@ -616,6 +619,7 @@ async fn test_liq_perps_base_position_and_bankruptcy() -> Result<(), TransportEr
     )
     .await
     .unwrap();
+    set_bank_stub_oracle_price(solana, group, quote_token, admin, 1.0).await;
 
     //
     // TEST: Can settle-pnl even though health is negative


### PR DESCRIPTION
While the flag is true, deposits that don't bring the account health over the init threshold are forbidden. This makes it impossible for users to drag out liquidation by continuously depositing tiny amounts.