### PR TITLE
Fix building with "no-entrypoint" feature

### DIFF
--- a/programs/mango-v4/src/accounts_ix/benchmark.rs
+++ b/programs/mango-v4/src/accounts_ix/benchmark.rs
@@ -1,4 +1,7 @@
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct Benchmark {}
+pub struct Benchmark<'info> {
+    /// CHECK: unused, exists only because anchor is unhappy in no-entrypoint mode otherwise
+    pub dummy: UncheckedAccount<'info>,
+}

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -3922,7 +3922,9 @@ impl ClientInstruction for BenchmarkInstruction {
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = mango_v4::id();
         let instruction = Self::Instruction {};
-        let accounts = Self::Accounts {};
+        let accounts = Self::Accounts {
+            dummy: Pubkey::new_unique(),
+        };
 
         let instruction = make_instruction(program_id, &accounts, &instruction);
         (accounts, instruction)


### PR DESCRIPTION
Without this, anchor complains about a missing lifetime on a struct relating to Benchmark.