### PR TITLE
Add oracleLastUpdatedSlot to Bank and PerpMarket

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "validate": "npm run typecheck && npm run lint && npm run format"
   },
   "devDependencies": {
-    "@jup-ag/core": "^1.0.0-beta.28",
     "@tsconfig/recommended": "^1.0.1",
     "@types/bs58": "^4.0.1",
     "@types/chai": "^4.3.0",
@@ -58,6 +57,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "@jup-ag/core": "^1.0.0-beta.28",
     "@project-serum/anchor": "^0.25.0",
     "@project-serum/serum": "^0.13.65",
     "@pythnetwork/client": "~2.8.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@jup-ag/core": "^1.0.0-beta.28",
     "@project-serum/anchor": "^0.25.0",
     "@project-serum/serum": "^0.13.65",
     "@pythnetwork/client": "~2.8.0",

--- a/ts/client/src/accounts/bank.ts
+++ b/ts/client/src/accounts/bank.ts
@@ -59,6 +59,7 @@ export class Bank implements BankForHealth {
   public util1: I80F48;
   public _price: I80F48 | undefined;
   public _uiPrice: number | undefined;
+  public _oracleLastUpdatedSlot: number | undefined;
   public collectedFeesNative: I80F48;
   public loanFeeRate: I80F48;
   public loanOriginationFeeRate: I80F48;
@@ -235,6 +236,7 @@ export class Bank implements BankForHealth {
     this.dust = I80F48.from(dust);
     this._price = undefined;
     this._uiPrice = undefined;
+    this._oracleLastUpdatedSlot = undefined;
   }
 
   toString(): string {
@@ -349,6 +351,15 @@ export class Bank implements BankForHealth {
       );
     }
     return this._uiPrice;
+  }
+
+  get oracleLastUpdatedSlot(): number {
+    if (!this._oracleLastUpdatedSlot) {
+      throw new Error(
+        `Undefined oracleLastUpdatedSlot for bank ${this.publicKey} with tokenIndex ${this.tokenIndex}!`,
+      );
+    }
+    return this._oracleLastUpdatedSlot;
   }
 
   nativeDeposits(): I80F48 {

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -380,34 +380,6 @@ export class Group {
     return { price, uiPrice, lastUpdatedSlot };
   }
 
-  private async decodeLastUpdatedSlotFromOracleAi(
-    coder: BorshAccountsCoder<string>,
-    oracle: PublicKey,
-    ai: AccountInfo<Buffer>,
-    client: MangoClient,
-  ): Promise<{ lastUpdatedSlot: number }> {
-    let lastUpdatedSlot: number;
-    if (
-      !BorshAccountsCoder.accountDiscriminator('stubOracle').compare(
-        ai.data.slice(0, 8),
-      )
-    ) {
-      const stubOracle = coder.decode('stubOracle', ai.data);
-      lastUpdatedSlot = stubOracle.lastUpdated.val;
-    } else if (isPythOracle(ai)) {
-      lastUpdatedSlot = parseInt(parsePriceData(ai.data).lastSlot.toString());
-    } else if (isSwitchboardOracle(ai)) {
-      lastUpdatedSlot = (
-        await parseSwitchboardOracle(ai, client.program.provider.connection)
-      ).lastUpdatedSlot;
-    } else {
-      throw new Error(
-        `Unknown oracle provider (parsing not implemented) for oracle ${oracle}, with owner ${ai.owner}!`,
-      );
-    }
-    return { lastUpdatedSlot };
-  }
-
   public async reloadVaults(client: MangoClient): Promise<void> {
     const vaultPks = Array.from(this.banksMapByMint.values())
       .flat()

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -48,21 +48,25 @@ export class StubOracle {
 }
 
 // https://gist.github.com/microwavedcola1/b741a11e6ee273a859f3ef00b35ac1f0
-export function parseSwitcboardOracleV1(
-  accountInfo: AccountInfo<Buffer>,
-): { price: number, lastUpdatedSlot: number } {
+export function parseSwitcboardOracleV1(accountInfo: AccountInfo<Buffer>): {
+  price: number;
+  lastUpdatedSlot: number;
+} {
   const price = accountInfo.data.readDoubleLE(1 + 32 + 4 + 4);
-  const lastUpdatedSlot = parseInt(accountInfo.data.readBigUInt64LE(1 + 32 + 4 + 4 + 8).toString())
-  return { price, lastUpdatedSlot }
+  const lastUpdatedSlot = parseInt(
+    accountInfo.data.readBigUInt64LE(1 + 32 + 4 + 4 + 8).toString(),
+  );
+  return { price, lastUpdatedSlot };
 }
 
 export function parseSwitcboardOracleV2(
   program: SwitchboardProgram,
   accountInfo: AccountInfo<Buffer>,
-): { price: number, lastUpdatedSlot: number } {
-  const price =
-    program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
-  const lastUpdatedSlot = program.decodeAggregator(accountInfo).previousConfirmedRoundSlot!.toNumber();
+): { price: number; lastUpdatedSlot: number } {
+  const price = program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
+  const lastUpdatedSlot = program
+    .decodeAggregator(accountInfo)
+    .previousConfirmedRoundSlot!.toNumber();
 
   if (!price || !lastUpdatedSlot)
     throw new Error('Unable to parse Switchboard Oracle V2');
@@ -77,7 +81,7 @@ export function parseSwitcboardOracleV2(
 export async function parseSwitchboardOracle(
   accountInfo: AccountInfo<Buffer>,
   connection: Connection,
-): Promise<{ price: number, lastUpdatedSlot: number }> {
+): Promise<{ price: number; lastUpdatedSlot: number }> {
   if (accountInfo.owner.equals(SwitchboardProgram.devnetPid)) {
     if (!sbv2DevnetProgram) {
       sbv2DevnetProgram = await SwitchboardProgram.loadDevnet(connection);

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -48,7 +48,7 @@ export class StubOracle {
 }
 
 // https://gist.github.com/microwavedcola1/b741a11e6ee273a859f3ef00b35ac1f0
-export function parseSwitcboardOracleV1(accountInfo: AccountInfo<Buffer>): {
+export function parseSwitchboardOracleV1(accountInfo: AccountInfo<Buffer>): {
   price: number;
   lastUpdatedSlot: number;
 } {
@@ -59,14 +59,14 @@ export function parseSwitcboardOracleV1(accountInfo: AccountInfo<Buffer>): {
   return { price, lastUpdatedSlot };
 }
 
-export function parseSwitcboardOracleV2(
+export function parseSwitchboardOracleV2(
   program: SwitchboardProgram,
   accountInfo: AccountInfo<Buffer>,
 ): { price: number; lastUpdatedSlot: number } {
   const price = program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
   const lastUpdatedSlot = program
     .decodeAggregator(accountInfo)
-    .previousConfirmedRoundSlot!.toNumber();
+    .latestConfirmedRound!.roundOpenSlot!.toNumber();
 
   if (!price || !lastUpdatedSlot)
     throw new Error('Unable to parse Switchboard Oracle V2');
@@ -86,21 +86,21 @@ export async function parseSwitchboardOracle(
     if (!sbv2DevnetProgram) {
       sbv2DevnetProgram = await SwitchboardProgram.loadDevnet(connection);
     }
-    return parseSwitcboardOracleV2(sbv2DevnetProgram, accountInfo);
+    return parseSwitchboardOracleV2(sbv2DevnetProgram, accountInfo);
   }
 
   if (accountInfo.owner.equals(SwitchboardProgram.mainnetPid)) {
     if (!sbv2MainnetProgram) {
       sbv2MainnetProgram = await SwitchboardProgram.loadMainnet(connection);
     }
-    return parseSwitcboardOracleV2(sbv2MainnetProgram, accountInfo);
+    return parseSwitchboardOracleV2(sbv2MainnetProgram, accountInfo);
   }
 
   if (
     accountInfo.owner.equals(SBV1_DEVNET_PID) ||
     accountInfo.owner.equals(SBV1_MAINNET_PID)
   ) {
-    return parseSwitcboardOracleV1(accountInfo);
+    return parseSwitchboardOracleV1(accountInfo);
   }
 
   throw new Error(`Should not be reached!`);

--- a/ts/client/src/accounts/perp.ts
+++ b/ts/client/src/accounts/perp.ts
@@ -48,6 +48,7 @@ export class PerpMarket {
 
   public _price: I80F48;
   public _uiPrice: number;
+  public _oracleLastUpdatedSlot: number;
 
   private priceLotsToUiConverter: number;
   private baseLotsToUiConverter: number;
@@ -244,6 +245,15 @@ export class PerpMarket {
       );
     }
     return this._uiPrice;
+  }
+
+  get oracleLastUpdatedSlot(): number {
+    if (!this._oracleLastUpdatedSlot) {
+      throw new Error(
+        `Undefined oracleLastUpdatedSlot for perpMarket ${this.publicKey} with marketIndex ${this.perpMarketIndex}!`,
+      );
+    }
+    return this._oracleLastUpdatedSlot;
   }
 
   get minOrderSize(): number {


### PR DESCRIPTION
Parses the best value we have for last updated slot and sets it on the Bank and PerpMarkets when reloading oracle prices. Used for checking oracle staleness on the client side.