### PR TITLE
Client: allow PDA token account owners by default

### DIFF
--- a/ts/client/src/utils.ts
+++ b/ts/client/src/utils.ts
@@ -84,7 +84,7 @@ export function toUiI80F48(nativeAmount: I80F48, decimals: number): I80F48 {
 export async function getAssociatedTokenAddress(
   mint: PublicKey,
   owner: PublicKey,
-  allowOwnerOffCurve = false,
+  allowOwnerOffCurve = true,
   programId = TOKEN_PROGRAM_ID,
   associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID,
 ): Promise<PublicKey> {


### PR DESCRIPTION
Disallowing PDA token owners currently causes errors when the user wallet is a Smart Wallet (PDA).

Until there's a good reason for having `allowOwnerOffCurve = false` by default, I suggest we change the defaults to `true`.