### PR TITLE
FlashLoan: Log the approved amount

### DIFF
--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -353,7 +353,8 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         let position = account.token_position_mut_by_raw_index(change.raw_token_index);
         let native = position.native(&bank);
 
-        let approved_amount = I80F48::from(bank.flash_loan_approved_amount);
+        let approved_amount_u64 = bank.flash_loan_approved_amount;
+        let approved_amount = I80F48::from(approved_amount_u64);
 
         let loan = if native.is_positive() {
             (approved_amount - native).max(I80F48::ZERO)
@@ -416,6 +417,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             borrow_index: bank.borrow_index.to_bits(),
             price: oracle_price.to_bits(),
             deposit_fee: deposit_fee.to_bits(),
+            approved_amount: approved_amount_u64,
         });
 
         emit!(TokenBalanceLog {

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -61,13 +61,32 @@ pub struct FlashLoanTokenDetail {
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct FlashLoanTokenDetailV2 {
     pub token_index: u16,
+
+    /// The amount by which the user's token position changed at the end
+    ///
+    /// So if the user repaid the approved_amount in full, it'd be 0.
+    ///
+    /// Does NOT include the loan_origination_fee or deposit_fee, so the true
+    /// change is `change_amount - loan_origination_fee - deposit_fee`.
     pub change_amount: i128,
+
+    /// The amount that was a loan (<= approved_amount, depends on user's deposits)
     pub loan: i128,
+
+    /// The fee paid on the loan, not included in `loan` or `change_amount`
     pub loan_origination_fee: i128,
+
     pub deposit_index: i128,
     pub borrow_index: i128,
     pub price: i128,
+
+    /// Deposit fee paid for positive change_amount.
+    ///
+    /// Not factored into change_amount.
     pub deposit_fee: i128,
+
+    /// The amount that was transfered out to the user
+    pub approved_amount: u64,
 }
 
 #[event]


### PR DESCRIPTION
Previously only the part of the approved amount that was a loan got logged, missing some interesting information.