### PR TITLE
Net borrow limit: Separate out tracking and checking

### DIFF
--- a/programs/mango-v4/src/health/cache.rs
+++ b/programs/mango-v4/src/health/cache.rs
@@ -859,7 +859,6 @@ mod tests {
                 account.ensure_token_position(4).unwrap().0,
                 I80F48::from(10),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
 
@@ -943,7 +942,6 @@ mod tests {
                 account.ensure_token_position(1).unwrap().0,
                 I80F48::from(testcase.token1),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
         bank2
@@ -952,7 +950,6 @@ mod tests {
                 account.ensure_token_position(4).unwrap().0,
                 I80F48::from(testcase.token2),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
         bank3
@@ -961,7 +958,6 @@ mod tests {
                 account.ensure_token_position(5).unwrap().0,
                 I80F48::from(testcase.token3),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
         for (settings, bank) in testcase

--- a/programs/mango-v4/src/health/client.rs
+++ b/programs/mango-v4/src/health/client.rs
@@ -59,7 +59,8 @@ impl HealthCache {
         let target_amount = amount * price;
 
         let mut source_bank = source_bank.clone();
-        source_bank.withdraw_with_fee(&mut source_position, amount, now_ts, source_oracle_price)?;
+        source_bank.withdraw_with_fee(&mut source_position, amount, now_ts)?;
+        source_bank.check_net_borrows(source_oracle_price)?;
         let mut target_bank = target_bank.clone();
         target_bank.deposit(&mut target_position, target_amount, now_ts)?;
 
@@ -403,7 +404,8 @@ impl HealthCache {
             let mut position = account.token_position(bank.token_index)?.clone();
 
             let mut bank = bank.clone();
-            bank.withdraw_with_fee(&mut position, amount, now_ts, token.prices.oracle)?;
+            bank.withdraw_with_fee(&mut position, amount, now_ts)?;
+            bank.check_net_borrows(token.prices.oracle)?;
 
             let mut resulting_cache = self.clone();
             resulting_cache.adjust_token_balance(&bank, -amount)?;
@@ -1133,7 +1135,6 @@ mod tests {
                 account.ensure_token_position(1).unwrap().0,
                 I80F48::from(100),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
 
@@ -1216,7 +1217,6 @@ mod tests {
                 account.ensure_token_position(1).unwrap().0,
                 I80F48::from(100),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
         bank1
@@ -1225,7 +1225,6 @@ mod tests {
                 account2.ensure_token_position(1).unwrap().0,
                 I80F48::from(-100),
                 DUMMY_NOW_TS,
-                DUMMY_PRICE,
             )
             .unwrap();
 

--- a/programs/mango-v4/src/instructions/account_buyback_fees_with_mngo.rs
+++ b/programs/mango-v4/src/instructions/account_buyback_fees_with_mngo.rs
@@ -103,12 +103,8 @@ pub fn account_buyback_fees_with_mngo(
         dao_mngo_token_position.indexed_position >= I80F48::ZERO,
         MangoError::SomeError
     );
-    let in_use = mngo_bank.withdraw_without_fee(
-        account_mngo_token_position,
-        max_buyback_mngo,
-        now_ts,
-        mngo_oracle_price,
-    )?;
+    let in_use =
+        mngo_bank.withdraw_without_fee(account_mngo_token_position, max_buyback_mngo, now_ts)?;
     emit!(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
@@ -132,12 +128,8 @@ pub fn account_buyback_fees_with_mngo(
         dao_account.ensure_token_position(fees_bank.token_index)?;
     let dao_fees = dao_fees_token_position.native(&fees_bank);
     assert!(dao_fees >= max_buyback_fees);
-    let in_use = fees_bank.withdraw_without_fee(
-        dao_fees_token_position,
-        max_buyback_fees,
-        now_ts,
-        fees_oracle_price,
-    )?;
+    let in_use =
+        fees_bank.withdraw_without_fee(dao_fees_token_position, max_buyback_fees, now_ts)?;
     if !in_use {
         dao_account.deactivate_token_position_and_log(
             dao_fees_raw_token_index,

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -351,23 +351,22 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             );
         }
 
-        // Enforce min vault to deposits ratio
-        if native_after_change < 0 {
+        let is_active = bank.change_without_fee(
+            position,
+            change_amount,
+            Clock::get()?.unix_timestamp.try_into().unwrap(),
+        )?;
+        if !is_active {
+            deactivated_token_positions.push(change.raw_token_index);
+        }
+
+        if change_amount < 0 && native_after_change < 0 {
             let vault_ai = vaults
                 .iter()
                 .find(|vault_ai| vault_ai.key == &bank.vault)
                 .unwrap();
             bank.enforce_min_vault_to_deposits_ratio(vault_ai)?;
-        }
-
-        let is_active = bank.change_without_fee(
-            position,
-            change.amount - loan_origination_fee,
-            Clock::get()?.unix_timestamp.try_into().unwrap(),
-            *oracle_price,
-        )?;
-        if !is_active {
-            deactivated_token_positions.push(change.raw_token_index);
+            bank.check_net_borrows(*oracle_price)?;
         }
 
         bank.flash_loan_approved_amount = 0;

--- a/programs/mango-v4/src/instructions/perp_liq_base_or_positive_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_base_or_positive_pnl.rs
@@ -451,12 +451,7 @@ pub(crate) fn liquidation_action(
             let liqor_token_position = liqor.token_position_mut(settle_token_index)?.0;
             let liqee_token_position = liqee.token_position_mut(settle_token_index)?.0;
             settle_bank.deposit(liqee_token_position, token_transfer, now_ts)?;
-            settle_bank.withdraw_without_fee(
-                liqor_token_position,
-                token_transfer,
-                now_ts,
-                settle_token_oracle_price,
-            )?;
+            settle_bank.withdraw_without_fee(liqor_token_position, token_transfer, now_ts)?;
             liqee_health_cache.adjust_token_balance(&settle_bank, token_transfer)?;
         }
         msg!(
@@ -756,16 +751,10 @@ mod tests {
                         token_p(&mut setup.liqee),
                         I80F48::from_num(init_liqee_spot),
                         0,
-                        I80F48::from(1),
                     )
                     .unwrap();
                 settle_bank
-                    .change_without_fee(
-                        token_p(&mut setup.liqor),
-                        I80F48::from_num(1000.0),
-                        0,
-                        I80F48::from(1),
-                    )
+                    .change_without_fee(token_p(&mut setup.liqor), I80F48::from_num(1000.0), 0)
                     .unwrap();
             }
 
@@ -817,20 +806,10 @@ mod tests {
 
             let settle_bank = setup.settle_bank.data();
             settle_bank
-                .change_without_fee(
-                    token_p(&mut setup.liqee),
-                    I80F48::from_num(5.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(token_p(&mut setup.liqee), I80F48::from_num(5.0), 0)
                 .unwrap();
             settle_bank
-                .change_without_fee(
-                    token_p(&mut setup.liqor),
-                    I80F48::from_num(1000.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(token_p(&mut setup.liqor), I80F48::from_num(1000.0), 0)
                 .unwrap();
         }
 

--- a/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
@@ -125,12 +125,7 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
             let liqor_token_position = liqor.token_position_mut(settle_token_index)?.0;
             let liqee_token_position = liqee.token_position_mut(settle_token_index)?.0;
             settle_bank.deposit(liqor_token_position, settlement, now_ts)?;
-            settle_bank.withdraw_without_fee(
-                liqee_token_position,
-                settlement,
-                now_ts,
-                settle_token_oracle_price,
-            )?;
+            settle_bank.withdraw_without_fee(liqee_token_position, settlement, now_ts)?;
             liqee_health_cache.adjust_token_balance(&settle_bank, -settlement)?;
 
             emit!(PerpLiqNegativePnlOrBankruptcyLog {

--- a/programs/mango-v4/src/instructions/perp_settle_fees.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_fees.rs
@@ -96,7 +96,6 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
         token_position,
         settlement,
         Clock::get()?.unix_timestamp.try_into().unwrap(),
-        settle_token_oracle_price,
     )?;
     // Update the settled balance on the market itself
     perp_market.fees_settled += settlement;

--- a/programs/mango-v4/src/instructions/perp_settle_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_pnl.rs
@@ -176,12 +176,7 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
     // Don't charge loan origination fees on borrows created via settling:
     // Even small loan origination fees could accumulate if a perp position is
     // settled back and forth repeatedly.
-    settle_bank.withdraw_without_fee(
-        b_token_position,
-        settlement,
-        now_ts,
-        settle_token_oracle_price,
-    )?;
+    settle_bank.withdraw_without_fee(b_token_position, settlement, now_ts)?;
 
     emit!(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),

--- a/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
@@ -137,12 +137,8 @@ pub fn token_liq_bankruptcy(
             // transfer liab from liqee to liqor
             let (liqor_liab, liqor_liab_raw_token_index, _) =
                 liqor.ensure_token_position(liab_token_index)?;
-            let (liqor_liab_active, loan_origination_fee) = liab_bank.withdraw_with_fee(
-                liqor_liab,
-                liab_transfer,
-                now_ts,
-                liab_oracle_price,
-            )?;
+            let (liqor_liab_active, loan_origination_fee) =
+                liab_bank.withdraw_with_fee(liqor_liab, liab_transfer, now_ts)?;
 
             // liqor liab
             emit!(TokenBalanceLog {

--- a/programs/mango-v4/src/instructions/token_liq_with_token.rs
+++ b/programs/mango-v4/src/instructions/token_liq_with_token.rs
@@ -192,12 +192,8 @@ pub(crate) fn liquidation_action(
 
     let (liqor_liab_position, liqor_liab_raw_index, _) =
         liqor.ensure_token_position(liab_token_index)?;
-    let (liqor_liab_active, loan_origination_fee) = liab_bank.withdraw_with_fee(
-        liqor_liab_position,
-        liab_transfer,
-        now_ts,
-        liab_oracle_price,
-    )?;
+    let (liqor_liab_active, loan_origination_fee) =
+        liab_bank.withdraw_with_fee(liqor_liab_position, liab_transfer, now_ts)?;
     let liqor_liab_indexed_position = liqor_liab_position.indexed_position;
     let liqee_liab_native_after = liqee_liab_position.native(liab_bank);
 
@@ -211,7 +207,6 @@ pub(crate) fn liquidation_action(
         liqee_asset_position,
         asset_transfer,
         now_ts,
-        asset_oracle_price,
     )?;
     let liqee_asset_indexed_position = liqee_asset_position.indexed_position;
     let liqee_assets_native_after = liqee_asset_position.native(asset_bank);
@@ -444,38 +439,18 @@ mod tests {
         {
             let asset_bank = setup.asset_bank.data();
             asset_bank
-                .change_without_fee(
-                    asset_p(&mut setup.liqee),
-                    I80F48::from_num(10.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(asset_p(&mut setup.liqee), I80F48::from_num(10.0), 0)
                 .unwrap();
             asset_bank
-                .change_without_fee(
-                    asset_p(&mut setup.liqor),
-                    I80F48::from_num(1000.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(asset_p(&mut setup.liqor), I80F48::from_num(1000.0), 0)
                 .unwrap();
 
             let liab_bank = setup.liab_bank.data();
             liab_bank
-                .change_without_fee(
-                    liab_p(&mut setup.liqor),
-                    I80F48::from_num(1000.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(liab_p(&mut setup.liqor), I80F48::from_num(1000.0), 0)
                 .unwrap();
             liab_bank
-                .change_without_fee(
-                    liab_p(&mut setup.liqee),
-                    I80F48::from_num(-9.0),
-                    0,
-                    I80F48::from(1),
-                )
+                .change_without_fee(liab_p(&mut setup.liqee), I80F48::from_num(-9.0), 0)
                 .unwrap();
         }
 

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -70,7 +70,6 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         amount_i80f48,
         Clock::get()?.unix_timestamp.try_into().unwrap(),
     )?;
-    bank.check_net_borrows(oracle_price)?;
 
     // Provide a readable error message in case the vault doesn't have enough tokens
     if ctx.accounts.vault.amount < amount {
@@ -140,10 +139,11 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         });
     }
 
-    // Enforce min vault to deposits ratio
+    // Enforce min vault to deposits ratio and net borrow limits
     if is_borrow {
         ctx.accounts.vault.reload()?;
         bank.enforce_min_vault_to_deposits_ratio(ctx.accounts.vault.as_ref())?;
+        bank.check_net_borrows(oracle_price)?;
     }
 
     Ok(())

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -69,8 +69,8 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         position,
         amount_i80f48,
         Clock::get()?.unix_timestamp.try_into().unwrap(),
-        oracle_price,
     )?;
+    bank.check_net_borrows(oracle_price)?;
 
     // Provide a readable error message in case the vault doesn't have enough tokens
     if ctx.accounts.vault.amount < amount {

--- a/programs/mango-v4/tests/cases/test_borrow_limits.rs
+++ b/programs/mango-v4/tests/cases/test_borrow_limits.rs
@@ -219,7 +219,11 @@ async fn test_bank_net_borrows_based_borrow_limit() -> Result<(), TransportError
             },
         )
         .await;
-        assert!(res.is_err());
+        assert_mango_error(
+            &res,
+            MangoError::BankNetBorrowsLimitReached.into(),
+            "".into(),
+        );
 
         // succeeds because is not a borrow
         send_tx(
@@ -308,7 +312,26 @@ async fn test_bank_net_borrows_based_borrow_limit() -> Result<(), TransportError
             },
         )
         .await;
-        assert!(res.is_err());
+        assert_mango_error(
+            &res,
+            MangoError::BankNetBorrowsLimitReached.into(),
+            "".into(),
+        );
+
+        // can still withdraw
+        send_tx(
+            solana,
+            TokenWithdrawInstruction {
+                amount: 4000,
+                allow_borrow: false,
+                account: account_0,
+                owner,
+                token_account: payer_mint_accounts[0],
+                bank_index: 0,
+            },
+        )
+        .await
+        .unwrap();
 
         set_bank_stub_oracle_price(solana, group, &tokens[0], admin, 5.0).await;
 
@@ -325,7 +348,11 @@ async fn test_bank_net_borrows_based_borrow_limit() -> Result<(), TransportError
             },
         )
         .await;
-        assert!(res.is_err());
+        assert_mango_error(
+            &res,
+            MangoError::BankNetBorrowsLimitReached.into(),
+            "".into(),
+        );
 
         // can borrow smaller amounts: (net borrowed 1000 + new borrow 199) * price 5.0 < limit 6000
         send_tx(

--- a/programs/mango-v4/tests/cases/test_perp_settle_fees.rs
+++ b/programs/mango-v4/tests/cases/test_perp_settle_fees.rs
@@ -337,7 +337,8 @@ async fn test_perp_settle_fees() -> Result<(), TransportError> {
             max_settle_amount: u64::MAX,
         },
     )
-    .await;
+    .await
+    .unwrap();
     // No change
     {
         let perp_market = solana.get_account::<PerpMarket>(perp_market).await;


### PR DESCRIPTION
That way it's easier to be specific about where the limit should be checked.