### PR TITLE
rust client: Make AccountFetcher futures Send

### DIFF
--- a/.github/workflows/ci-code-review-rust.yml
+++ b/.github/workflows/ci-code-review-rust.yml
@@ -59,7 +59,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Run clippy
-        run: cargo clippy -- --deny=warnings --allow=clippy::style --allow=clippy::complexity
+        run: cargo clippy --no-deps -- --deny=warnings --allow=clippy::style --allow=clippy::complexity
 
   tests:
     name: Run tests

--- a/.github/workflows/ci-code-review-rust.yml
+++ b/.github/workflows/ci-code-review-rust.yml
@@ -22,7 +22,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   SOLANA_VERSION: '1.14.9'
-  RUST_TOOLCHAIN: '1.60.0'
+  RUST_TOOLCHAIN: '1.65.0'
   LOG_PROGRAM: 'm43thNJ58XCjL798ZSq6JGAG1BnWskhdq5or6kcnfsD'
 
 defaults:
@@ -59,7 +59,8 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Run clippy
-        run: cargo clippy --no-deps -- --deny=warnings --allow=clippy::style --allow=clippy::complexity
+        # The --allow args are due to clippy scanning anchor
+        run: cargo clippy --no-deps -- --deny=warnings --allow=clippy::style --allow=clippy::complexity --allow=clippy::manual-retain --allow=clippy::crate-in-macro-def --allow=clippy::result-large-err
 
   tests:
     name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61305cacf1d0c5c9d3ee283d22f8f1f8c743a18ceb44a1b102bd53476c141de"
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1124,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "anyhow",
+ "async-once-cell",
  "async-trait",
  "base64 0.13.1",
  "bincode",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,6 +11,7 @@ anchor-client = { path = "../anchor/client" }
 anchor-lang = { path = "../anchor/lang" }
 anchor-spl = { path = "../anchor/spl" }
 anyhow = "1.0"
+async-once-cell = { version = "0.4.2", features = ["unpin"] }
 async-trait = "0.1.52"
 fixed = { version = "=1.11.0", features = ["serde", "borsh"] }
 fixed-macro = "^1.1.1"

--- a/client/src/account_fetcher.rs
+++ b/client/src/account_fetcher.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::Mutex;
+
+use async_once_cell::unpin::Lazy;
 
 use anyhow::Context;
 
@@ -12,7 +15,7 @@ use solana_sdk::pubkey::Pubkey;
 
 use mango_v4::state::MangoAccountValue;
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 pub trait AccountFetcher: Sync + Send {
     async fn fetch_raw_account(&self, address: &Pubkey) -> anyhow::Result<AccountSharedData>;
     async fn fetch_raw_account_lookup_table(
@@ -54,7 +57,7 @@ pub struct RpcAccountFetcher {
     pub rpc: RpcClientAsync,
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl AccountFetcher for RpcAccountFetcher {
     async fn fetch_raw_account(&self, address: &Pubkey) -> anyhow::Result<AccountSharedData> {
         self.rpc
@@ -99,9 +102,44 @@ impl AccountFetcher for RpcAccountFetcher {
     }
 }
 
+struct CoalescedAsyncJob<Key, Output> {
+    jobs: HashMap<Key, Arc<Lazy<Output>>>,
+}
+
+impl<Key, Output> Default for CoalescedAsyncJob<Key, Output> {
+    fn default() -> Self {
+        Self {
+            jobs: Default::default(),
+        }
+    }
+}
+
+impl<Key: std::cmp::Eq + std::hash::Hash, Output: 'static> CoalescedAsyncJob<Key, Output> {
+    /// Either returns the job for `key` or registers a new job for it
+    fn run_coalesced<F: std::future::Future<Output = Output> + Send + 'static>(
+        &mut self,
+        key: Key,
+        fut: F,
+    ) -> Arc<Lazy<Output>> {
+        self.jobs
+            .entry(key)
+            .or_insert_with(|| Arc::new(Lazy::new(Box::pin(fut))))
+            .clone()
+    }
+
+    fn remove(&mut self, key: &Key) {
+        self.jobs.remove(key);
+    }
+}
+
+#[derive(Default)]
 struct AccountCache {
     accounts: HashMap<Pubkey, AccountSharedData>,
     keys_for_program_and_discriminator: HashMap<(Pubkey, [u8; 8]), Vec<Pubkey>>,
+
+    account_jobs: CoalescedAsyncJob<Pubkey, anyhow::Result<AccountSharedData>>,
+    program_accounts_jobs:
+        CoalescedAsyncJob<(Pubkey, [u8; 8]), anyhow::Result<Vec<(Pubkey, AccountSharedData)>>>,
 }
 
 impl AccountCache {
@@ -112,18 +150,24 @@ impl AccountCache {
 }
 
 pub struct CachedAccountFetcher<T: AccountFetcher> {
-    fetcher: T,
-    cache: Mutex<AccountCache>,
+    fetcher: Arc<T>,
+    cache: Arc<Mutex<AccountCache>>,
+}
+
+impl<T: AccountFetcher> Clone for CachedAccountFetcher<T> {
+    fn clone(&self) -> Self {
+        Self {
+            fetcher: self.fetcher.clone(),
+            cache: self.cache.clone(),
+        }
+    }
 }
 
 impl<T: AccountFetcher> CachedAccountFetcher<T> {
-    pub fn new(fetcher: T) -> Self {
+    pub fn new(fetcher: Arc<T>) -> Self {
         Self {
             fetcher,
-            cache: Mutex::new(AccountCache {
-                accounts: HashMap::new(),
-                keys_for_program_and_discriminator: HashMap::new(),
-            }),
+            cache: Arc::new(Mutex::new(AccountCache::default())),
         }
     }
 
@@ -133,16 +177,41 @@ impl<T: AccountFetcher> CachedAccountFetcher<T> {
     }
 }
 
-#[async_trait::async_trait(?Send)]
-impl<T: AccountFetcher> AccountFetcher for CachedAccountFetcher<T> {
+#[async_trait::async_trait]
+impl<T: AccountFetcher + 'static> AccountFetcher for CachedAccountFetcher<T> {
     async fn fetch_raw_account(&self, address: &Pubkey) -> anyhow::Result<AccountSharedData> {
-        let mut cache = self.cache.lock().unwrap();
-        if let Some(account) = cache.accounts.get(address) {
-            return Ok(account.clone());
+        let fetch_job = {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(acc) = cache.accounts.get(address) {
+                return Ok(acc.clone());
+            }
+
+            // Start or fetch a reference to the fetch + cache update job
+            let self_copy = self.clone();
+            let address_copy = address.clone();
+            cache.account_jobs.run_coalesced(*address, async move {
+                let result = self_copy.fetcher.fetch_raw_account(&address_copy).await;
+                let mut cache = self_copy.cache.lock().unwrap();
+
+                // remove the job from the job list, so it can be redone if it errored
+                cache.account_jobs.remove(&address_copy);
+
+                // store a successful fetch
+                if let Ok(account) = result.as_ref() {
+                    cache.accounts.insert(address_copy, account.clone());
+                }
+                result
+            })
+        };
+
+        match fetch_job.get().await {
+            Ok(v) => Ok(v.clone()),
+            // Can't clone the stored error, so need to stringize it
+            Err(err) => Err(anyhow::format_err!(
+                "fetch error in CachedAccountFetcher: {:?}",
+                err
+            )),
         }
-        let account = self.fetcher.fetch_raw_account(address).await?;
-        cache.accounts.insert(*address, account.clone());
-        Ok(account)
     }
 
     async fn fetch_program_accounts(
@@ -151,23 +220,45 @@ impl<T: AccountFetcher> AccountFetcher for CachedAccountFetcher<T> {
         discriminator: [u8; 8],
     ) -> anyhow::Result<Vec<(Pubkey, AccountSharedData)>> {
         let cache_key = (*program, discriminator);
-        let mut cache = self.cache.lock().unwrap();
-        if let Some(accounts) = cache.keys_for_program_and_discriminator.get(&cache_key) {
-            return Ok(accounts
-                .iter()
-                .map(|pk| (*pk, cache.accounts.get(&pk).unwrap().clone()))
-                .collect::<Vec<_>>());
+        let fetch_job = {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(accounts) = cache.keys_for_program_and_discriminator.get(&cache_key) {
+                return Ok(accounts
+                    .iter()
+                    .map(|pk| (*pk, cache.accounts.get(&pk).unwrap().clone()))
+                    .collect::<Vec<_>>());
+            }
+
+            let self_copy = self.clone();
+            let program_copy = program.clone();
+            cache
+                .program_accounts_jobs
+                .run_coalesced(cache_key.clone(), async move {
+                    let result = self_copy
+                        .fetcher
+                        .fetch_program_accounts(&program_copy, discriminator)
+                        .await;
+                    let mut cache = self_copy.cache.lock().unwrap();
+                    cache.program_accounts_jobs.remove(&cache_key);
+                    if let Ok(accounts) = result.as_ref() {
+                        cache
+                            .keys_for_program_and_discriminator
+                            .insert(cache_key, accounts.iter().map(|(pk, _)| *pk).collect());
+                        for (pk, acc) in accounts.iter() {
+                            cache.accounts.insert(*pk, acc.clone());
+                        }
+                    }
+                    result
+                })
+        };
+
+        match fetch_job.get().await {
+            Ok(v) => Ok(v.clone()),
+            // Can't clone the stored error, so need to stringize it
+            Err(err) => Err(anyhow::format_err!(
+                "fetch error in CachedAccountFetcher: {:?}",
+                err
+            )),
         }
-        let accounts = self
-            .fetcher
-            .fetch_program_accounts(program, discriminator)
-            .await?;
-        cache
-            .keys_for_program_and_discriminator
-            .insert(cache_key, accounts.iter().map(|(pk, _)| *pk).collect());
-        for (pk, acc) in accounts.iter() {
-            cache.accounts.insert(*pk, acc.clone());
-        }
-        Ok(accounts)
     }
 }

--- a/client/src/chain_data_fetcher.rs
+++ b/client/src/chain_data_fetcher.rs
@@ -141,7 +141,7 @@ impl AccountFetcher {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl crate::AccountFetcher for AccountFetcher {
     async fn fetch_raw_account(
         &self,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -220,7 +220,9 @@ impl MangoClient {
         owner: Keypair,
     ) -> anyhow::Result<Self> {
         let rpc = client.rpc_async();
-        let account_fetcher = Arc::new(CachedAccountFetcher::new(RpcAccountFetcher { rpc }));
+        let account_fetcher = Arc::new(CachedAccountFetcher::new(Arc::new(RpcAccountFetcher {
+            rpc,
+        })));
         let mango_account =
             account_fetcher_fetch_mango_account(&*account_fetcher, &account).await?;
         let group = mango_account.fixed.group;


### PR DESCRIPTION
This required redoing the cached account fetcher logic to properly deal with locking and repeated calls while a fetch is ongoing.