### PR TITLE
Ts/ids fixes

### DIFF
--- a/ts/client/ids.json
+++ b/ts/client/ids.json
@@ -13,7 +13,8 @@
           "mint": "So11111111111111111111111111111111111111112",
           "tokenIndex": 5,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "USDT",
@@ -21,7 +22,8 @@
           "mint": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
           "tokenIndex": 1,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "USDC",
@@ -29,7 +31,8 @@
           "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "tokenIndex": 0,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "BTC",
@@ -37,7 +40,8 @@
           "mint": "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
           "tokenIndex": 2,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "soETH",
@@ -45,7 +49,8 @@
           "mint": "2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk",
           "tokenIndex": 4,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "ETH",
@@ -53,7 +58,8 @@
           "mint": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
           "tokenIndex": 3,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         },
         {
           "name": "MSOL",
@@ -61,7 +67,8 @@
           "mint": "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",
           "tokenIndex": 6,
           "bankNum": 0,
-          "active": true
+          "active": true,
+          "decimals": 99999
         }
       ],
       "stubOracles": [

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -144,7 +144,7 @@ export class Group {
       ),
       this.reloadMintInfos(client, ids),
       this.reloadSerum3Markets(client, ids).then(() =>
-        this.reloadSerum3ExternalMarkets(client),
+        this.reloadSerum3ExternalMarkets(client, ids),
       ),
     ]);
     // console.timeEnd('group.reload');
@@ -280,23 +280,63 @@ export class Group {
     );
   }
 
-  public async reloadSerum3ExternalMarkets(client: MangoClient): Promise<void> {
-    const externalMarkets = await Promise.all(
-      Array.from(this.serum3MarketsMapByExternal.values()).map((serum3Market) =>
-        Market.load(
-          client.program.provider.connection,
-          serum3Market.serumMarketExternal,
-          { commitment: client.program.provider.connection.commitment },
-          OPENBOOK_PROGRAM_ID[client.cluster],
+  public async reloadSerum3ExternalMarkets(
+    client: MangoClient,
+    ids?: Id,
+  ): Promise<void> {
+    let markets: Market[] = [];
+    const externalMarketIds = ids?.getSerum3ExternalMarkets();
+
+    if (ids && externalMarketIds && externalMarketIds.length) {
+      markets = await Promise.all(
+        (
+          await client.program.provider.connection.getMultipleAccountsInfo(
+            externalMarketIds,
+          )
+        ).map(
+          (account, index) =>
+            new Market(
+              Market.getLayout(OPENBOOK_PROGRAM_ID[client.cluster]).decode(
+                account?.data,
+              ),
+              ids.banks.find(
+                (b) =>
+                  b.tokenIndex ===
+                  this.serum3MarketsMapByExternal.get(
+                    externalMarketIds[index].toString(),
+                  )?.baseTokenIndex,
+              )?.decimals || 6,
+              ids.banks.find(
+                (b) =>
+                  b.tokenIndex ===
+                  this.serum3MarketsMapByExternal.get(
+                    externalMarketIds[index].toString(),
+                  )?.quoteTokenIndex,
+              )?.decimals || 6,
+              { commitment: client.program.provider.connection.commitment },
+              OPENBOOK_PROGRAM_ID[client.cluster],
+            ),
         ),
-      ),
-    );
+      );
+    } else {
+      markets = await Promise.all(
+        Array.from(this.serum3MarketsMapByExternal.values()).map(
+          (serum3Market) =>
+            Market.load(
+              client.program.provider.connection,
+              serum3Market.serumMarketExternal,
+              { commitment: client.program.provider.connection.commitment },
+              OPENBOOK_PROGRAM_ID[client.cluster],
+            ),
+        ),
+      );
+    }
 
     this.serum3ExternalMarketsMap = new Map(
       Array.from(this.serum3MarketsMapByExternal.values()).map(
         (serum3Market, index) => [
           serum3Market.serumMarketExternal.toBase58(),
-          externalMarkets[index],
+          markets[index],
         ],
       ),
     );
@@ -469,7 +509,6 @@ export class Group {
       await client.program.provider.connection.getMultipleAccountsInfo(
         vaultPks,
       );
-    const coder = new BorshAccountsCoder(client.program.idl);
     this.vaultAmountsMap = new Map(
       vaultAccounts.map((vaultAi, i) => {
         if (!vaultAi) {

--- a/ts/client/src/ids.ts
+++ b/ts/client/src/ids.ts
@@ -8,7 +8,14 @@ export class Id {
     public publicKey: string,
     public serum3ProgramId: string,
     public mangoProgramId: string,
-    public banks: { name: string; publicKey: string; active: boolean }[],
+    public banks: {
+      name: string;
+      mint: string;
+      tokenIndex: number;
+      publicKey: string;
+      active: boolean;
+      decimals: number;
+    }[],
     public stubOracles: { name: string; publicKey: string }[],
     public mintInfos: { name: string; publicKey: string }[],
     public serum3Markets: {
@@ -23,7 +30,7 @@ export class Id {
   public getBanks(): PublicKey[] {
     return Array.from(
       this.banks
-        .filter((perpMarket) => perpMarket.active)
+        .filter((bank) => bank.active)
         .map((bank) => new PublicKey(bank.publicKey)),
     );
   }
@@ -43,8 +50,16 @@ export class Id {
   public getSerum3Markets(): PublicKey[] {
     return Array.from(
       this.serum3Markets
-        .filter((perpMarket) => perpMarket.active)
+        .filter((serum3Market) => serum3Market.active)
         .map((serum3Market) => new PublicKey(serum3Market.publicKey)),
+    );
+  }
+
+  public getSerum3ExternalMarkets(): PublicKey[] {
+    return Array.from(
+      this.serum3Markets
+        .filter((serum3Market) => serum3Market.active)
+        .map((serum3Market) => new PublicKey(serum3Market.marketExternal)),
     );
   }
 
@@ -56,6 +71,7 @@ export class Id {
     );
   }
 
+  // DEPRECATED
   static fromIdsByName(name: string): Id {
     const groupConfig = ids.groups.find((id) => id['name'] === name);
     if (!groupConfig) throw new Error(`No group config ${name} found in Ids!`);
@@ -73,6 +89,7 @@ export class Id {
     );
   }
 
+  // DEPRECATED
   static fromIdsByPk(groupPk: PublicKey): Id {
     const groupConfig = ids.groups.find(
       (id) => id['publicKey'] === groupPk.toString(),
@@ -115,6 +132,8 @@ export class Id {
           tokenIndex: t.tokenIndex,
           bankNum: b.bankNum,
           publicKey: b.publicKey,
+          active: t.active,
+          decimals: t.decimals,
         })),
       ),
       groupConfig.stubOracles.map((s) => ({
@@ -126,15 +145,18 @@ export class Id {
         mint: t.mint,
         tokenIndex: t.tokenIndex,
         publicKey: t.mintInfo,
+        active: t.active,
       })),
       groupConfig.serum3Markets.map((s) => ({
         name: s.name,
         publicKey: s.publicKey,
-        marketExternal: s.marketExternal,
+        marketExternal: s.serumMarketExternal,
+        active: s.active,
       })),
       groupConfig.perpMarkets.map((p) => ({
         name: p.name,
         publicKey: p.publicKey,
+        active: p.active,
       })),
     );
   }


### PR DESCRIPTION
Using the client in 'api' mode isn't working because the Ids class doesn't expose an 'active' flag available for many of the banks, markets, etc

Deprecate ids.json. I don't think it ever worked and doesn't make sense now. Also deprecate the functions that rely on it.