### PR TITLE
Don't reload OpenOrders if there's no active markets

### DIFF
--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -115,6 +115,7 @@ export class MangoAccount {
 
   async reloadSerum3OpenOrders(client: MangoClient): Promise<MangoAccount> {
     const serum3Active = this.serum3Active();
+    if (!serum3Active.length) return this;
     const ais =
       await client.program.provider.connection.getMultipleAccountsInfo(
         serum3Active.map((serum3) => serum3.openOrders),


### PR DESCRIPTION
Attempting to settle Perp PnL in the UI results in RPC ratelimiting. This is caused by many getMultipleAccounts calls with no addresses in the params. We should check if there's any active spot markets before making the gMA call.