### PR TITLE
Liquidation: Fix amounts when stable price != oracle price

### DIFF
--- a/programs/mango-v4/tests/cases/test_liq_perps_positive_pnl.rs
+++ b/programs/mango-v4/tests/cases/test_liq_perps_positive_pnl.rs
@@ -3,7 +3,7 @@ use super::*;
 #[tokio::test]
 async fn test_liq_perps_positive_pnl() -> Result<(), TransportError> {
     let mut test_builder = TestContextBuilder::new();
-    test_builder.test().set_compute_max_units(120_000); // PerpLiqNegativePnlOrBankruptcy takes a lot of CU
+    test_builder.test().set_compute_max_units(140_000); // PerpLiqNegativePnlOrBankruptcy takes a lot of CU
     let context = test_builder.start_default().await;
     let solana = &context.solana.clone();
 


### PR DESCRIPTION
Previously liquidation would overestimate the amount required, because it used the oracle price for computing the health gain from liquidation.

Now it uses the correct (stable price adjusted) price for figuring out the amount of liquidation required, while still executing at fee-adjusted oracle price.