### PR TITLE
Perp: User-selected reduce-only behaves more intuitively

### DIFF
--- a/programs/mango-v4/src/instructions/perp_place_order.rs
+++ b/programs/mango-v4/src/instructions/perp_place_order.rs
@@ -91,27 +91,7 @@ pub fn perp_place_order(
     let pp = account.perp_position(perp_market_index)?;
     let effective_pos = pp.effective_base_position_lots();
     let max_base_lots = if order.reduce_only || perp_market.is_reduce_only() {
-        let allowed_base_lots = if order.side == Side::Bid {
-            // ignores open asks
-            msg!(
-                "reduce only: effective base position incl open bids is {} lots",
-                effective_pos + pp.bids_base_lots
-            );
-            (effective_pos + pp.bids_base_lots).min(0).abs()
-        } else {
-            // ignores open bids
-            msg!(
-                "reduce only: effective base position incl open asks is {} lots",
-                effective_pos - pp.asks_base_lots
-            );
-            (effective_pos - pp.asks_base_lots).max(0)
-        };
-        msg!(
-            "max allowed {:?}: {} base lots",
-            order.side,
-            allowed_base_lots
-        );
-        allowed_base_lots.min(order.max_base_lots)
+        reduce_only_max_base_lots(pp, &order, perp_market.is_reduce_only())
     } else {
         order.max_base_lots
     };
@@ -144,4 +124,96 @@ pub fn perp_place_order(
     }
 
     Ok(order_id_opt)
+}
+
+fn reduce_only_max_base_lots(pp: &PerpPosition, order: &Order, market_reduce_only: bool) -> i64 {
+    let effective_pos = pp.effective_base_position_lots();
+    msg!(
+        "reduce only: current effective position: {} lots",
+        effective_pos
+    );
+    let allowed_base_lots = if (order.side == Side::Bid && effective_pos >= 0)
+        || (order.side == Side::Ask && effective_pos <= 0)
+    {
+        msg!("reduce only: cannot increase magnitude of effective position");
+        0
+    } else if market_reduce_only {
+        // If the market is in reduce-only mode, we are stricter and pretend
+        // all open orders that go into the same direction as the new order
+        // execute.
+        if order.side == Side::Bid {
+            msg!(
+                "reduce only: effective base position incl open bids is {} lots",
+                effective_pos + pp.bids_base_lots
+            );
+            (effective_pos + pp.bids_base_lots).min(0).abs()
+        } else {
+            msg!(
+                "reduce only: effective base position incl open asks is {} lots",
+                effective_pos - pp.asks_base_lots
+            );
+            (effective_pos - pp.asks_base_lots).max(0)
+        }
+    } else {
+        effective_pos.abs()
+    };
+    msg!(
+        "reduce only: max allowed {:?}: {} base lots",
+        order.side,
+        allowed_base_lots
+    );
+    allowed_base_lots.min(order.max_base_lots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_perp_reduce_only() {
+        let test_cases = vec![
+            ("null", true, 0, (0, 0), (Side::Bid, 0), 0),
+            ("ok bid", true, -5, (0, 0), (Side::Bid, 1), 1),
+            ("limited bid", true, -5, (0, 0), (Side::Bid, 10), 5),
+            ("limited bid2", true, -5, (1, 10), (Side::Bid, 10), 4),
+            ("limited bid3", false, -5, (1, 10), (Side::Bid, 10), 5),
+            ("no bid", true, 5, (0, 0), (Side::Bid, 1), 0),
+            ("ok ask", true, 5, (0, 0), (Side::Ask, 1), 1),
+            ("limited ask", true, 5, (0, 0), (Side::Ask, 10), 5),
+            ("limited ask2", true, 5, (10, 1), (Side::Ask, 10), 4),
+            ("limited ask3", false, 5, (10, 1), (Side::Ask, 10), 5),
+            ("no ask", true, -5, (0, 0), (Side::Ask, 1), 0),
+        ];
+
+        for (
+            name,
+            market_reduce_only,
+            base_lots,
+            (open_bids, open_asks),
+            (side, amount),
+            expected,
+        ) in test_cases
+        {
+            println!("test: {name}");
+
+            let pp = PerpPosition {
+                base_position_lots: base_lots,
+                bids_base_lots: open_bids,
+                asks_base_lots: open_asks,
+                ..PerpPosition::default()
+            };
+            let order = Order {
+                side,
+                max_base_lots: amount,
+                max_quote_lots: 0,
+                client_order_id: 0,
+                reduce_only: true,
+                time_in_force: 0,
+                params: OrderParams::Market,
+            };
+
+            let result = reduce_only_max_base_lots(&pp, &order, market_reduce_only);
+            assert_eq!(result, expected);
+        }
+    }
 }

--- a/programs/mango-v4/src/state/mango_account_components.rs
+++ b/programs/mango-v4/src/state/mango_account_components.rs
@@ -179,10 +179,10 @@ pub struct PerpPosition {
     pub settle_pnl_limit_settled_in_current_window_native: i64,
 
     /// Active position size, measured in base lots
-    base_position_lots: i64,
+    pub base_position_lots: i64,
     /// Active position in quote (conversation rate is that of the time the order was settled)
     /// measured in native quote
-    quote_position_native: I80F48,
+    pub quote_position_native: I80F48,
 
     /// Tracks what the position is to calculate average entry & break even price
     pub quote_running_native: i64,


### PR DESCRIPTION
The previous strict behavior of taking existing open orders into account is only used when the perp market itself is also flagged as reduce-only.