### PR TITLE
Improve error message for FixedAccountRetriever

### DIFF
--- a/programs/mango-v4/src/error.rs
+++ b/programs/mango-v4/src/error.rs
@@ -99,6 +99,8 @@ pub enum MangoError {
     HealthRegionBadInnerInstruction,
     #[msg("token is in force close")]
     TokenInForceClose,
+    #[msg("incorrect number of health accounts")]
+    InvalidHealthAccountCount,
 }
 
 impl MangoError {

--- a/programs/mango-v4/src/health/account_retriever.rs
+++ b/programs/mango-v4/src/health/account_retriever.rs
@@ -66,7 +66,11 @@ pub fn new_fixed_order_account_retriever<'a, 'info>(
     let expected_ais = active_token_len * 2 // banks + oracles
         + active_perp_len * 2 // PerpMarkets + Oracles
         + active_serum3_len; // open_orders
-    require_eq!(ais.len(), expected_ais);
+    require_msg_typed!(ais.len() == expected_ais, MangoError::InvalidHealthAccountCount,
+        "received {} accounts but expected {} ({} banks, {} bank oracles, {} perp markets, {} perp oracles, {} serum3 oos)",
+        ais.len(), expected_ais,
+        active_token_len, active_token_len, active_perp_len, active_perp_len, active_serum3_len
+    );
 
     Ok(FixedOrderAccountRetriever {
         ais: AccountInfoRef::borrow_slice(ais)?,


### PR DESCRIPTION
When an invalid number of accounts is passed in, which is one of the most common error messages new integrators will see.