### PR TITLE
change 'ci' to 'devops' label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,8 +6,11 @@ liquidator:
 - 'liquidator/**'
 keeper:
 - 'keeper/**'
-ci:
-- '.github/workflows/**'
+devops:
+- '*.yml'
+- '*.yaml'
+- '*Dockerfile*'
+- 'fly.toml'
 dependency:
 - '*.lock'
 documentation:


### PR DESCRIPTION
Minor change to broaden the previous 'ci' PR label to encompass all DevOps'y changes