### PR TITLE
output to security tab

### DIFF
--- a/.github/workflows/ci-code-review-ts.yml
+++ b/.github/workflows/ci-code-review-ts.yml
@@ -11,7 +11,6 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -31,7 +30,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -51,7 +49,6 @@ jobs:
   unit-test:
     name: Unit Test
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -71,7 +68,6 @@ jobs:
   semgrep:
     name: Security Scan
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     container:
       image: returntocorp/semgrep
 
@@ -80,6 +76,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run semgrep
-        run: semgrep ci
+        run: semgrep ci --sarif --output=semgrep-results.sarif
         env:
            SEMGREP_RULES: p/typescript
+      
+      - name: Upload output
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: semgrep-results.sarif

--- a/.github/workflows/ci-dependency-scan-cargo.yml
+++ b/.github/workflows/ci-dependency-scan-cargo.yml
@@ -25,12 +25,11 @@ jobs:
   trivy:
     name: Dependency Scan
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Report all vulnerabilities in CI output
+      # Report all vulnerabilities in security tab
       - name: Report on all vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
@@ -38,7 +37,8 @@ jobs:
           scan-ref: 'Cargo.lock'
           ignore-unfixed: true
           hide-progress: true
-          format: 'table'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           
       # Fail the job on critical vulnerabiliies with fix available
       - name: Fail on critical vulnerabilities
@@ -51,3 +51,9 @@ jobs:
           format: 'table'
           severity: 'CRITICAL'
           exit-code: '1'
+
+      - name: Upload output
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/ci-dependency-scan-yarn.yml
+++ b/.github/workflows/ci-dependency-scan-yarn.yml
@@ -11,12 +11,11 @@ jobs:
   trivy:
     name: Dependency Scan
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Report all vulnerabilities in CI output
+      # Report all vulnerabilities in security tab
       - name: Report on all vulnerabilities
         uses: aquasecurity/trivy-action@master
         with:
@@ -24,7 +23,8 @@ jobs:
           scan-ref: 'yarn.lock'
           ignore-unfixed: true
           hide-progress: true
-          format: 'table'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           
       # Fail the job on critical vulnerabiliies with fix available
       - name: Fail on critical vulnerabilities
@@ -37,3 +37,9 @@ jobs:
           format: 'table'
           severity: 'CRITICAL'
           exit-code: '1'
+
+      - name: Upload output
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR changes outputs from dependency and TS code scanning tools from the runner to the security tab
![image](https://user-images.githubusercontent.com/95582913/212139522-0a52e46b-bd73-4dd4-aa49-047377a00e5a.png)

Makes it easier to track non-critical vulnerabilities and enables us to easily ignore etc. with audit trail.