### PR TITLE
Perp: settlement applies no loan origination fee

### DIFF
--- a/programs/mango-v4/src/instructions/perp_settle_fees.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_fees.rs
@@ -104,7 +104,7 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
     let token_position = account
         .token_position_mut(perp_market.settle_token_index)?
         .0;
-    bank.withdraw_with_fee(
+    bank.withdraw_without_fee(
         token_position,
         settlement,
         Clock::get()?.unix_timestamp.try_into().unwrap(),

--- a/programs/mango-v4/src/instructions/perp_settle_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_pnl.rs
@@ -198,7 +198,10 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
     let a_token_position = account_a.token_position_mut(settle_token_index)?.0;
     let b_token_position = account_b.token_position_mut(settle_token_index)?.0;
     bank.deposit(a_token_position, cm!(settlement - fee), now_ts)?;
-    bank.withdraw_with_fee(b_token_position, settlement, now_ts, oracle_price)?;
+    // Don't charge loan origination fees on borrows created via settling:
+    // Even small loan origination fees could accumulate if a perp position is
+    // settled back and forth repeatedly.
+    bank.withdraw_without_fee(b_token_position, settlement, now_ts, oracle_price)?;
 
     emit!(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),


### PR DESCRIPTION
It's likely for perp pnl to oscillate and be settled in positive and negative direction repeatedly. If the user's USDC balance is <= 0, every settlement of negative pnl will increase borrows and cause loan origination fees.

Over time the fees accumulated this way could be significant. Skipping loan origination fees for borrows created from perp settlement avoids that.