### PR TITLE
Clarkeni/oracle confidence

### DIFF
--- a/mango_v4.json
+++ b/mango_v4.json
@@ -7882,6 +7882,78 @@
       ]
     },
     {
+      "name": "PerpUpdateFundingLogV2",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "longFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "shortFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "price",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "oracleConfidence",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleType",
+          "type": {
+            "defined": "OracleType"
+          },
+          "index": false
+        },
+        {
+          "name": "stablePrice",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesAccrued",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesSettled",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "openInterest",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "instantaneousFundingRate",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
       "name": "UpdateIndexLog",
       "fields": [
         {

--- a/programs/mango-v4/src/instructions/perp_place_order.rs
+++ b/programs/mango-v4/src/instructions/perp_place_order.rs
@@ -18,6 +18,8 @@ pub fn perp_place_order(
 
     let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
     let oracle_price;
+    let oracle_confidence;
+    let oracle_type;
 
     // Update funding if possible.
     //
@@ -31,12 +33,20 @@ pub fn perp_place_order(
         };
 
         let oracle_slot;
-        (oracle_price, oracle_slot) = perp_market.oracle_price_and_slot(
-            &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
-            None, // staleness checked in health
-        )?;
+        (oracle_price, oracle_slot, oracle_confidence, oracle_type) = perp_market
+            .oracle_price_and_meta(
+                &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
+                None, // staleness checked in health
+            )?;
 
-        perp_market.update_funding_and_stable_price(&book, oracle_price, oracle_slot, now_ts)?;
+        perp_market.update_funding_and_stable_price(
+            &book,
+            oracle_price,
+            oracle_slot,
+            oracle_confidence,
+            oracle_type,
+            now_ts,
+        )?;
     }
 
     let mut account = ctx.accounts.account.load_full_mut()?;

--- a/programs/mango-v4/src/instructions/perp_place_order.rs
+++ b/programs/mango-v4/src/instructions/perp_place_order.rs
@@ -18,8 +18,6 @@ pub fn perp_place_order(
 
     let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
     let oracle_price;
-    let oracle_confidence;
-    let oracle_type;
 
     // Update funding if possible.
     //
@@ -32,21 +30,13 @@ pub fn perp_place_order(
             asks: ctx.accounts.asks.load_mut()?,
         };
 
-        let oracle_slot;
-        (oracle_price, oracle_slot, oracle_confidence, oracle_type) = perp_market
-            .oracle_price_and_meta(
-                &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
-                None, // staleness checked in health
-            )?;
-
-        perp_market.update_funding_and_stable_price(
-            &book,
-            oracle_price,
-            oracle_slot,
-            oracle_confidence,
-            oracle_type,
-            now_ts,
+        let oracle_state;
+        (oracle_price, oracle_state) = perp_market.oracle_price_and_state(
+            &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
+            None, // staleness checked in health
         )?;
+
+        perp_market.update_funding_and_stable_price(&book, oracle_price, oracle_state, now_ts)?;
     }
 
     let mut account = ctx.accounts.account.load_full_mut()?;

--- a/programs/mango-v4/src/instructions/perp_update_funding.rs
+++ b/programs/mango-v4/src/instructions/perp_update_funding.rs
@@ -14,20 +14,12 @@ pub fn perp_update_funding(ctx: Context<PerpUpdateFunding>) -> Result<()> {
     };
 
     let now_slot = Clock::get()?.slot;
-    let (oracle_price, oracle_slot, oracle_confidence, oracle_type) = perp_market
-        .oracle_price_and_meta(
-            &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
-            Some(now_slot),
-        )?;
-
-    perp_market.update_funding_and_stable_price(
-        &book,
-        oracle_price,
-        oracle_slot,
-        oracle_confidence,
-        oracle_type,
-        now_ts,
+    let (oracle_price, oracle_state) = perp_market.oracle_price_and_state(
+        &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
+        Some(now_slot),
     )?;
+
+    perp_market.update_funding_and_stable_price(&book, oracle_price, oracle_state, now_ts)?;
 
     Ok(())
 }

--- a/programs/mango-v4/src/instructions/perp_update_funding.rs
+++ b/programs/mango-v4/src/instructions/perp_update_funding.rs
@@ -14,12 +14,20 @@ pub fn perp_update_funding(ctx: Context<PerpUpdateFunding>) -> Result<()> {
     };
 
     let now_slot = Clock::get()?.slot;
-    let (oracle_price, oracle_slot) = perp_market.oracle_price_and_slot(
-        &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
-        Some(now_slot),
-    )?;
+    let (oracle_price, oracle_slot, oracle_confidence, oracle_type) = perp_market
+        .oracle_price_and_meta(
+            &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?,
+            Some(now_slot),
+        )?;
 
-    perp_market.update_funding_and_stable_price(&book, oracle_price, oracle_slot, now_ts)?;
+    perp_market.update_funding_and_stable_price(
+        &book,
+        oracle_price,
+        oracle_slot,
+        oracle_confidence,
+        oracle_type,
+        now_ts,
+    )?;
 
     Ok(())
 }

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -1,6 +1,6 @@
 use crate::{
     accounts_ix::FlashLoanType,
-    state::{PerpMarket, PerpPosition},
+    state::{OracleType, PerpMarket, PerpPosition},
 };
 use anchor_lang::prelude::*;
 use borsh::BorshSerialize;
@@ -145,6 +145,23 @@ pub struct PerpUpdateFundingLog {
     pub short_funding: i128,
     pub price: i128,
     pub oracle_slot: u64,
+    pub stable_price: i128,
+    pub fees_accrued: i128,
+    pub fees_settled: i128,
+    pub open_interest: i64,
+    pub instantaneous_funding_rate: i128,
+}
+
+#[event]
+pub struct PerpUpdateFundingLogV2 {
+    pub mango_group: Pubkey,
+    pub market_index: u16,
+    pub long_funding: i128,
+    pub short_funding: i128,
+    pub price: i128,
+    pub oracle_slot: u64,
+    pub oracle_confidence: i128,
+    pub oracle_type: OracleType,
     pub stable_price: i128,
     pub fees_accrued: i128,
     pub fees_settled: i128,

--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -789,7 +789,7 @@ impl Bank {
         staleness_slot: Option<u64>,
     ) -> Result<I80F48> {
         require_keys_eq!(self.oracle, *oracle_acc.key());
-        let (price, _) = oracle::oracle_price_and_slot(
+        let (price, _, _, _) = oracle::oracle_price_and_meta(
             oracle_acc,
             &self.oracle_config,
             self.mint_decimals,

--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -789,7 +789,7 @@ impl Bank {
         staleness_slot: Option<u64>,
     ) -> Result<I80F48> {
         require_keys_eq!(self.oracle, *oracle_acc.key());
-        let (price, _, _, _) = oracle::oracle_price_and_meta(
+        let (price, _) = oracle::oracle_price_and_state(
             oracle_acc,
             &self.oracle_config,
             self.mint_decimals,

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -7882,6 +7882,78 @@ export type MangoV4 = {
       ]
     },
     {
+      "name": "PerpUpdateFundingLogV2",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "longFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "shortFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "price",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "oracleConfidence",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleType",
+          "type": {
+            "defined": "OracleType"
+          },
+          "index": false
+        },
+        {
+          "name": "stablePrice",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesAccrued",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesSettled",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "openInterest",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "instantaneousFundingRate",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
       "name": "UpdateIndexLog",
       "fields": [
         {
@@ -16867,6 +16939,78 @@ export const IDL: MangoV4 = {
         {
           "name": "oracleSlot",
           "type": "u64",
+          "index": false
+        },
+        {
+          "name": "stablePrice",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesAccrued",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "feesSettled",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "openInterest",
+          "type": "i64",
+          "index": false
+        },
+        {
+          "name": "instantaneousFundingRate",
+          "type": "i128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "PerpUpdateFundingLogV2",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "marketIndex",
+          "type": "u16",
+          "index": false
+        },
+        {
+          "name": "longFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "shortFunding",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "price",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleSlot",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "oracleConfidence",
+          "type": "i128",
+          "index": false
+        },
+        {
+          "name": "oracleType",
+          "type": {
+            "defined": "OracleType"
+          },
           "index": false
         },
         {


### PR DESCRIPTION
Add oracle confidence to update funding logs (with a new V2 anchor event).
Unfortunately the meaning of the confidence value is different for different oracle providers so I also log the oracle type so they can be interpreted appropriately on the other end.
Also the confidence data types are u64, f64 and I80F48 - so I cast them all to I80F48.
Please let me know if you would like changes.
I believe there is another deployment this week - would like to target that if we can.