### PR TITLE
Limit funding and interest accrual during downtimes

### DIFF
--- a/programs/mango-v4/src/state/perp_market.rs
+++ b/programs/mango-v4/src/state/perp_market.rs
@@ -288,7 +288,14 @@ impl PerpMarket {
             (None, None) => I80F48::ZERO,
         };
 
-        let diff_ts = I80F48::from_num(now_ts - self.funding_last_updated as u64);
+        // Limit the maximal time interval that funding is applied for. This means we won't use
+        // the funding rate computed from a single orderbook snapshot for a very long time period
+        // in exceptional circumstances, like a solana downtime or the security council disabling
+        // funding updates.
+        let max_funding_timestep = 3600; // one hour
+        let diff_ts =
+            I80F48::from_num((now_ts - self.funding_last_updated as u64).min(max_funding_timestep));
+
         let time_factor = diff_ts / DAY_I80F48;
         let base_lot_size = I80F48::from_num(self.base_lot_size);
 


### PR DESCRIPTION
Previously, if the funding or interest updating instruction wasn't called for a long time (like for a solana downtime or the security council halting the program), the next update would apply funding or interest for the whole time interval since the last update.

This could lead to a bad downtime situation becoming worse. Instead, limit the maximum funding and interest time interval to one hour.