### PR TITLE
Fix bug in closing mango account

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -1231,7 +1231,6 @@ export class MangoClient {
     mintPk: PublicKey,
     nativeAmount: BN,
     allowBorrow: boolean,
-    healthAccountsToExclude: PublicKey[] = [],
   ): Promise<TransactionSignature> {
     const ixs = await this.tokenWithdrawNativeIx(
       group,
@@ -1239,7 +1238,6 @@ export class MangoClient {
       mintPk,
       nativeAmount,
       allowBorrow,
-      healthAccountsToExclude,
     );
     return await this.sendAndConfirmTransactionForGroup(group, ixs);
   }
@@ -2402,7 +2400,6 @@ export class MangoClient {
     const perpMarket = group.getPerpMarketByMarketIndex(perpMarketIndex);
     const healthRemainingAccounts: PublicKey[] =
       this.buildHealthRemainingAccounts(
-        AccountRetriever.Scanning,
         group,
         [profitableAccount, unprofitableAccount],
         [group.getFirstBankForPerpSettlement()],
@@ -2786,7 +2783,6 @@ export class MangoClient {
 
     const healthRemainingAccounts: PublicKey[] =
       this.buildHealthRemainingAccounts(
-        AccountRetriever.Scanning,
         group,
         [liqor, liqee],
         [assetBank, liabBank],

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -2931,6 +2931,23 @@ export class MangoClient {
     );
   }
 
+  /**
+   * Builds health remaining accounts.
+   *
+   * For single mango account it builds a list of PublicKeys
+   * which is compatbile with Fixed account retriever.
+   *
+   * For multiple mango accounts it uses same logic as for fixed
+   * but packing all banks, then perp markets, and then serum oo accounts, which
+   * should always be compatible with Scanning account retriever.
+   *
+   * @param group
+   * @param mangoAccounts
+   * @param banks - banks in which new positions might be opened
+   * @param perpMarkets - markets in which new positions might be opened
+   * @param openOrdersForMarket - markets in which new positions might be opened
+   * @returns
+   */
   buildHealthRemainingAccounts(
     group: Group,
     mangoAccounts: MangoAccount[],

--- a/ts/client/src/utils/rpc.ts
+++ b/ts/client/src/utils/rpc.ts
@@ -43,7 +43,7 @@ export async function sendTransaction(
 
   if (
     typeof payer.signTransaction === 'function' &&
-    !(payer instanceof NodeWallet)
+    !(payer instanceof NodeWallet || payer.constructor.name == 'NodeWallet')
   ) {
     vtx = (await payer.signTransaction(
       vtx as any,


### PR DESCRIPTION
* Refactor code for collecting health accounts, 
* Remove scanning retriever, only build accounts for fixed retriever because they should always works, saves having to maintain 2 code blocks
* fix bug where bank oracle was skipped while closing account if same perp position in a market with same oracle was also deactivated earlier in same tx

Tested on mainnet so - via UI, created an account, deposited sol and usdc, opened perp and spot market positions, closed perp position, settled perp and spot, then called clients emptyAndCloseMangoAccount on dev and this branch, breaks on dev (https://explorer.solana.com/tx/3Wgf6GVtCYXVT3D3H1MK5TtEroKt3wYrdtnBgRNWH9JY2yvfLyov8dRUY5K7ukT8VPHJmGKovLEiLii59AV1zgNa), works on this branch (https://explorer.solana.com/tx/4Y8sVCxKxo3SwwRt1Kjc9zvk63cypbkqQd2cbCCewM1JQLGHb9jHnHhLEBvENiXnWPu34uNCYkwLrJEMgJpj57kE)