### PR TITLE
Security admin: Allow disabling token/perp init collateral

### DIFF
--- a/programs/mango-v4/src/instructions/perp_edit_market.rs
+++ b/programs/mango-v4/src/instructions/perp_edit_market.rs
@@ -129,7 +129,12 @@ pub fn perp_edit_market(
             init_overall_asset_weight
         );
         perp_market.init_overall_asset_weight = I80F48::from_num(init_overall_asset_weight);
-        require_group_admin = true;
+
+        // The security admin is allowed to disable init collateral contributions,
+        // but all other changes need to go through the full group admin.
+        if init_overall_asset_weight != 0.0 {
+            require_group_admin = true;
+        }
     }
     if let Some(base_liquidation_fee) = base_liquidation_fee_opt {
         msg!(

--- a/programs/mango-v4/src/instructions/token_edit.rs
+++ b/programs/mango-v4/src/instructions/token_edit.rs
@@ -151,7 +151,12 @@ pub fn token_edit(
             );
 
             bank.init_asset_weight = I80F48::from_num(init_asset_weight);
-            require_group_admin = true;
+
+            // The security admin is allowed to decrease the init collateral weight to zero,
+            // but all other changes need to go through the full group admin.
+            if init_asset_weight != 0.0 {
+                require_group_admin = true;
+            }
         }
         if let Some(maint_liab_weight) = maint_liab_weight_opt {
             msg!(


### PR DESCRIPTION
This allows the security council to say "users can't create new borrows against this token/perp anymore". In some emergency situations this can help reduce risk exposure.

For example, if the price of a wrapped asset permanently depegs from its underlying or there is a successful long-term attack on an oracle, this (and reduce-only) would significantly reduce exploitability until the DAO's decision for how to resolve the issue goes through.