### PR TITLE
Downgrade the `fixed` crate to v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.23.0"
+version = "1.11.0"
 dependencies = [
  "arbitrary",
  "az",
@@ -2164,12 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.2.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
-]
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hash32"

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 clap = { version = "3.1.8", features = ["derive", "env"] }
 dotenv = "0.15.0"
 env_logger = "0.8.4"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde", "borsh"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde", "borsh"] }
 futures = "0.3.21"
 log = "0.4.0"
 mango-v4 = { path = "../../programs/mango-v4", features = ["client"] }

--- a/bin/keeper/Cargo.toml
+++ b/bin/keeper/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 clap = { version = "3.1.8", features = ["derive", "env"] }
 dotenv = "0.15.0"
 env_logger = "0.8.4"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde", "borsh"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde", "borsh"] }
 futures = "0.3.21"
 itertools = "0.10.3"
 log = "0.4.0"

--- a/bin/liquidator/Cargo.toml
+++ b/bin/liquidator/Cargo.toml
@@ -20,7 +20,7 @@ bytemuck = "^1.7.2"
 bytes = "1.0"
 clap = { version = "3.1.8", features = ["derive", "env"] }
 dotenv = "0.15.0"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde"] }
 futures = "0.3.17"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/bin/settle-bot/Cargo.toml
+++ b/bin/settle-bot/Cargo.toml
@@ -21,7 +21,7 @@ bytemuck = "^1.7.2"
 bytes = "1.0"
 clap = { version = "3.1.8", features = ["derive", "env"] }
 dotenv = "0.15.0"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde"] }
 futures = "0.3.17"
 futures-core = "0.3"
 futures-util = "0.3"

--- a/lib/client/Cargo.toml
+++ b/lib/client/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 async-channel = "1.6"
 async-once-cell = { version = "0.4.2", features = ["unpin"] }
 async-trait = "0.1.52"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde", "borsh"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde", "borsh"] }
 futures = "0.3.25"
 itertools = "0.10.3"
 jsonrpc-core = "18.0.0"

--- a/programs/mango-v4/Cargo.toml
+++ b/programs/mango-v4/Cargo.toml
@@ -31,11 +31,11 @@ borsh = { version = "0.9.3", features = ["const-generics"] }
 bytemuck = { version = "^1.7.2", features = ["min_const_generics"] }
 default-env = "0.1.1"
 derivative = "2.2.0"
-fixed = { path = "../../3rdparty/fixed", version = "=1.23.0", features = ["serde", "borsh", "disable-cache", "debug-assert-in-release"] }
+fixed = { path = "../../3rdparty/fixed", version = "1.11.0", features = ["serde", "borsh", "debug-assert-in-release"] }
 num_enum = "0.5.1"
 pyth-sdk-solana = "0.1.0"
 serde = "^1.0"
-serum_dex = { git = "https://github.com/openbook-dex/program.git", default-features=false,features = ["no-entrypoint", "program"] }
+serum_dex = { git = "https://github.com/openbook-dex/program.git", default-features=false, features = ["no-entrypoint", "program"] }
 solana-address-lookup-table-program = "~1.14.9"
 solana-program = "~1.14.9"
 solana-sdk = { version = "~1.14.9", default-features = false, optional = true }

--- a/programs/mango-v4/src/accounts_ix/token_register.rs
+++ b/programs/mango-v4/src/accounts_ix/token_register.rs
@@ -1,11 +1,8 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use fixed::types::I80F48;
 
 use crate::error::*;
 use crate::state::*;
-
-pub const INDEX_START: I80F48 = I80F48::lit("1_000_000");
 
 const FIRST_BANK_NUM: u32 = 0;
 

--- a/programs/mango-v4/src/health/cache.rs
+++ b/programs/mango-v4/src/health/cache.rs
@@ -801,6 +801,7 @@ mod tests {
     use super::*;
     use crate::state::*;
     use serum_dex::state::OpenOrders;
+    use std::str::FromStr;
 
     #[test]
     fn test_precision() {

--- a/programs/mango-v4/src/health/client.rs
+++ b/programs/mango-v4/src/health/client.rs
@@ -475,7 +475,7 @@ fn binary_search(
     fun: impl Fn(I80F48) -> Result<I80F48>,
 ) -> Result<I80F48> {
     let max_iterations = 50;
-    let target_error = I80F48::lit("0.1");
+    let target_error = I80F48::from_num(0.1);
     let right_value = fun(right)?;
     require_msg!(
         (left_value <= target_value && right_value >= target_value)

--- a/programs/mango-v4/src/instructions/benchmark.rs
+++ b/programs/mango-v4/src/instructions/benchmark.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::*;
 use fixed::types::{I80F48, U80F48};
 use solana_program::{log::sol_log_compute_units, program_memory::sol_memcmp};
+use std::str::FromStr;
 
 use crate::accounts_ix::*;
 use crate::i80f48::LowPrecisionDivision;

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -8,7 +8,7 @@ use crate::util::fill_from_str;
 
 use crate::logs::TokenMetaDataLog;
 
-pub const INDEX_START: I80F48 = I80F48::lit("1_000_000");
+pub const INDEX_START: I80F48 = I80F48::from_bits(1_000_000 * I80F48::ONE.to_bits());
 
 use crate::accounts_ix::*;
 

--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -14,9 +14,9 @@ use std::mem::size_of;
 
 pub const HOUR: i64 = 3600;
 pub const DAY: i64 = 86400;
-pub const DAY_I80F48: I80F48 = I80F48::lit("86_400");
-pub const YEAR_I80F48: I80F48 = I80F48::lit("31_536_000");
-pub const MINIMUM_MAX_RATE: I80F48 = I80F48::lit("0.5");
+pub const DAY_I80F48: I80F48 = I80F48::from_bits(86_400 * I80F48::ONE.to_bits());
+pub const YEAR_I80F48: I80F48 = I80F48::from_bits(31_536_000 * I80F48::ONE.to_bits());
+pub const MINIMUM_MAX_RATE: I80F48 = I80F48::from_bits(I80F48::ONE.to_bits() / 2);
 
 #[derive(Derivative)]
 #[derivative(Debug)]


### PR DESCRIPTION
Should also review the top commit on https://gitlab.com/ckamm/fixed/-/commits/v1.11.0-mango/ which is backported from https://gitlab.com/ckamm/fixed/-/commits/v1.23.0-mango