### PR TITLE
cumulative funding in offchain-sanity-check reflects smart contract

### DIFF
--- a/ts/client/scripts/offchain-sanity-check.ts
+++ b/ts/client/scripts/offchain-sanity-check.ts
@@ -107,7 +107,7 @@ async function main(): Promise<void> {
     }
 
     const offChain =
-      offChainEntry['long_funding'] + offChainEntry['short_funding'];
+      -offChainEntry['long_funding'] - offChainEntry['short_funding'];
     return [onChain, offChain];
   }
   for (const a of largeMangoAccounts) {


### PR DESCRIPTION
Cumulative funding in the offchain service is multiplied by -1 for readability. Since the UI relies on this and afaik cumulative funding values are not used to calculate pnl, I think it's better to keep the offchain service as-is and instead change this script.

The offchain service displays a user paying $1 in funding for a long position as -1e6. We can see the opposite in the contract:
https://github.com/blockworks-foundation/mango-v4/blob/eeef6711ab8f20bc8fc898686fa9a0f15ffd0200/programs/mango-v4/src/state/mango_account_components.rs#L212-L222