### PR TITLE
Perps: track overall realized pnl relating to a position

### DIFF
--- a/client/src/perp_pnl.rs
+++ b/client/src/perp_pnl.rs
@@ -59,7 +59,7 @@ pub async fn fetch_top(
             let mut perp_pos = perp_pos.unwrap().clone();
             perp_pos.settle_funding(&perp_market);
             perp_pos.update_settle_limit(&perp_market, now_ts);
-            let pnl = perp_pos.pnl_for_price(&perp_market, oracle_price).unwrap();
+            let pnl = perp_pos.unsettled_pnl(&perp_market, oracle_price).unwrap();
             let limited_pnl = perp_pos.apply_pnl_settle_limit(&perp_market, pnl);
             if limited_pnl >= 0 && direction == Direction::MaxNegative
                 || limited_pnl <= 0 && direction == Direction::MaxPositive

--- a/programs/mango-v4/src/instructions/perp_liq_quote_and_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_quote_and_bankruptcy.rs
@@ -159,7 +159,7 @@ pub fn perp_liq_quote_and_bankruptcy(
         liqee_perp_position.settle_funding(&perp_market);
         liqor_perp_position.settle_funding(&perp_market);
 
-        let liqee_pnl = liqee_perp_position.pnl_for_price(&perp_market, oracle_price)?;
+        let liqee_pnl = liqee_perp_position.unsettled_pnl(&perp_market, oracle_price)?;
         // TODO: deal with positive liqee pnl! Maybe another instruction?
         require!(liqee_pnl < 0, MangoError::ProfitabilityMismatch);
 
@@ -221,7 +221,7 @@ pub fn perp_liq_quote_and_bankruptcy(
     //
     let insurance_transfer = if settlement == max_settlement_liqee {
         let liqee_perp_position = liqee.perp_position_mut(perp_market_index)?;
-        let liqee_pnl = liqee_perp_position.pnl_for_price(&perp_market, oracle_price)?;
+        let liqee_pnl = liqee_perp_position.unsettled_pnl(&perp_market, oracle_price)?;
 
         let max_liab_transfer_from_liqee = (-liqee_pnl).min(-liqee_init_health).max(I80F48::ZERO);
         let liab_transfer = max_liab_transfer_from_liqee

--- a/programs/mango-v4/src/instructions/perp_settle_fees.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_fees.rs
@@ -70,7 +70,7 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
     perp_position.settle_funding(&perp_market);
 
     // Calculate PnL
-    let pnl = perp_position.pnl_for_price(&perp_market, oracle_price)?;
+    let pnl = perp_position.unsettled_pnl(&perp_market, oracle_price)?;
 
     // Account perp position must have a loss to be able to settle against the fee account
     require!(pnl.is_negative(), MangoError::ProfitabilityMismatch);

--- a/programs/mango-v4/src/instructions/perp_settle_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_pnl.rs
@@ -112,8 +112,8 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
     let b_perp_position = account_b.perp_position_mut(perp_market_index)?;
     a_perp_position.settle_funding(&perp_market);
     b_perp_position.settle_funding(&perp_market);
-    let a_pnl = a_perp_position.pnl_for_price(&perp_market, oracle_price)?;
-    let b_pnl = b_perp_position.pnl_for_price(&perp_market, oracle_price)?;
+    let a_pnl = a_perp_position.unsettled_pnl(&perp_market, oracle_price)?;
+    let b_pnl = b_perp_position.unsettled_pnl(&perp_market, oracle_price)?;
 
     // PnL must have opposite signs for there to be a settlement:
     // Account A must be profitable, and B must be unprofitable.

--- a/programs/mango-v4/tests/test_liq_perps.rs
+++ b/programs/mango-v4/tests/test_liq_perps.rs
@@ -719,10 +719,10 @@ async fn test_liq_perps_base_position_and_bankruptcy() -> Result<(), TransportEr
     // the remainder got socialized via funding payments
     let perp_market = solana.get_account::<PerpMarket>(perp_market).await;
     let pnl_before = liqee_before.perps[0]
-        .pnl_for_price(&perp_market, I80F48::ONE)
+        .unsettled_pnl(&perp_market, I80F48::ONE)
         .unwrap();
     let pnl_after = liqee_after.perps[0]
-        .pnl_for_price(&perp_market, I80F48::ONE)
+        .unsettled_pnl(&perp_market, I80F48::ONE)
         .unwrap();
     let socialized_amount = (pnl_after - pnl_before).to_num::<f64>() - liq_perp_quote_amount;
     assert!(assert_equal(

--- a/programs/mango-v4/tests/test_perp_settle.rs
+++ b/programs/mango-v4/tests/test_perp_settle.rs
@@ -390,6 +390,14 @@ async fn test_perp_settle_pnl() -> Result<(), TransportError> {
             mango_account_1.perp_spot_transfers, -expected_total_settle,
             "net_settled on account 1 updated with loss from settlement"
         );
+        assert_eq!(
+            mango_account_0.perps[0].perp_spot_transfers, expected_total_settle,
+            "net_settled on account 0 updated with profit from settlement"
+        );
+        assert_eq!(
+            mango_account_1.perps[0].perp_spot_transfers, -expected_total_settle,
+            "net_settled on account 1 updated with loss from settlement"
+        );
     }
 
     // Change the oracle to a reasonable price in other direction

--- a/ts/client/src/accounts/healthCache.spec.ts
+++ b/ts/client/src/accounts/healthCache.spec.ts
@@ -111,6 +111,7 @@ describe('Health Cache', () => {
       ZERO_I80F48(),
       ZERO_I80F48(),
       new BN(0),
+      ZERO_I80F48(),
     );
     const pi1 = PerpInfo.fromPerpPosition(pM, pp);
 
@@ -227,6 +228,7 @@ describe('Health Cache', () => {
         ZERO_I80F48(),
         ZERO_I80F48(),
         new BN(0),
+        ZERO_I80F48(),
       );
       const pi1 = PerpInfo.fromPerpPosition(pM, pp);
 

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -175,7 +175,6 @@ export class MangoAccount {
 
   public getPerpPosition(
     perpMarketIndex: PerpMarketIndex,
-    useEventQueue?: boolean,
   ): PerpPosition | undefined {
     return this.perps.find((pp) => pp.marketIndex == perpMarketIndex);
   }
@@ -1180,6 +1179,7 @@ export class PerpPosition {
       I80F48.from(dto.realizedTradePnlNative),
       I80F48.from(dto.realizedOtherPnlNative),
       dto.settlePnlLimitRealizedTrade,
+      I80F48.from(dto.realizedPnlForPositionNative),
     );
   }
 
@@ -1208,6 +1208,7 @@ export class PerpPosition {
       ZERO_I80F48(),
       ZERO_I80F48(),
       new BN(0),
+      ZERO_I80F48(),
     );
   }
 
@@ -1233,6 +1234,7 @@ export class PerpPosition {
     public realizedTradePnlNative: I80F48,
     public realizedOtherPnlNative: I80F48,
     public settlePnlLimitRealizedTrade: BN,
+    public realizedPnlForPositionNative: I80F48,
   ) {}
 
   isActive(): boolean {
@@ -1459,6 +1461,7 @@ export class PerpPositionDto {
     public realizedTradePnlNative: I80F48Dto,
     public realizedOtherPnlNative: I80F48Dto,
     public settlePnlLimitRealizedTrade: BN,
+    public realizedPnlForPositionNative: I80F48Dto,
   ) {}
 }
 

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -1327,10 +1327,6 @@ export class PerpPosition {
   }
 
   public getAverageEntryPriceUi(perpMarket: PerpMarket): number {
-    if (perpMarket.perpMarketIndex !== this.marketIndex) {
-      throw new Error("PerpPosition doesn't belong to the given market!");
-    }
-
     return perpMarket.priceNativeToUi(
       this.getAverageEntryPrice(perpMarket).toNumber(),
     );

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -1323,7 +1323,9 @@ export class PerpPosition {
   }
 
   public getAverageEntryPrice(perpMarket: PerpMarket): I80F48 {
-    return I80F48.fromI64(this.basePositionLots.mul(perpMarket.baseLotSize));
+    return I80F48.fromNumber(this.avgEntryPricePerBaseLot).mul(
+      I80F48.fromI64(perpMarket.baseLotSize),
+    );
   }
 
   public getAverageEntryPriceUi(perpMarket: PerpMarket): number {

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -5366,11 +5366,26 @@ export type MangoV4 = {
             "type": "i64"
           },
           {
+            "name": "realizedPnlForPositionNative",
+            "docs": [
+              "Trade pnl, fees, funding that were added over the current position's lifetime.",
+              "",
+              "Reset when the position changes sign or goes to zero.",
+              "Not decreased by settling.",
+              "",
+              "This is tracked for display purposes: this value plus the difference between entry",
+              "price and current price of the base position is the overall pnl."
+            ],
+            "type": {
+              "defined": "I80F48"
+            }
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                104
+                88
               ]
             }
           }
@@ -13120,11 +13135,26 @@ export const IDL: MangoV4 = {
             "type": "i64"
           },
           {
+            "name": "realizedPnlForPositionNative",
+            "docs": [
+              "Trade pnl, fees, funding that were added over the current position's lifetime.",
+              "",
+              "Reset when the position changes sign or goes to zero.",
+              "Not decreased by settling.",
+              "",
+              "This is tracked for display purposes: this value plus the difference between entry",
+              "price and current price of the base position is the overall pnl."
+            ],
+            "type": {
+              "defined": "I80F48"
+            }
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                104
+                88
               ]
             }
           }

--- a/ts/client/src/scripts/mm/taker.ts
+++ b/ts/client/src/scripts/mm/taker.ts
@@ -31,7 +31,7 @@ async function settlePnl(
   const pp = mangoAccount
     .perpActive()
     .find((pp) => pp.marketIndex === perpMarket.perpMarketIndex)!;
-  const pnl = pp.getPnl(perpMarket);
+  const pnl = pp.getUnsettledPnl(perpMarket);
 
   console.log(
     `Avg entry price - ${pp.getAverageEntryPriceUi(


### PR DESCRIPTION
This includes trade pnl, funding and fees. Tracking this makes it easier for uis to display a consistent position overall pnl value that doesn't decrease by settling.