### PR TITLE
Improvements to liquidator and client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "anyhow",
+ "async-channel",
  "async-once-cell",
  "async-trait",
  "base64 0.13.1",
@@ -1132,6 +1133,8 @@ dependencies = [
  "fixed-macro",
  "futures 0.3.25",
  "itertools 0.10.5",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core-client",
  "log 0.4.17",
  "mango-v4",
  "pyth-sdk-solana",
@@ -1143,10 +1146,12 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-program",
  "solana-client",
+ "solana-rpc",
  "solana-sdk",
  "spl-associated-token-account",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -160,7 +160,7 @@ async fn main() -> Result<(), anyhow::Error> {
         Command::Deposit(cmd) => {
             let client = cmd.rpc.client(Some(&cmd.owner))?;
             let account = client::pubkey_from_cli(&cmd.account);
-            let owner = client::keypair_from_cli(&cmd.owner);
+            let owner = Arc::new(client::keypair_from_cli(&cmd.owner));
             let mint = client::pubkey_from_cli(&cmd.mint);
             let client = MangoClient::new_for_existing_account(client, account, owner).await?;
             let txsig = client.token_deposit(mint, cmd.amount, false).await?;
@@ -169,7 +169,7 @@ async fn main() -> Result<(), anyhow::Error> {
         Command::JupiterSwap(cmd) => {
             let client = cmd.rpc.client(Some(&cmd.owner))?;
             let account = client::pubkey_from_cli(&cmd.account);
-            let owner = client::keypair_from_cli(&cmd.owner);
+            let owner = Arc::new(client::keypair_from_cli(&cmd.owner));
             let input_mint = client::pubkey_from_cli(&cmd.input_mint);
             let output_mint = client::pubkey_from_cli(&cmd.output_mint);
             let client = MangoClient::new_for_existing_account(client, account, owner).await?;

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -11,18 +11,22 @@ anchor-client = { path = "../3rdparty/anchor/client" }
 anchor-lang = { path = "../3rdparty/anchor/lang" }
 anchor-spl = { path = "../3rdparty/anchor/spl" }
 anyhow = "1.0"
+async-channel = "1.6"
 async-once-cell = { version = "0.4.2", features = ["unpin"] }
 async-trait = "0.1.52"
 fixed = { version = "=1.11.0", features = ["serde", "borsh"] }
 fixed-macro = "^1.1.1"
 futures = "0.3.25"
 itertools = "0.10.3"
+jsonrpc-core = "18.0.0"
+jsonrpc-core-client = { version = "18.0.0", features = ["ws", "http", "tls"] }
 mango-v4 = { path = "../programs/mango-v4", features = ["client"] }
 pyth-sdk-solana = "0.1.0"
 serum_dex = { git = "https://github.com/openbook-dex/program.git", default-features=false,features = ["no-entrypoint", "program"] }
 shellexpand = "2.1.0"
 solana-account-decoder = "~1.14.9"
 solana-client = "~1.14.9"
+solana-rpc = "~1.14.9"
 solana-sdk = "~1.14.9"
 solana-address-lookup-table-program = "~1.14.9"
 spl-associated-token-account = "1.0.3"
@@ -30,6 +34,7 @@ thiserror = "1.0.31"
 log = "0.4"
 reqwest = "0.11.11"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1.9"}
 serde = "1.0.141"
 serde_json = "1.0.82"
 base64 = "0.13.0"

--- a/client/src/account_update_stream.rs
+++ b/client/src/account_update_stream.rs
@@ -1,0 +1,98 @@
+use solana_client::rpc_response::{Response, RpcKeyedAccount};
+use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+
+use log::*;
+use std::{str::FromStr, sync::Arc};
+
+use crate::chain_data;
+
+#[derive(Clone)]
+pub struct AccountUpdate {
+    pub pubkey: Pubkey,
+    pub slot: u64,
+    pub account: AccountSharedData,
+}
+
+impl AccountUpdate {
+    pub fn from_rpc(rpc: Response<RpcKeyedAccount>) -> anyhow::Result<Self> {
+        let pubkey = Pubkey::from_str(&rpc.value.pubkey)?;
+        let account = rpc
+            .value
+            .account
+            .decode()
+            .ok_or_else(|| anyhow::anyhow!("could not decode account"))?;
+        Ok(AccountUpdate {
+            pubkey,
+            slot: rpc.context.slot,
+            account,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub enum Message {
+    Account(AccountUpdate),
+    Snapshot(Vec<AccountUpdate>),
+    Slot(Arc<solana_client::rpc_response::SlotUpdate>),
+}
+
+impl Message {
+    pub fn update_chain_data(&self, chain: &mut chain_data::ChainData) {
+        use chain_data::*;
+        match self {
+            Message::Account(account_write) => {
+                trace!("websocket account message");
+                chain.update_account(
+                    account_write.pubkey,
+                    AccountAndSlot {
+                        slot: account_write.slot,
+                        account: account_write.account.clone(),
+                    },
+                );
+            }
+            Message::Snapshot(snapshot) => {
+                for account_update in snapshot {
+                    chain.update_account(
+                        account_update.pubkey,
+                        chain_data::AccountAndSlot {
+                            slot: account_update.slot,
+                            account: account_update.account.clone(),
+                        },
+                    );
+                }
+            }
+            Message::Slot(slot_update) => {
+                trace!("websocket slot message");
+                let slot_update = match **slot_update {
+                    solana_client::rpc_response::SlotUpdate::CreatedBank {
+                        slot, parent, ..
+                    } => Some(SlotData {
+                        slot,
+                        parent: Some(parent),
+                        status: SlotStatus::Processed,
+                        chain: 0,
+                    }),
+                    solana_client::rpc_response::SlotUpdate::OptimisticConfirmation {
+                        slot,
+                        ..
+                    } => Some(SlotData {
+                        slot,
+                        parent: None,
+                        status: SlotStatus::Confirmed,
+                        chain: 0,
+                    }),
+                    solana_client::rpc_response::SlotUpdate::Root { slot, .. } => Some(SlotData {
+                        slot,
+                        parent: None,
+                        status: SlotStatus::Rooted,
+                        chain: 0,
+                    }),
+                    _ => None,
+                };
+                if let Some(update) = slot_update {
+                    chain.update_slot(update);
+                }
+            }
+        }
+    }
+}

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -31,7 +31,6 @@ use crate::account_fetcher::*;
 use crate::context::{MangoGroupContext, Serum3MarketContext, TokenContext};
 use crate::gpa::{fetch_anchor_account, fetch_mango_accounts};
 use crate::jupiter;
-use crate::util::MyClone;
 
 use anyhow::Context;
 use solana_sdk::account::ReadableAccount;
@@ -54,13 +53,13 @@ impl Client {
     pub fn new(
         cluster: Cluster,
         commitment: CommitmentConfig,
-        fee_payer: &Keypair,
+        fee_payer: Arc<Keypair>,
         timeout: Option<Duration>,
         prioritization_micro_lamports: u64,
     ) -> Self {
         Self {
             cluster,
-            fee_payer: Arc::new(fee_payer.clone()),
+            fee_payer,
             commitment,
             timeout,
             prioritization_micro_lamports,
@@ -93,7 +92,7 @@ pub struct MangoClient {
     // call to refresh banks etc -- if it's backed by websockets, these could just do nothing
     pub account_fetcher: Arc<dyn AccountFetcher>,
 
-    pub owner: Keypair,
+    pub owner: Arc<Keypair>,
     pub mango_account_address: Pubkey,
 
     pub context: MangoGroupContext,
@@ -219,7 +218,7 @@ impl MangoClient {
     pub async fn new_for_existing_account(
         client: Client,
         account: Pubkey,
-        owner: Keypair,
+        owner: Arc<Keypair>,
     ) -> anyhow::Result<Self> {
         let rpc = client.rpc_async();
         let account_fetcher = Arc::new(CachedAccountFetcher::new(Arc::new(RpcAccountFetcher {
@@ -246,7 +245,7 @@ impl MangoClient {
     pub fn new_detail(
         client: Client,
         account: Pubkey,
-        owner: Keypair,
+        owner: Arc<Keypair>,
         // future: maybe pass Arc<MangoGroupContext>, so it can be extenally updated?
         group_context: MangoGroupContext,
         account_fetcher: Arc<dyn AccountFetcher>,
@@ -1360,7 +1359,7 @@ impl MangoClient {
             instructions,
             address_lookup_tables,
             payer,
-            signers: vec![&self.owner],
+            signers: vec![&*self.owner],
         }
         .send_and_confirm(&self.client)
         .await
@@ -1445,7 +1444,7 @@ impl MangoClient {
             instructions,
             address_lookup_tables: vec![],
             payer: self.client.fee_payer.pubkey(),
-            signers: vec![&self.owner, &*self.client.fee_payer],
+            signers: vec![&*self.owner, &*self.client.fee_payer],
         }
         .send_and_confirm(&self.client)
         .await

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1481,7 +1481,7 @@ pub enum MangoClientError {
 pub struct TransactionBuilder<'a> {
     instructions: Vec<Instruction>,
     address_lookup_tables: Vec<AddressLookupTableAccount>,
-    signers: Vec<&'a dyn Signer>,
+    signers: Vec<&'a Keypair>,
     payer: Pubkey,
 }
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,4 +12,6 @@ mod gpa;
 pub mod health_cache;
 mod jupiter;
 pub mod perp_pnl;
+pub mod snapshot_source;
 mod util;
+pub mod websocket_source;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -4,6 +4,7 @@ pub use context::*;
 pub use util::*;
 
 mod account_fetcher;
+pub mod account_update_stream;
 pub mod chain_data;
 mod chain_data_fetcher;
 mod client;

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -3,9 +3,7 @@ use solana_client::{
 };
 use solana_sdk::transaction::Transaction;
 use solana_sdk::{
-    clock::Slot,
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signature},
+    clock::Slot, commitment_config::CommitmentConfig, signature::Signature,
     transaction::uses_durable_nonce,
 };
 
@@ -26,13 +24,15 @@ use std::{thread, time};
 //     Err(anyhow!("Retry failed"))
 // }
 
-pub trait MyClone {
-    fn clone(&self) -> Self;
+pub trait AnyhowWrap {
+    type Value;
+    fn map_err_anyhow(self) -> anyhow::Result<Self::Value>;
 }
 
-impl MyClone for Keypair {
-    fn clone(&self) -> Keypair {
-        Self::from_bytes(&self.to_bytes()).unwrap()
+impl<T, E: std::fmt::Debug> AnyhowWrap for Result<T, E> {
+    type Value = T;
+    fn map_err_anyhow(self) -> anyhow::Result<Self::Value> {
+        self.map_err(|err| anyhow::anyhow!("{:?}", err))
     }
 }
 

--- a/client/src/websocket_source.rs
+++ b/client/src/websocket_source.rs
@@ -15,8 +15,7 @@ use log::*;
 use std::{str::FromStr, sync::Arc, time::Duration};
 use tokio_stream::StreamMap;
 
-use client::chain_data;
-
+use crate::chain_data;
 use crate::AnyhowWrap;
 
 #[derive(Clone)]
@@ -50,7 +49,6 @@ pub enum Message {
 
 pub struct Config {
     pub rpc_ws_url: String,
-    pub mango_program: Pubkey,
     pub serum_program: Pubkey,
     pub open_orders_authority: Pubkey,
 }
@@ -94,7 +92,7 @@ async fn feed_data(
     };
     let mut mango_sub = client
         .program_subscribe(
-            config.mango_program.to_string(),
+            mango_v4::id().to_string(),
             Some(all_accounts_config.clone()),
         )
         .map_err_anyhow()?;

--- a/client/src/websocket_source.rs
+++ b/client/src/websocket_source.rs
@@ -5,47 +5,18 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, RpcFilterType},
-    rpc_response::{Response, RpcKeyedAccount, RpcResponseContext},
+    rpc_response::{RpcKeyedAccount, RpcResponseContext},
 };
 use solana_rpc::rpc_pubsub::RpcSolPubSubClient;
-use solana_sdk::{account::AccountSharedData, commitment_config::CommitmentConfig, pubkey::Pubkey};
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 
 use anyhow::Context;
 use log::*;
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio_stream::StreamMap;
 
-use crate::chain_data;
+use crate::account_update_stream::{AccountUpdate, Message};
 use crate::AnyhowWrap;
-
-#[derive(Clone)]
-pub struct AccountUpdate {
-    pub pubkey: Pubkey,
-    pub slot: u64,
-    pub account: AccountSharedData,
-}
-
-impl AccountUpdate {
-    pub fn from_rpc(rpc: Response<RpcKeyedAccount>) -> anyhow::Result<Self> {
-        let pubkey = Pubkey::from_str(&rpc.value.pubkey)?;
-        let account = rpc
-            .value
-            .account
-            .decode()
-            .ok_or_else(|| anyhow::anyhow!("could not decode account"))?;
-        Ok(AccountUpdate {
-            pubkey,
-            slot: rpc.context.slot,
-            account,
-        })
-    }
-}
-
-#[derive(Clone)]
-pub enum Message {
-    Account(AccountUpdate),
-    Slot(Arc<solana_client::rpc_response::SlotUpdate>),
-}
 
 pub struct Config {
     pub rpc_ws_url: String,
@@ -179,53 +150,6 @@ pub fn start(config: Config, mango_oracles: Vec<Pubkey>, sender: async_channel::
             }
         }
     });
-}
-
-pub fn update_chain_data(chain: &mut chain_data::ChainData, message: Message) {
-    use chain_data::*;
-    match message {
-        Message::Account(account_write) => {
-            trace!("websocket account message");
-            chain.update_account(
-                account_write.pubkey,
-                AccountAndSlot {
-                    slot: account_write.slot,
-                    account: account_write.account,
-                },
-            );
-        }
-        Message::Slot(slot_update) => {
-            trace!("websocket slot message");
-            let slot_update = match *slot_update {
-                solana_client::rpc_response::SlotUpdate::CreatedBank { slot, parent, .. } => {
-                    Some(SlotData {
-                        slot,
-                        parent: Some(parent),
-                        status: SlotStatus::Processed,
-                        chain: 0,
-                    })
-                }
-                solana_client::rpc_response::SlotUpdate::OptimisticConfirmation {
-                    slot, ..
-                } => Some(SlotData {
-                    slot,
-                    parent: None,
-                    status: SlotStatus::Confirmed,
-                    chain: 0,
-                }),
-                solana_client::rpc_response::SlotUpdate::Root { slot, .. } => Some(SlotData {
-                    slot,
-                    parent: None,
-                    status: SlotStatus::Rooted,
-                    chain: 0,
-                }),
-                _ => None,
-            };
-            if let Some(update) = slot_update {
-                chain.update_slot(update);
-            }
-        }
-    }
 }
 
 pub async fn get_next_create_bank_slot(

--- a/keeper/src/main.rs
+++ b/keeper/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let cli = Cli::parse_from(args);
 
-    let owner = keypair_from_cli(&cli.owner);
+    let owner = Arc::new(keypair_from_cli(&cli.owner));
 
     let rpc_url = cli.rpc_url;
     let ws_url = rpc_url.replace("https", "wss");
@@ -102,12 +102,12 @@ async fn main() -> Result<(), anyhow::Error> {
             Client::new(
                 cluster,
                 commitment,
-                &owner,
+                owner.clone(),
                 Some(Duration::from_secs(cli.timeout)),
                 cli.prioritization_micro_lamports,
             ),
             cli.mango_account,
-            owner,
+            owner.clone(),
         )
         .await?,
     );

--- a/liquidator/src/rebalance.rs
+++ b/liquidator/src/rebalance.rs
@@ -1,6 +1,4 @@
-use crate::AnyhowWrap;
-
-use client::{chain_data, AccountFetcher, MangoClient, TokenContext};
+use client::{chain_data, AccountFetcher, AnyhowWrap, MangoClient, TokenContext};
 use mango_v4::accounts_zerocopy::KeyedAccountSharedData;
 use mango_v4::state::{
     Bank, BookSide, PlaceOrderType, Side, TokenIndex, TokenPosition, QUOTE_TOKEN_INDEX,

--- a/liquidator/src/rebalance.rs
+++ b/liquidator/src/rebalance.rs
@@ -8,6 +8,7 @@ use {fixed::types::I80F48, solana_sdk::pubkey::Pubkey};
 
 use futures::{stream, StreamExt, TryStreamExt};
 use solana_sdk::signature::Signature;
+use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
 
 #[derive(Clone)]
@@ -63,14 +64,14 @@ impl TokenState {
     }
 }
 
-pub struct Rebalancer<'a> {
-    pub mango_client: &'a MangoClient,
-    pub account_fetcher: &'a chain_data::AccountFetcher,
+pub struct Rebalancer {
+    pub mango_client: Arc<MangoClient>,
+    pub account_fetcher: Arc<chain_data::AccountFetcher>,
     pub mango_account_address: Pubkey,
     pub config: Config,
 }
 
-impl<'a> Rebalancer<'a> {
+impl Rebalancer {
     pub async fn zero_all_non_quote(&self) -> anyhow::Result<()> {
         log::trace!("checking for rebalance: {}", self.mango_account_address);
 
@@ -114,7 +115,7 @@ impl<'a> Rebalancer<'a> {
                     let token = self.mango_client.context.token(token_position.token_index);
                     Ok((
                         token.token_index,
-                        TokenState::new_position(token, token_position, self.account_fetcher)
+                        TokenState::new_position(token, token_position, &self.account_fetcher)
                             .await?,
                     ))
                 })
@@ -172,7 +173,7 @@ impl<'a> Rebalancer<'a> {
                 if !self.refresh_mango_account_after_tx(txsig).await? {
                     return Ok(());
                 }
-                let bank = TokenState::bank(token, self.account_fetcher)?;
+                let bank = TokenState::bank(token, &self.account_fetcher)?;
                 amount = self
                     .mango_client
                     .mango_account()
@@ -204,7 +205,7 @@ impl<'a> Rebalancer<'a> {
                 if !self.refresh_mango_account_after_tx(txsig).await? {
                     return Ok(());
                 }
-                let bank = TokenState::bank(token, self.account_fetcher)?;
+                let bank = TokenState::bank(token, &self.account_fetcher)?;
                 amount = self
                     .mango_client
                     .mango_account()
@@ -351,7 +352,7 @@ impl<'a> Rebalancer<'a> {
                 };
                 let counters = client::perp_pnl::fetch_top(
                     &self.mango_client.context,
-                    self.account_fetcher,
+                    self.account_fetcher.as_ref(),
                     perp_position.market_index,
                     direction,
                     2,


### PR DESCRIPTION
- move actual liquidation to a separate thread from updating the chain_data
- make it easier to reuse liquidator logic for the upcoming settle-bot