### PR TITLE
fix bug where serum oo where not loaded

### DIFF
--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -90,7 +90,7 @@ export class MangoAccount {
 
   public async reload(client: MangoClient): Promise<MangoAccount> {
     const mangoAccount = await client.getMangoAccount(this);
-    await mangoAccount.reloadAccountData(client);
+    await mangoAccount.reloadSerum3OpenOrders(client);
     Object.assign(this, mangoAccount);
     return mangoAccount;
   }
@@ -99,12 +99,12 @@ export class MangoAccount {
     client: MangoClient,
   ): Promise<{ value: MangoAccount; slot: number }> {
     const resp = await client.getMangoAccountWithSlot(this.publicKey);
-    await resp?.value.reloadAccountData(client);
+    await resp?.value.reloadSerum3OpenOrders(client);
     Object.assign(this, resp?.value);
     return { value: resp!.value, slot: resp!.slot };
   }
 
-  async reloadAccountData(client: MangoClient): Promise<MangoAccount> {
+  async reloadSerum3OpenOrders(client: MangoClient): Promise<MangoAccount> {
     const serum3Active = this.serum3Active();
     const ais =
       await client.program.provider.connection.getMultipleAccountsInfo(

--- a/ts/client/src/accounts/perp.ts
+++ b/ts/client/src/accounts/perp.ts
@@ -431,7 +431,17 @@ export class PerpMarket {
     direction: 'negative' | 'positive',
     count = 2,
   ): Promise<{ account: MangoAccount; settleablePnl: I80F48 }[]> {
-    let accountsWithSettleablePnl = (await client.getAllMangoAccounts(group))
+    let accountsWithSettleablePnl = (
+      await Promise.all(
+        await (
+          await client.getAllMangoAccounts(group)
+        ).map(async (a) => {
+          // Need to load serum oo accounts to compute settle perp health
+          await a.reloadAccountData(client);
+          return a;
+        }),
+      )
+    )
       .filter((acc) => acc.perpPositionExistsForMarket(this))
       .map((acc) => {
         const pp = acc

--- a/ts/client/src/accounts/perp.ts
+++ b/ts/client/src/accounts/perp.ts
@@ -432,15 +432,7 @@ export class PerpMarket {
     count = 2,
   ): Promise<{ account: MangoAccount; settleablePnl: I80F48 }[]> {
     let accountsWithSettleablePnl = (
-      await Promise.all(
-        await (
-          await client.getAllMangoAccounts(group)
-        ).map(async (a) => {
-          // Need to load serum oo accounts to compute settle perp health
-          await a.reloadAccountData(client);
-          return a;
-        }),
-      )
+      await await client.getAllMangoAccounts(group, true)
     )
       .filter((acc) => acc.perpPositionExistsForMarket(this))
       .map((acc) => {

--- a/ts/client/src/accounts/perp.ts
+++ b/ts/client/src/accounts/perp.ts
@@ -432,7 +432,7 @@ export class PerpMarket {
     count = 2,
   ): Promise<{ account: MangoAccount; settleablePnl: I80F48 }[]> {
     let accountsWithSettleablePnl = (
-      await await client.getAllMangoAccounts(group, true)
+      await client.getAllMangoAccounts(group, true)
     )
       .filter((acc) => acc.perpPositionExistsForMarket(this))
       .map((acc) => {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -694,20 +694,6 @@ export class MangoClient {
     return mangoAccount_;
   }
 
-  public async getMangoAccountForPublicKey(
-    mangoAccountPk: PublicKey,
-    loadSerum3Oo = false,
-  ): Promise<MangoAccount> {
-    const mangoAccount = MangoAccount.from(
-      mangoAccountPk,
-      await this.program.account.mangoAccount.fetch(mangoAccountPk),
-    );
-    if (loadSerum3Oo) {
-      await mangoAccount?.reloadSerum3OpenOrders(this);
-    }
-    return mangoAccount;
-  }
-
   public async getMangoAccountWithSlot(
     mangoAccountPk: PublicKey,
     loadSerum3Oo = false,
@@ -734,14 +720,14 @@ export class MangoClient {
     accountNumber: number,
     loadSerum3Oo = false,
   ): Promise<MangoAccount | undefined> {
-    const mangoAccounts = await this.getMangoAccountsForOwner(group, ownerPk);
+    const mangoAccounts = await this.getMangoAccountsForOwner(
+      group,
+      ownerPk,
+      loadSerum3Oo,
+    );
     const foundMangoAccount = mangoAccounts.find(
       (a) => a.accountNum == accountNumber,
     );
-
-    if (loadSerum3Oo) {
-      await foundMangoAccount?.reloadSerum3OpenOrders(this);
-    }
 
     return foundMangoAccount;
   }

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -53,10 +53,10 @@ import { I80F48 } from './numbers/I80F48';
 import { FlashLoanType, InterestRateParams, OracleConfigParams } from './types';
 import {
   I64_MAX_BN,
+  U64_MAX_BN,
   createAssociatedTokenAccountIdempotentInstruction,
   getAssociatedTokenAddress,
   toNative,
-  U64_MAX_BN,
 } from './utils';
 import { sendTransaction } from './utils/rpc';
 
@@ -540,16 +540,24 @@ export class MangoClient {
 
   // MangoAccount
 
-  public async getOrCreateMangoAccount(group: Group): Promise<MangoAccount> {
+  public async getOrCreateMangoAccount(
+    group: Group,
+    loadSerum3Oo = false,
+  ): Promise<MangoAccount> {
     const clientOwner = (this.program.provider as AnchorProvider).wallet
       .publicKey;
     let mangoAccounts = await this.getMangoAccountsForOwner(
       group,
       (this.program.provider as AnchorProvider).wallet.publicKey,
+      loadSerum3Oo,
     );
     if (mangoAccounts.length === 0) {
       await this.createMangoAccount(group);
-      mangoAccounts = await this.getMangoAccountsForOwner(group, clientOwner);
+      mangoAccounts = await this.getMangoAccountsForOwner(
+        group,
+        clientOwner,
+        loadSerum3Oo,
+      );
     }
     return mangoAccounts.sort((a, b) => a.accountNum - b.accountNum)[0];
   }
@@ -593,6 +601,7 @@ export class MangoClient {
     serum3Count?: number,
     perpCount?: number,
     perpOoCount?: number,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount | undefined> {
     const accNum = accountNumber ?? 0;
     await this.createMangoAccount(
@@ -608,6 +617,7 @@ export class MangoClient {
       group,
       (this.program.provider as AnchorProvider).wallet.publicKey,
       accNum,
+      loadSerum3Oo,
     );
   }
 
@@ -668,28 +678,39 @@ export class MangoClient {
 
   public async getMangoAccount(
     mangoAccount: MangoAccount | PublicKey,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount> {
     const mangoAccountPk =
       mangoAccount instanceof MangoAccount
         ? mangoAccount.publicKey
         : mangoAccount;
-    return MangoAccount.from(
+    const mangoAccount_ = MangoAccount.from(
       mangoAccountPk,
       await this.program.account.mangoAccount.fetch(mangoAccountPk),
     );
+    if (loadSerum3Oo) {
+      await mangoAccount_?.reloadSerum3OpenOrders(this);
+    }
+    return mangoAccount_;
   }
 
   public async getMangoAccountForPublicKey(
     mangoAccountPk: PublicKey,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount> {
-    return MangoAccount.from(
+    const mangoAccount = MangoAccount.from(
       mangoAccountPk,
       await this.program.account.mangoAccount.fetch(mangoAccountPk),
     );
+    if (loadSerum3Oo) {
+      await mangoAccount?.reloadSerum3OpenOrders(this);
+    }
+    return mangoAccount;
   }
 
   public async getMangoAccountWithSlot(
     mangoAccountPk: PublicKey,
+    loadSerum3Oo = false,
   ): Promise<{ slot: number; value: MangoAccount } | undefined> {
     const resp =
       await this.program.provider.connection.getAccountInfoAndContext(
@@ -701,6 +722,9 @@ export class MangoClient {
       resp.value.data,
     );
     const mangoAccount = MangoAccount.from(mangoAccountPk, decodedMangoAccount);
+    if (loadSerum3Oo) {
+      await mangoAccount?.reloadSerum3OpenOrders(this);
+    }
     return { slot: resp.context.slot, value: mangoAccount };
   }
 
@@ -708,11 +732,16 @@ export class MangoClient {
     group: Group,
     ownerPk: PublicKey,
     accountNumber: number,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount | undefined> {
     const mangoAccounts = await this.getMangoAccountsForOwner(group, ownerPk);
     const foundMangoAccount = mangoAccounts.find(
       (a) => a.accountNum == accountNumber,
     );
+
+    if (loadSerum3Oo) {
+      await foundMangoAccount?.reloadSerum3OpenOrders(this);
+    }
 
     return foundMangoAccount;
   }
@@ -720,8 +749,9 @@ export class MangoClient {
   public async getMangoAccountsForOwner(
     group: Group,
     ownerPk: PublicKey,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount[]> {
-    return (
+    const accounts = (
       await this.program.account.mangoAccount.all([
         {
           memcmp: {
@@ -739,13 +769,22 @@ export class MangoClient {
     ).map((pa) => {
       return MangoAccount.from(pa.publicKey, pa.account);
     });
+
+    if (loadSerum3Oo) {
+      await Promise.all(
+        accounts.map(async (a) => await a.reloadSerum3OpenOrders(this)),
+      );
+    }
+
+    return accounts;
   }
 
   public async getMangoAccountsForDelegate(
     group: Group,
     delegate: PublicKey,
+    loadSerum3Oo = false,
   ): Promise<MangoAccount[]> {
-    return (
+    const accounts = (
       await this.program.account.mangoAccount.all([
         {
           memcmp: {
@@ -763,10 +802,21 @@ export class MangoClient {
     ).map((pa) => {
       return MangoAccount.from(pa.publicKey, pa.account);
     });
+
+    if (loadSerum3Oo) {
+      await Promise.all(
+        accounts.map(async (a) => await a.reloadSerum3OpenOrders(this)),
+      );
+    }
+
+    return accounts;
   }
 
-  public async getAllMangoAccounts(group: Group): Promise<MangoAccount[]> {
-    return (
+  public async getAllMangoAccounts(
+    group: Group,
+    loadSerum3Oo = false,
+  ): Promise<MangoAccount[]> {
+    const accounts = (
       await this.program.account.mangoAccount.all([
         {
           memcmp: {
@@ -778,6 +828,14 @@ export class MangoClient {
     ).map((pa) => {
       return MangoAccount.from(pa.publicKey, pa.account);
     });
+
+    if (loadSerum3Oo) {
+      await Promise.all(
+        accounts.map(async (a) => await a.reloadSerum3OpenOrders(this)),
+      );
+    }
+
+    return accounts;
   }
 
   /**

--- a/ts/client/src/scripts/mm/log-perp-ob.ts
+++ b/ts/client/src/scripts/mm/log-perp-ob.ts
@@ -28,7 +28,7 @@ async function main() {
   );
 
   // Load mango account
-  let mangoAccount = await client.getMangoAccountForPublicKey(
+  let mangoAccount = await client.getMangoAccount(
     new PublicKey(MANGO_ACCOUNT_PK),
   );
   await mangoAccount.reload(client);

--- a/ts/client/src/scripts/mm/market-maker.ts
+++ b/ts/client/src/scripts/mm/market-maker.ts
@@ -28,7 +28,6 @@ import {
   makeInitSequenceEnforcerAccountIx,
   seqEnforcerProgramIds,
 } from './sequence-enforcer-util';
-import * as defaultParams from './params/default.json';
 
 // Future
 // * use async nodejs logging
@@ -248,7 +247,7 @@ async function fullMarketMaker() {
   );
 
   // Load mango account
-  let mangoAccount = await client.getMangoAccountForPublicKey(
+  let mangoAccount = await client.getMangoAccount(
     new PublicKey(MANGO_ACCOUNT_PK),
   );
   console.log(

--- a/ts/client/src/scripts/mm/taker.ts
+++ b/ts/client/src/scripts/mm/taker.ts
@@ -177,7 +177,7 @@ async function main() {
   );
 
   // Load mango account
-  let mangoAccount = await client.getMangoAccountForPublicKey(
+  let mangoAccount = await client.getMangoAccount(
     new PublicKey(MANGO_ACCOUNT_PK),
   );
   await mangoAccount.reload(client);


### PR DESCRIPTION
Serum OO accounts are needed to do a full health computation. But these are only loaded via mango account reload or reloadAccountData methods. Now this side effect is already achievable while fetching the mango account with an explicity flag. Also reloadAccountData is renamed to be more specific, since we dont really load any other data

Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>