### PR TITLE
token_register_trustless: Disable borrowing by default

### DIFF
--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -71,9 +71,9 @@ pub fn token_register_trustless(
             * net_borrow_limit_window_size_ts,
         net_borrow_limit_per_window_quote: 250_000_000_000, // $250k
         net_borrows_in_window: 0,
-        borrow_weight_scale_start_quote: 100_000_000_000.0, // $100k
-        deposit_weight_scale_start_quote: 100_000_000_000.0, // $100k
-        reduce_only: 0,
+        borrow_weight_scale_start_quote: 5_000_000_000.0, // $5k
+        deposit_weight_scale_start_quote: 5_000_000_000.0, // $5k
+        reduce_only: 2,                                   // deposit-only
         force_close: 0,
         reserved: [0; 2118],
     };


### PR DESCRIPTION
Previously tokens listed this way could be borrowed. Now tokens start with reduce-only set to the "no borrows" mode.

Also decrease the default soft borrow/deposit limits significantly, even if they don't come into effect when there are no borrows and the deposit weight is 0 anyway.