### PR TITLE
Create a single rust test binary

### DIFF
--- a/programs/mango-v4/tests/cases/mod.rs
+++ b/programs/mango-v4/tests/cases/mod.rs
@@ -1,0 +1,33 @@
+pub use anchor_lang::prelude::Pubkey;
+pub use fixed::types::I80F48;
+pub use fixed_macro::types::I80F48;
+pub use solana_program_test::*;
+pub use solana_sdk::transport::TransportError;
+
+pub use mango_setup::*;
+pub use mango_v4::{error::MangoError, state::*};
+pub use program_test::*;
+
+pub use super::program_test;
+
+pub use utils::assert_equal_fixed_f64 as assert_equal;
+
+mod test_alt;
+mod test_bankrupt_tokens;
+mod test_basic;
+mod test_benchmark;
+mod test_borrow_limits;
+mod test_delegate;
+mod test_health_compute;
+mod test_health_region;
+mod test_ix_gate_set;
+mod test_liq_perps;
+mod test_liq_tokens;
+mod test_margin_trade;
+mod test_perp;
+mod test_perp_settle;
+mod test_perp_settle_fees;
+mod test_position_lifetime;
+mod test_reduce_only;
+mod test_serum;
+mod test_token_update_index_and_rate;

--- a/programs/mango-v4/tests/cases/test_alt.rs
+++ b/programs/mango-v4/tests/cases/test_alt.rs
@@ -1,14 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use solana_program_test::*;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transport::TransportError;
-
-use mango_setup::*;
-use mango_v4::state::*;
-use program_test::*;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_alt() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_bankrupt_tokens.rs
+++ b/programs/mango-v4/tests/cases/test_bankrupt_tokens.rs
@@ -1,15 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use fixed::types::I80F48;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::*;
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_bankrupt_tokens_socialize_loss() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_basic.rs
+++ b/programs/mango-v4/tests/cases/test_basic.rs
@@ -1,13 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use fixed::types::I80F48;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::*;
-use program_test::*;
-
-mod program_test;
+use super::*;
 
 // This is an unspecific happy-case test that just runs a few instructions to check
 // that they work in principle. It should be split up / renamed.

--- a/programs/mango-v4/tests/cases/test_benchmark.rs
+++ b/programs/mango-v4/tests/cases/test_benchmark.rs
@@ -1,10 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_benchmark() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_borrow_limits.rs
+++ b/programs/mango-v4/tests/cases/test_borrow_limits.rs
@@ -1,11 +1,4 @@
-#![cfg(all(feature = "test-bpf"))]
-
-use mango_setup::*;
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_bank_utilization_based_borrow_limit() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_delegate.rs
+++ b/programs/mango-v4/tests/cases/test_delegate.rs
@@ -1,14 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::*;
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_delegate() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_health_compute.rs
+++ b/programs/mango-v4/tests/cases/test_health_compute.rs
@@ -1,15 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use fixed::types::I80F48;
-use mango_v4::state::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 // Try to reach compute limits in health checks by having many different tokens in an account
 #[tokio::test]

--- a/programs/mango-v4/tests/cases/test_health_region.rs
+++ b/programs/mango-v4/tests/cases/test_health_region.rs
@@ -1,15 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::MangoAccount;
-
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_health_wrap() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_ix_gate_set.rs
+++ b/programs/mango-v4/tests/cases/test_ix_gate_set.rs
@@ -1,13 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::*;
-use program_test::*;
-
-use mango_setup::*;
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_ix_gate_set() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_liq_perps.rs
+++ b/programs/mango-v4/tests/cases/test_liq_perps.rs
@@ -1,18 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use anchor_lang::prelude::Pubkey;
-use fixed::types::I80F48;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_v4::state::{PerpMarketIndex, *};
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
-
-use utils::assert_equal_fixed_f64 as assert_equal;
+use super::*;
 
 #[tokio::test]
 async fn test_liq_perps_force_cancel() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_liq_tokens.rs
+++ b/programs/mango-v4/tests/cases/test_liq_tokens.rs
@@ -1,15 +1,6 @@
-#![cfg(feature = "test-bpf")]
-
-use fixed::types::I80F48;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
+use super::*;
 
 use mango_v4::instructions::{Serum3OrderType, Serum3SelfTradeBehavior, Serum3Side};
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
 
 #[tokio::test]
 async fn test_liq_tokens_force_cancel() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_margin_trade.rs
+++ b/programs/mango-v4/tests/cases/test_margin_trade.rs
@@ -1,11 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use program_test::*;
-use solana_program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 // This is an unspecific happy-case test that just runs a few instructions to check
 // that they work in principle. It should be split up / renamed.

--- a/programs/mango-v4/tests/cases/test_perp.rs
+++ b/programs/mango-v4/tests/cases/test_perp.rs
@@ -1,17 +1,4 @@
-#![cfg(all(feature = "test-bpf"))]
-
-use anchor_lang::prelude::Pubkey;
-use fixed::types::I80F48;
-use fixed_macro::types::I80F48;
-use mango_v4::state::*;
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_setup::*;
-use utils::assert_equal_fixed_f64 as assert_equal;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_perp_fixed() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_perp_settle.rs
+++ b/programs/mango-v4/tests/cases/test_perp_settle.rs
@@ -1,13 +1,4 @@
-#![cfg(all(feature = "test-bpf"))]
-
-use fixed::types::I80F48;
-use mango_setup::*;
-use mango_v4::{error::MangoError, state::*};
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_perp_settle_pnl() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_perp_settle_fees.rs
+++ b/programs/mango-v4/tests/cases/test_perp_settle_fees.rs
@@ -1,13 +1,4 @@
-#![cfg(all(feature = "test-bpf"))]
-
-use fixed::types::I80F48;
-use mango_setup::*;
-use mango_v4::{error::MangoError, state::*};
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_perp_settle_fees() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_position_lifetime.rs
+++ b/programs/mango-v4/tests/cases/test_position_lifetime.rs
@@ -1,17 +1,8 @@
-#![cfg(feature = "test-bpf")]
-
-use anchor_lang::prelude::*;
-use solana_program_test::*;
-
-use program_test::*;
-
-use mango_setup::*;
-
-mod program_test;
+use super::*;
 
 // Check opening and closing positions
 #[tokio::test]
-async fn test_position_lifetime() -> Result<()> {
+async fn test_position_lifetime() -> Result<(), TransportError> {
     let context = TestContext::new().await;
     let solana = &context.solana.clone();
 

--- a/programs/mango-v4/tests/cases/test_reduce_only.rs
+++ b/programs/mango-v4/tests/cases/test_reduce_only.rs
@@ -1,13 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use fixed::types::I80F48;
-use mango_setup::*;
-use mango_v4::state::{Bank, MangoAccount, PerpMarket, Side};
-use program_test::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_reduce_only_token() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/cases/test_serum.rs
+++ b/programs/mango-v4/tests/cases/test_serum.rs
@@ -1,18 +1,6 @@
-#![cfg(feature = "test-bpf")]
-#![allow(dead_code)]
+use super::*;
 
-use solana_program_test::*;
-use solana_sdk::{pubkey::Pubkey, transport::TransportError};
-
-use mango_v4::instructions::{
-    OpenOrdersSlim, Serum3OrderType, Serum3SelfTradeBehavior, Serum3Side,
-};
-use mango_v4::state::Serum3Orders;
-use program_test::*;
-
-mod program_test;
-
-use mango_setup::*;
+use mango_v4::instructions::{Serum3OrderType, Serum3SelfTradeBehavior, Serum3Side};
 use std::sync::Arc;
 
 struct SerumOrderPlacer {
@@ -138,10 +126,6 @@ impl SerumOrderPlacer {
             .find(|s| s.open_orders == self.open_orders)
             .unwrap();
         orders.clone()
-    }
-
-    async fn open_orders(&self) -> OpenOrdersSlim {
-        OpenOrdersSlim::from_oo(&self.serum.load_open_orders(self.open_orders).await)
     }
 }
 

--- a/programs/mango-v4/tests/cases/test_token_update_index_and_rate.rs
+++ b/programs/mango-v4/tests/cases/test_token_update_index_and_rate.rs
@@ -1,14 +1,4 @@
-#![cfg(feature = "test-bpf")]
-
-use mango_v4::state::*;
-use solana_program_test::*;
-use solana_sdk::transport::TransportError;
-
-use mango_setup::*;
-use program_test::*;
-use utils::assert_equal_fixed_f64 as assert_equal;
-
-mod program_test;
+use super::*;
 
 #[tokio::test]
 async fn test_token_update_index_and_rate() -> Result<(), TransportError> {

--- a/programs/mango-v4/tests/program_test/cookies.rs
+++ b/programs/mango-v4/tests/program_test/cookies.rs
@@ -1,6 +1,6 @@
 use solana_program::pubkey::*;
 
-use crate::utils::*;
+use super::utils::*;
 
 #[derive(Debug, Clone, Copy)]
 pub struct MintCookie {

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -2595,7 +2595,7 @@ pub struct PerpCreateMarketInstruction {
 impl PerpCreateMarketInstruction {
     pub async fn with_new_book_and_queue(
         solana: &SolanaCookie,
-        base: &crate::mango_setup::Token,
+        base: &super::mango_setup::Token,
     ) -> Self {
         PerpCreateMarketInstruction {
             bids: solana

--- a/programs/mango-v4/tests/program_test/serum.rs
+++ b/programs/mango-v4/tests/program_test/serum.rs
@@ -6,7 +6,7 @@ use bytemuck::from_bytes;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::{instruction::Instruction, signature::Signer};
 
-use crate::*;
+use super::*;
 
 pub struct ListingKeys {
     market_key: TestKeypair,

--- a/programs/mango-v4/tests/program_test/solana.rs
+++ b/programs/mango-v4/tests/program_test/solana.rs
@@ -3,7 +3,7 @@
 use std::cell::RefCell;
 use std::sync::{Arc, RwLock};
 
-use crate::utils::TestKeypair;
+use super::utils::TestKeypair;
 use anchor_lang::AccountDeserialize;
 use anchor_spl::token::TokenAccount;
 use solana_program::{program_pack::Pack, rent::*, system_instruction};

--- a/programs/mango-v4/tests/test_all.rs
+++ b/programs/mango-v4/tests/test_all.rs
@@ -1,0 +1,4 @@
+#![cfg(feature = "test-bpf")]
+
+mod cases;
+pub mod program_test;


### PR DESCRIPTION
Speeds up the linking step, needs way less disk space for test binaries and executes tests significantly faster.

Test execution went from 35s -> 29s for me and compilation improved a lot.