### PR TITLE
Dont include equity for untrusted perp markets

### DIFF
--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -1303,7 +1303,13 @@ export class PerpPosition {
       .sub(unsettledFunding)
       .add(takerQuote);
 
-    return baseLots.mul(lotsToQuote).add(quoteCurrent);
+    const uncappedEquity = baseLots.mul(lotsToQuote).add(quoteCurrent);
+
+    if (perpMarket.trustedMarket) {
+      return uncappedEquity;
+    } else {
+      return baseLots.mul(lotsToQuote).add(quoteCurrent).min(ZERO_I80F48());
+    }
   }
 
   public hasOpenOrders(): boolean {


### PR DESCRIPTION
This change filters out positive unsettled pnl for untrusted perp markets in a PerpPosition's getEquity calculation. This change was a result of Max's report that his account leverage number was wrong. The leverage calculation in the UI is essentially `mangoAccount.getAssetsValue() / mangoAccount.getEquity()`. The mangoAccount.getEquity() function calls the perpPosition.getEquity() function changed in this PR.

> so i have this account:
> 1) it has $2.09 in unsettled mngo-perp pnl
> 2) it's max long USDC/DAI - 0.029552 / -0.02686591
> 
> this is surprising:
> 1) i would expect the max leverage for a USDC/DAI position to be around 10x on $0.003  but it displays 1x
> 2) my health is at 4% which suggest that i am already leveraged quite high
> 
> i think the issue here is that the leverage calculation does include the perp market somehow in my pnl

![image](https://user-images.githubusercontent.com/1254942/212496100-40631b29-98f9-4eb7-8b54-cfbb9b0de865.png)
<img width="906" alt="Screen Shot 2023-01-14 at 3 49 19 PM" src="https://user-images.githubusercontent.com/1254942/212496133-c7a65794-f554-49bb-9c1e-26cbf1729bcf.png">

There are two possible side effects of this change that I am uncertain of. 

The first is the effect that this will have on `market-maker.ts`. There is code in that file on line 421 that calls `mangoAccount.getEquity()` and mangoAccount.getEquity calls the perp position's `getEquity()` function that is changed in this PR.

The second side effect is from `mangoAccount.getPnl()` which calls mangoAccount.getEquity() which is affected by this change. Though I couldn't find any calls to mangoAccount.getPnl in the client or the UI.

After this change the UI for Max's test account will display the leverage number he expected:

<img width="979" alt="Screen Shot 2023-01-14 at 3 58 21 PM" src="https://user-images.githubusercontent.com/1254942/212496639-7174997e-d4b4-4a71-a8d8-4e2a2d38af3b.png">

