### PR TITLE
Account size: Don't fail on unrelated resize

### DIFF
--- a/lib/client/src/client.rs
+++ b/lib/client/src/client.rs
@@ -212,8 +212,8 @@ impl MangoClient {
                 account_num,
                 name: mango_account_name.to_owned(),
                 token_count: 8,
-                serum3_count: 8,
-                perp_count: 8,
+                serum3_count: 6,
+                perp_count: 3,
                 perp_oo_count: 8,
             }),
         };

--- a/programs/mango-v4/src/accounts_ix/account_create.rs
+++ b/programs/mango-v4/src/accounts_ix/account_create.rs
@@ -15,7 +15,7 @@ pub struct AccountCreate<'info> {
         seeds = [b"MangoAccount".as_ref(), group.key().as_ref(), owner.key().as_ref(), &account_num.to_le_bytes()],
         bump,
         payer = payer,
-        space = MangoAccount::space(token_count, serum3_count, perp_count, perp_oo_count, 0)?,
+        space = MangoAccount::space(token_count, serum3_count, perp_count, perp_oo_count, 0),
     )]
     pub account: AccountLoader<'info, MangoAccountFixed>,
     pub owner: Signer<'info>,
@@ -39,7 +39,7 @@ pub struct AccountCreateV2<'info> {
         seeds = [b"MangoAccount".as_ref(), group.key().as_ref(), owner.key().as_ref(), &account_num.to_le_bytes()],
         bump,
         payer = payer,
-        space = MangoAccount::space(token_count, serum3_count, perp_count, perp_oo_count, token_conditional_swap_count)?,
+        space = MangoAccount::space(token_count, serum3_count, perp_count, perp_oo_count, token_conditional_swap_count),
     )]
     pub account: AccountLoader<'info, MangoAccountFixed>,
     pub owner: Signer<'info>,

--- a/programs/mango-v4/src/instructions/account_create.rs
+++ b/programs/mango-v4/src/instructions/account_create.rs
@@ -18,6 +18,15 @@ pub fn account_create(
 ) -> Result<()> {
     let mut account = account_ai.load_full_init()?;
 
+    let header = MangoAccountDynamicHeader {
+        token_count,
+        serum3_count,
+        perp_count,
+        perp_oo_count,
+        token_conditional_swap_count,
+    };
+    header.check_resize_from(&MangoAccountDynamicHeader::zero())?;
+
     msg!(
         "Initialized account with header version {}",
         account.header_version()

--- a/programs/mango-v4/src/instructions/account_expand.rs
+++ b/programs/mango-v4/src/instructions/account_expand.rs
@@ -17,7 +17,7 @@ pub fn account_expand(
         perp_count,
         perp_oo_count,
         token_conditional_swap_count,
-    )?;
+    );
     let new_rent_minimum = Rent::get()?.minimum_balance(new_space);
 
     let realloc_account = ctx.accounts.account.as_ref();

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -554,12 +554,12 @@ impl MangoAccountDynamicHeader {
 
         require_gte!(self.serum3_count, prev.serum3_count);
         if self.serum3_count > prev.serum3_count {
-            require_gte!(8, self.serum3_count);
+            require_gte!(6, self.serum3_count);
         }
 
         require_gte!(self.perp_count, prev.perp_count);
         if self.perp_count > prev.perp_count {
-            require_gte!(4, self.perp_count);
+            require_gte!(3, self.perp_count);
         }
 
         require_gte!(self.perp_oo_count, prev.perp_oo_count);
@@ -578,7 +578,7 @@ impl MangoAccountDynamicHeader {
         let new_health_accounts = self.expected_health_accounts();
         let prev_health_accounts = prev.expected_health_accounts();
         if new_health_accounts > prev_health_accounts {
-            require_gte!(32, new_health_accounts);
+            require_gte!(28, new_health_accounts);
         }
 
         Ok(())

--- a/programs/mango-v4/tests/cases/test_basic.rs
+++ b/programs/mango-v4/tests/cases/test_basic.rs
@@ -34,7 +34,7 @@ async fn test_basic() -> Result<(), TransportError> {
         AccountCreateInstruction {
             account_num: 0,
             token_count: 6,
-            serum3_count: 7,
+            serum3_count: 5,
             perp_count: 0,
             perp_oo_count: 0,
             token_conditional_swap_count: 0,
@@ -52,7 +52,7 @@ async fn test_basic() -> Result<(), TransportError> {
         account_data.tokens.iter().filter(|t| t.is_active()).count(),
         0
     );
-    assert_eq!(account_data.serum3.len(), 7);
+    assert_eq!(account_data.serum3.len(), 5);
     assert_eq!(
         account_data.serum3.iter().filter(|s| s.is_active()).count(),
         0
@@ -66,8 +66,8 @@ async fn test_basic() -> Result<(), TransportError> {
         AccountExpandInstruction {
             account_num: 0,
             token_count: 8,
-            serum3_count: 8,
-            perp_count: 4,
+            serum3_count: 6,
+            perp_count: 3,
             perp_oo_count: 8,
             token_conditional_swap_count: 4,
             group,
@@ -85,13 +85,13 @@ async fn test_basic() -> Result<(), TransportError> {
         account_data.tokens.iter().filter(|t| t.is_active()).count(),
         0
     );
-    assert_eq!(account_data.serum3.len(), 8);
+    assert_eq!(account_data.serum3.len(), 6);
     assert_eq!(
         account_data.serum3.iter().filter(|s| s.is_active()).count(),
         0
     );
 
-    assert_eq!(account_data.perps.len(), 4);
+    assert_eq!(account_data.perps.len(), 3);
     assert_eq!(account_data.perp_open_orders.len(), 8);
 
     //

--- a/programs/mango-v4/tests/cases/test_health_compute.rs
+++ b/programs/mango-v4/tests/cases/test_health_compute.rs
@@ -44,7 +44,7 @@ async fn test_health_compute_serum() -> Result<(), TransportError> {
     let admin = TestKeypair::new();
     let owner = context.users[0].key;
     let payer = context.users[1].key;
-    let mints = &context.mints[0..8];
+    let mints = &context.mints[0..7];
     let payer_mint_accounts = &context.users[1].token_accounts[0..mints.len()];
 
     //
@@ -161,7 +161,7 @@ async fn test_health_compute_perp() -> Result<(), TransportError> {
     let admin = TestKeypair::new();
     let owner = context.users[0].key;
     let payer = context.users[1].key;
-    let mints = &context.mints[0..5];
+    let mints = &context.mints[0..4];
     let payer_mint_accounts = &context.users[1].token_accounts[0..mints.len()];
 
     //

--- a/programs/mango-v4/tests/cases/test_token_conditional_swap.rs
+++ b/programs/mango-v4/tests/cases/test_token_conditional_swap.rs
@@ -111,8 +111,8 @@ async fn test_token_conditional_swap() -> Result<(), TransportError> {
         AccountExpandInstruction {
             account_num: 0,
             token_count: 8,
-            serum3_count: 8,
-            perp_count: 4,
+            serum3_count: 6,
+            perp_count: 3,
             perp_oo_count: 16,
             token_conditional_swap_count: 2,
             group,

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -1824,8 +1824,8 @@ impl Default for AccountCreateInstruction {
         AccountCreateInstruction {
             account_num: 0,
             token_count: 8,
-            serum3_count: 8,
-            perp_count: 4,
+            serum3_count: 6,
+            perp_count: 3,
             perp_oo_count: 16,
             token_conditional_swap_count: 1,
             group: Default::default(),

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -739,8 +739,8 @@ export class MangoClient {
       .accountCreate(
         accountNumber ?? 0,
         tokenCount ?? 8,
-        serum3Count ?? 8,
-        perpCount ?? 4,
+        serum3Count ?? 6,
+        perpCount ?? 3,
         perpOoCount ?? 32,
         name ?? '',
       )


### PR DESCRIPTION
If the account was previously resized to larger than is allowed now, don't fail unrelated resizes.