### PR TITLE
Add price to WithdrawLoanLog

### DIFF
--- a/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
@@ -90,6 +90,8 @@ pub fn serum3_liq_force_cancel_orders(
             &mut quote_bank,
             &mut account.borrow_mut(),
             &before_oo,
+            None,
+            None,
         )?;
 
         before_oo

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -182,14 +182,11 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
-        let base_oracle_price = if let Some(base_oracle_ai) = base_oracle {
-            Some(base_bank.oracle_price(
-                &AccountInfoRef::borrow(base_oracle_ai)?,
-                Some(Clock::get()?.slot),
-            )?)
-        } else {
-            None
-        };
+        let base_oracle_price = base_oracle
+            .map(|ai| {
+                base_bank.oracle_price(&AccountInfoRef::borrow(ai)?, Some(Clock::get()?.slot))
+            })
+            .transpose()?;
 
         emit!(WithdrawLoanLog {
             mango_group: *group_pubkey,
@@ -221,14 +218,11 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
-        let quote_oracle_price = if let Some(quote_oracle_ai) = quote_oracle {
-            Some(quote_bank.oracle_price(
-                &AccountInfoRef::borrow(quote_oracle_ai)?,
-                Some(Clock::get()?.slot),
-            )?)
-        } else {
-            None
-        };
+        let quote_oracle_price = quote_oracle
+            .map(|ai| {
+                quote_bank.oracle_price(&AccountInfoRef::borrow(ai)?, Some(Clock::get()?.slot))
+            })
+            .transpose()?;
 
         emit!(WithdrawLoanLog {
             mango_group: *group_pubkey,

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-
 use fixed::types::I80F48;
 
 use crate::error::*;
@@ -10,6 +9,8 @@ use super::{apply_settle_changes, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::accounts_ix::*;
 use crate::logs::Serum3OpenOrdersBalanceLogV2;
 use crate::logs::{LoanOriginationFeeInstruction, WithdrawLoanLog};
+
+use crate::accounts_zerocopy::AccountInfoRef;
 
 /// Settling means moving free funds from the serum3 open orders account
 /// back into the mango account wallet.
@@ -82,6 +83,8 @@ pub fn serum3_settle_funds<'info>(
             &mut quote_bank,
             &mut account.borrow_mut(),
             &before_oo,
+            v2.map(|d| d.base_oracle.as_ref()),
+            v2.map(|d| d.quote_oracle.as_ref()),
         )?;
     }
 
@@ -154,6 +157,8 @@ pub fn charge_loan_origination_fees(
     quote_bank: &mut Bank,
     account: &mut MangoAccountRefMut,
     before_oo: &OpenOrdersSlim,
+    base_oracle: Option<&AccountInfo>,
+    quote_oracle: Option<&AccountInfo>,
 ) -> Result<()> {
     let serum3_account = account.serum3_orders_mut(market_index).unwrap();
 
@@ -177,6 +182,19 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
+        let base_oracle_price_bits = if let Some(base_oracle_ai) = base_oracle {
+            Some(
+                base_bank
+                    .oracle_price(
+                        &AccountInfoRef::borrow(base_oracle_ai)?,
+                        Some(Clock::get()?.slot),
+                    )?
+                    .to_bits(),
+            )
+        } else {
+            None
+        };
+
         emit!(WithdrawLoanLog {
             mango_group: *group_pubkey,
             mango_account: *account_pubkey,
@@ -184,6 +202,7 @@ pub fn charge_loan_origination_fees(
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
+            price: base_oracle_price_bits
         });
     }
 
@@ -206,6 +225,19 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
+        let quote_oracle_price_bits = if let Some(quote_oracle_ai) = quote_oracle {
+            Some(
+                quote_bank
+                    .oracle_price(
+                        &AccountInfoRef::borrow(quote_oracle_ai)?,
+                        Some(Clock::get()?.slot),
+                    )?
+                    .to_bits(),
+            )
+        } else {
+            None
+        };
+
         emit!(WithdrawLoanLog {
             mango_group: *group_pubkey,
             mango_account: *account_pubkey,
@@ -213,6 +245,7 @@ pub fn charge_loan_origination_fees(
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
+            price: quote_oracle_price_bits
         });
     }
 

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -83,8 +83,8 @@ pub fn serum3_settle_funds<'info>(
             &mut quote_bank,
             &mut account.borrow_mut(),
             &before_oo,
-            v2.map(|d| d.base_oracle.as_ref()),
-            v2.map(|d| d.quote_oracle.as_ref()),
+            v2.as_ref().map(|d| d.base_oracle.as_ref()),
+            v2.as_ref().map(|d| d.quote_oracle.as_ref()),
         )?;
     }
 
@@ -182,15 +182,11 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
-        let base_oracle_price_bits = if let Some(base_oracle_ai) = base_oracle {
-            Some(
-                base_bank
-                    .oracle_price(
-                        &AccountInfoRef::borrow(base_oracle_ai)?,
-                        Some(Clock::get()?.slot),
-                    )?
-                    .to_bits(),
-            )
+        let base_oracle_price = if let Some(base_oracle_ai) = base_oracle {
+            Some(base_bank.oracle_price(
+                &AccountInfoRef::borrow(base_oracle_ai)?,
+                Some(Clock::get()?.slot),
+            )?)
         } else {
             None
         };
@@ -202,7 +198,7 @@ pub fn charge_loan_origination_fees(
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
-            price: base_oracle_price_bits
+            price: base_oracle_price.map(|p| p.to_bits())
         });
     }
 
@@ -225,15 +221,11 @@ pub fn charge_loan_origination_fees(
             now_ts,
         )?;
 
-        let quote_oracle_price_bits = if let Some(quote_oracle_ai) = quote_oracle {
-            Some(
-                quote_bank
-                    .oracle_price(
-                        &AccountInfoRef::borrow(quote_oracle_ai)?,
-                        Some(Clock::get()?.slot),
-                    )?
-                    .to_bits(),
-            )
+        let quote_oracle_price = if let Some(quote_oracle_ai) = quote_oracle {
+            Some(quote_bank.oracle_price(
+                &AccountInfoRef::borrow(quote_oracle_ai)?,
+                Some(Clock::get()?.slot),
+            )?)
         } else {
             None
         };
@@ -245,7 +237,7 @@ pub fn charge_loan_origination_fees(
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
-            price: quote_oracle_price_bits
+            price: quote_oracle_price.map(|p| p.to_bits())
         });
     }
 

--- a/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
@@ -178,7 +178,8 @@ pub fn token_liq_bankruptcy(
                     token_index: liab_token_index,
                     loan_amount: liqor_liab_withdraw_result.loan_amount.to_bits(),
                     loan_origination_fee: liqor_liab_withdraw_result.loan_origination_fee.to_bits(),
-                    instruction: LoanOriginationFeeInstruction::LiqTokenBankruptcy
+                    instruction: LoanOriginationFeeInstruction::LiqTokenBankruptcy,
+                    price: Some(liab_oracle_price.to_bits())
                 });
             }
 

--- a/programs/mango-v4/src/instructions/token_liq_with_token.rs
+++ b/programs/mango-v4/src/instructions/token_liq_with_token.rs
@@ -298,7 +298,8 @@ pub(crate) fn liquidation_action(
             token_index: liab_token_index,
             loan_amount: liqor_liab_withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: liqor_liab_withdraw_result.loan_origination_fee.to_bits(),
-            instruction: LoanOriginationFeeInstruction::LiqTokenWithToken
+            instruction: LoanOriginationFeeInstruction::LiqTokenWithToken,
+            price: Some(liab_oracle_price.to_bits())
         });
     }
 

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -135,6 +135,7 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::TokenWithdraw,
+            price: Some(oracle_price.to_bits()),
         });
     }
 

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -265,6 +265,7 @@ pub struct WithdrawLoanLog {
     pub loan_amount: i128,
     pub loan_origination_fee: i128,
     pub instruction: LoanOriginationFeeInstruction,
+    pub price: Option<i128>, // Ideally would log price everywhere but in serum3_settle_funds oracle is not a passed in account
 }
 
 #[event]


### PR DESCRIPTION
For performance reasons it is desirable to have prices logged in the WithdrawLoanLog.
I am using the same event (not incrementing it) as I hope this can be merged before the previous WithdrawLoanLog event is deployed. 