### PR TITLE
Client: use createWithSeed when wrapping SOL

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -1248,33 +1248,41 @@ export class MangoClient {
     let wrappedSolAccount: Keypair | undefined;
     let preInstructions: TransactionInstruction[] = [];
     let postInstructions: TransactionInstruction[] = [];
-    const additionalSigners: Signer[] = [];
     if (mintPk.equals(NATIVE_MINT)) {
-      wrappedSolAccount = new Keypair();
+      // Generate a random seed for wrappedSolAccount.
+      const seed = Keypair.generate().publicKey.toBase58().slice(0, 32);
+      // Calculate a publicKey that will be controlled by the `mangoAccount.owner`.
+      const wrappedSolAccount = await PublicKey.createWithSeed(
+        mangoAccount.owner,
+        seed,
+        TOKEN_PROGRAM_ID,
+      );
+
       const lamports = nativeAmount.add(new BN(1e7));
 
       preInstructions = [
-        SystemProgram.createAccount({
+        SystemProgram.createAccountWithSeed({
           fromPubkey: mangoAccount.owner,
-          newAccountPubkey: wrappedSolAccount.publicKey,
+          basePubkey: mangoAccount.owner,
+          seed,
+          newAccountPubkey: wrappedSolAccount,
           lamports: lamports.toNumber(),
           space: 165,
           programId: TOKEN_PROGRAM_ID,
         }),
         createInitializeAccount3Instruction(
-          wrappedSolAccount.publicKey,
+          wrappedSolAccount,
           NATIVE_MINT,
           mangoAccount.owner,
         ),
       ];
       postInstructions = [
         createCloseAccountInstruction(
-          wrappedSolAccount.publicKey,
+          wrappedSolAccount,
           mangoAccount.owner,
           mangoAccount.owner,
         ),
       ];
-      additionalSigners.push(wrappedSolAccount);
     }
 
     const healthRemainingAccounts: PublicKey[] =
@@ -1300,11 +1308,11 @@ export class MangoClient {
       )
       .instruction();
 
-    return await this.sendAndConfirmTransactionForGroup(
-      group,
-      [...preInstructions, ix, ...postInstructions],
-      { additionalSigners },
-    );
+    return await this.sendAndConfirmTransactionForGroup(group, [
+      ...preInstructions,
+      ix,
+      ...postInstructions,
+    ]);
   }
 
   public async tokenWithdraw(


### PR DESCRIPTION
Using `SystemProgram.createAccountWithSeed` instead of `SystemProgram.createAccount` eliminates the need in an ephemeral signer for the the wrapping SOL transaction. 

This makes the transaction compatible with Smart Wallets that use delayed transaction execution mechanism, e.g. Fuse Wallet

For more in-depth explanation see section "Ephemeral Signers" here: https://fusedocs.framer.website/docs/fuse-intergration-for-app-devs