### PR TITLE
Add account_create_v2 instruction

### DIFF
--- a/mango_v4.json
+++ b/mango_v4.json
@@ -1215,6 +1215,90 @@
       ]
     },
     {
+      "name": "accountCreateV2",
+      "accounts": [
+        {
+          "name": "group",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "account",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "MangoAccount"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "owner"
+              },
+              {
+                "kind": "arg",
+                "type": "u32",
+                "path": "account_num"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "accountNum",
+          "type": "u32"
+        },
+        {
+          "name": "tokenCount",
+          "type": "u8"
+        },
+        {
+          "name": "serum3Count",
+          "type": "u8"
+        },
+        {
+          "name": "perpCount",
+          "type": "u8"
+        },
+        {
+          "name": "perpOoCount",
+          "type": "u8"
+        },
+        {
+          "name": "tokenConditionalSwapCount",
+          "type": "u8"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    {
       "name": "accountExpand",
       "accounts": [
         {

--- a/programs/mango-v4/src/instructions/account_create.rs
+++ b/programs/mango-v4/src/instructions/account_create.rs
@@ -12,6 +12,7 @@ pub fn account_create(
     serum3_count: u8,
     perp_count: u8,
     perp_oo_count: u8,
+    token_conditional_swap_count: u8,
     name: String,
 ) -> Result<()> {
     let mut account = ctx.accounts.account.load_full_init()?;
@@ -29,7 +30,13 @@ pub fn account_create(
     account.fixed.delegate = Pubkey::default();
     account.fixed.set_being_liquidated(false);
 
-    account.expand_dynamic_content(token_count, serum3_count, perp_count, perp_oo_count, 0)?;
+    account.expand_dynamic_content(
+        token_count,
+        serum3_count,
+        perp_count,
+        perp_oo_count,
+        token_conditional_swap_count,
+    )?;
 
     Ok(())
 }

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -294,6 +294,31 @@ pub mod mango_v4 {
             serum3_count,
             perp_count,
             perp_oo_count,
+            0,
+            name,
+        )?;
+        Ok(())
+    }
+
+    pub fn account_create_v2(
+        ctx: Context<AccountCreate>,
+        account_num: u32,
+        token_count: u8,
+        serum3_count: u8,
+        perp_count: u8,
+        perp_oo_count: u8,
+        token_conditional_swap_count: u8,
+        name: String,
+    ) -> Result<()> {
+        #[cfg(feature = "enable-gpl")]
+        instructions::account_create(
+            ctx,
+            account_num,
+            token_count,
+            serum3_count,
+            perp_count,
+            perp_oo_count,
+            token_conditional_swap_count,
             name,
         )?;
         Ok(())

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -1821,18 +1821,19 @@ pub struct AccountCreateInstruction {
 #[async_trait::async_trait(?Send)]
 impl ClientInstruction for AccountCreateInstruction {
     type Accounts = mango_v4::accounts::AccountCreate;
-    type Instruction = mango_v4::instruction::AccountCreate;
+    type Instruction = mango_v4::instruction::AccountCreateV2;
     async fn to_instruction(
         &self,
         _account_loader: impl ClientAccountLoader + 'async_trait,
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = mango_v4::id();
-        let instruction = mango_v4::instruction::AccountCreate {
+        let instruction = Self::Instruction {
             account_num: self.account_num,
             token_count: self.token_count,
             serum3_count: self.serum3_count,
             perp_count: self.perp_count,
             perp_oo_count: self.perp_oo_count,
+            token_conditional_swap_count: 0,
             name: "my_mango_account".to_string(),
         };
 
@@ -1847,7 +1848,7 @@ impl ClientInstruction for AccountCreateInstruction {
         )
         .0;
 
-        let accounts = mango_v4::accounts::AccountCreate {
+        let accounts = Self::Accounts {
             group: self.group,
             owner: self.owner.pubkey(),
             account,

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -1215,6 +1215,90 @@ export type MangoV4 = {
       ]
     },
     {
+      "name": "accountCreateV2",
+      "accounts": [
+        {
+          "name": "group",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "account",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "MangoAccount"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "owner"
+              },
+              {
+                "kind": "arg",
+                "type": "u32",
+                "path": "account_num"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "accountNum",
+          "type": "u32"
+        },
+        {
+          "name": "tokenCount",
+          "type": "u8"
+        },
+        {
+          "name": "serum3Count",
+          "type": "u8"
+        },
+        {
+          "name": "perpCount",
+          "type": "u8"
+        },
+        {
+          "name": "perpOoCount",
+          "type": "u8"
+        },
+        {
+          "name": "tokenConditionalSwapCount",
+          "type": "u8"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    {
       "name": "accountExpand",
       "accounts": [
         {
@@ -13659,6 +13743,90 @@ export const IDL: MangoV4 = {
         },
         {
           "name": "perpOoCount",
+          "type": "u8"
+        },
+        {
+          "name": "name",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "accountCreateV2",
+      "accounts": [
+        {
+          "name": "group",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "account",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "MangoAccount"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "group"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "path": "owner"
+              },
+              {
+                "kind": "arg",
+                "type": "u32",
+                "path": "account_num"
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "accountNum",
+          "type": "u32"
+        },
+        {
+          "name": "tokenCount",
+          "type": "u8"
+        },
+        {
+          "name": "serum3Count",
+          "type": "u8"
+        },
+        {
+          "name": "perpCount",
+          "type": "u8"
+        },
+        {
+          "name": "perpOoCount",
+          "type": "u8"
+        },
+        {
+          "name": "tokenConditionalSwapCount",
           "type": "u8"
         },
         {


### PR DESCRIPTION
This one allows specifying the number of tcs slots. That way accounts can be created without needing a separate extend instruction afterwards.