### PR TITLE
switch from storing group info in maps and use arrays instead

### DIFF
--- a/ts/client/scripts/mm/market-maker.ts
+++ b/ts/client/scripts/mm/market-maker.ts
@@ -90,9 +90,9 @@ const binanceClient = Binance();
 const krakenClient = new Kraken();
 
 function getPerpMarketAssetsToTradeOn(group: Group) {
-  const allMangoGroupPerpMarketAssets = Array.from(
-    group.perpMarketsMapByName.keys(),
-  ).map((marketName) => marketName.replace('-PERP', ''));
+  const allMangoGroupPerpMarketAssets = group.perpMarkets.map((perpMarket) =>
+    perpMarket.name.replace('-PERP', ''),
+  );
   return Object.keys(params.assets).filter((asset) =>
     allMangoGroupPerpMarketAssets.includes(asset),
   );
@@ -267,9 +267,7 @@ async function fullMarketMaker() {
   await group.reloadAll(client);
 
   // Cancel all existing orders
-  for (const perpMarket of Array.from(
-    group.perpMarketsMapByMarketIndex.values(),
-  )) {
+  for (const perpMarket of group.perpMarkets) {
     await client.perpCancelAllOrders(
       group,
       mangoAccount,

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -98,11 +98,8 @@ export class Group {
     public serum3Markets: Market[],
     public perpMarkets: PerpMarket[],
     public mintInfos: MintInfo[],
-    public vaultAmountsMap: Map<string, BN>, // public banksMapByName: Map<string, Bank[]>, // public banksMapByMint: Map<string, Bank[]>, // public banksMapByTokenIndex: Map<TokenIndex, Bank[]>, // public serum3MarketsMapByExternal: Map<string, Serum3Market>, // public serum3MarketsMapByMarketIndex: Map<MarketIndex, Serum3Market>, // public serum3ExternalMarketsMap: Map<string, Market>, // public perpMarketsMapByOracle: Map<string, PerpMarket>, // public perpMarketsMapByMarketIndex: Map<PerpMarketIndex, PerpMarket>, // public perpMarketsMapByName: Map<string, PerpMarket>,
-  ) // public mintInfosMapByTokenIndex: Map<TokenIndex, MintInfo>,
-  // public mintInfosMapByMint: Map<string, MintInfo>,
-  // public vaultAmountsMap: Map<string, BN>,
-  {}
+    public vaultAmountsMap: Map<string, BN>,
+  ) {}
 
   public async reloadAll(client: MangoClient): Promise<void> {
     const ids: Id | undefined = await client.getIds(this.publicKey);

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -630,9 +630,8 @@ export class MangoAccount {
       throw new Error(`No open orders account found for ${externalMarketPk}`);
     }
 
-    const serum3MarketExternal = group.serum3ExternalMarketsMap.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3MarketExternal =
+      group.getSerum3ExternalMarket(externalMarketPk);
     const [bidsInfo, asksInfo] =
       await client.program.provider.connection.getMultipleAccountsInfo([
         serum3MarketExternal.bidsAddress,

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -354,7 +354,7 @@ export class MangoClient {
     params: TokenEditParams,
   ): Promise<TransactionSignature> {
     const bank = group.getFirstBankByMint(mintPk);
-    const mintInfo = group.mintInfosMapByTokenIndex.get(bank.tokenIndex)!;
+    const mintInfo = group.getMintInfoByTokenIndex(bank.tokenIndex)!;
 
     const ix = await this.program.methods
       .tokenEdit(
@@ -429,8 +429,7 @@ export class MangoClient {
       .accounts({
         group: group.publicKey,
         admin: adminPk,
-        mintInfo: group.mintInfosMapByTokenIndex.get(bank.tokenIndex)
-          ?.publicKey,
+        mintInfo: group.getMintInfoByTokenIndex(bank.tokenIndex)?.publicKey,
         dustVault: dustVaultPk,
         solDestination: (this.program.provider as AnchorProvider).wallet
           .publicKey,
@@ -928,7 +927,7 @@ export class MangoClient {
     const healthAccountsToExclude: PublicKey[] = [];
 
     for (const serum3Account of mangoAccount.serum3Active()) {
-      const serum3Market = group.serum3MarketsMapByMarketIndex.get(
+      const serum3Market = group.getSerum3MarketByMarketIndex(
         serum3Account.marketIndex,
       )!;
 
@@ -1269,9 +1268,8 @@ export class MangoClient {
     group: Group,
     externalMarketPk: PublicKey,
   ): Promise<TransactionSignature> {
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
     const marketIndexBuf = Buffer.alloc(2);
     marketIndexBuf.writeUInt16LE(serum3Market.marketIndex);
@@ -1342,9 +1340,8 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     externalMarketPk: PublicKey,
   ): Promise<TransactionSignature> {
-    const serum3Market: Serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market: Serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
     const ix = await this.program.methods
       .serum3CreateOpenOrders()
@@ -1366,9 +1363,8 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     externalMarketPk: PublicKey,
   ): Promise<TransactionInstruction> {
-    const serum3Market: Serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market: Serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
     const ix = await this.program.methods
       .serum3CreateOpenOrders()
@@ -1391,9 +1387,8 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     externalMarketPk: PublicKey,
   ): Promise<TransactionInstruction> {
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
     const openOrders = mangoAccount.serum3.find(
       (account) => account.marketIndex === serum3Market.marketIndex,
@@ -1448,9 +1443,8 @@ export class MangoClient {
     limit: number,
   ): Promise<TransactionInstruction[]> {
     const ixs: TransactionInstruction[] = [];
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
     let openOrderPk: PublicKey | undefined = undefined;
     const banks: Bank[] = [];
@@ -1488,9 +1482,8 @@ export class MangoClient {
         openOrdersForMarket,
       );
 
-    const serum3MarketExternal = group.serum3ExternalMarketsMap.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3MarketExternal =
+      group.getSerum3ExternalMarket(externalMarketPk);
     const serum3MarketExternalVaultSigner =
       await generateSerum3MarketExternalVaultSignerAddress(
         this.cluster,
@@ -1604,13 +1597,11 @@ export class MangoClient {
     externalMarketPk: PublicKey,
     limit?: number,
   ): Promise<TransactionSignature> {
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
-    const serum3MarketExternal = group.serum3ExternalMarketsMap.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3MarketExternal =
+      group.getSerum3ExternalMarket(externalMarketPk);
 
     const ix = await this.program.methods
       .serum3CancelAllOrders(limit ? limit : 10)
@@ -1637,12 +1628,10 @@ export class MangoClient {
     mangoAccount: MangoAccount,
     externalMarketPk: PublicKey,
   ): Promise<TransactionInstruction> {
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
-    const serum3MarketExternal = group.serum3ExternalMarketsMap.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
+    const serum3MarketExternal =
+      group.getSerum3ExternalMarket(externalMarketPk);
 
     const [serum3MarketExternalVaultSigner, openOrderPublicKey] =
       await Promise.all([
@@ -1702,13 +1691,11 @@ export class MangoClient {
     side: Serum3Side,
     orderId: BN,
   ): Promise<TransactionInstruction> {
-    const serum3Market = group.serum3MarketsMapByExternal.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3Market =
+      group.getSerum3MarketByExternalMarket(externalMarketPk);
 
-    const serum3MarketExternal = group.serum3ExternalMarketsMap.get(
-      externalMarketPk.toBase58(),
-    )!;
+    const serum3MarketExternal =
+      group.getSerum3ExternalMarket(externalMarketPk);
 
     const ix = await this.program.methods
       .serum3CancelOrder(side, orderId)
@@ -2285,7 +2272,7 @@ export class MangoClient {
         [group.getFirstBankForPerpSettlement()],
         [perpMarket],
       );
-    const bank = group.banksMapByTokenIndex.get(0 as TokenIndex)![0];
+    const bank = group.getFirstBankByTokenIndex(0 as TokenIndex);
     const ix = await this.program.methods
       .perpSettlePnl()
       .accounts({
@@ -2326,7 +2313,7 @@ export class MangoClient {
         [group.getFirstBankForPerpSettlement()],
         [perpMarket],
       );
-    const bank = group.banksMapByTokenIndex.get(0 as TokenIndex)![0];
+    const bank = group.getFirstBankByTokenIndex(0 as TokenIndex);
     const ix = await this.program.methods
       .perpSettleFees(maxSettleAmount)
       .accounts({
@@ -2581,7 +2568,7 @@ export class MangoClient {
     mintPk: PublicKey,
   ): Promise<TransactionSignature> {
     const bank = group.getFirstBankByMint(mintPk);
-    const mintInfo = group.mintInfosMapByMint.get(mintPk.toString())!;
+    const mintInfo = group.mintInfosMapByMint(mintPk);
 
     const ix = await this.program.methods
       .tokenUpdateIndexAndRate()
@@ -2840,7 +2827,7 @@ export class MangoClient {
     }
     const mintInfos = tokenPositionIndices
       .filter((tokenIndex) => tokenIndex !== TokenPosition.TokenIndexUnset)
-      .map((tokenIndex) => group.mintInfosMapByTokenIndex.get(tokenIndex)!);
+      .map((tokenIndex) => group.getMintInfoByTokenIndex(tokenIndex));
     healthRemainingAccounts.push(
       ...mintInfos.map((mintInfo) => mintInfo.firstBank()),
     );
@@ -2932,8 +2919,8 @@ export class MangoClient {
         tokenIndices.push(bank.tokenIndex);
       }
     }
-    const mintInfos = [...new Set(tokenIndices)].map(
-      (tokenIndex) => group.mintInfosMapByTokenIndex.get(tokenIndex)!,
+    const mintInfos = [...new Set(tokenIndices)].map((tokenIndex) =>
+      group.getMintInfoByTokenIndex(tokenIndex),
     );
     healthRemainingAccounts.push(
       ...mintInfos.map((mintInfo) => mintInfo.firstBank()),

--- a/ts/client/src/development.ts
+++ b/ts/client/src/development.ts
@@ -26,22 +26,22 @@ export function debugHealthAccounts(
   publicKeys: PublicKey[],
 ): void {
   const banks = new Map(
-    Array.from(group.banksMapByName.values()).map((banks: Bank[]) => [
+    group.banks.map((banks: Bank[]) => [
       banks[0].publicKey.toBase58(),
       `${banks[0].name} bank`,
     ]),
   );
   const oracles = new Map(
-    Array.from(group.banksMapByName.values()).map((banks: Bank[]) => [
+    group.banks.map((banks: Bank[]) => [
       banks[0].oracle.toBase58(),
       `${banks[0].name} oracle`,
     ]),
   );
   const serum3 = new Map(
     mangoAccount.serum3Active().map((serum3: Serum3Orders) => {
-      const serum3Market = Array.from(
-        group.serum3MarketsMapByExternal.values(),
-      ).find((serum3Market) => serum3Market.marketIndex === serum3.marketIndex);
+      const serum3Market = group.serum3MarketInfos.find(
+        (serum3Market) => serum3Market.marketIndex === serum3.marketIndex,
+      );
       if (!serum3Market) {
         throw new Error(
           `Serum3Orders for non existent market with market index ${serum3.marketIndex}`,
@@ -51,12 +51,10 @@ export function debugHealthAccounts(
     }),
   );
   const perps = new Map(
-    Array.from(group.perpMarketsMapByName.values()).map(
-      (perpMarket: PerpMarket) => [
-        perpMarket.publicKey.toBase58(),
-        `${perpMarket.name} perp market`,
-      ],
-    ),
+    group.perpMarkets.map((perpMarket: PerpMarket) => [
+      perpMarket.publicKey.toBase58(),
+      `${perpMarket.name} perp market`,
+    ]),
   );
 
   publicKeys.map((pk) => {


### PR DESCRIPTION
The changes in the PR were a result of finding that calling `group.reloadAll` and then calling `mangoAccount.getEquity(group)` resulted in stale information being returned from `getEquity`.

I believe this stemmed from an issue inside `reloadPerpMarketOraclePrices` where the prices were only being updated on the `perpMarketsMapByName` however the `getEquity` call uses the `getPerpMarketByMarketIndex`.  I also found that `reloadBankOraclePrices` was only updating `bankMapsByMint` so that could cause similar issues in the future.