### PR TITLE
Serum3 open orders: Fix health overestimation

### DIFF
--- a/programs/mango-v4/src/health/cache.rs
+++ b/programs/mango-v4/src/health/cache.rs
@@ -19,8 +19,10 @@ use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 
 use crate::error::*;
+use crate::serum3_cpi::{OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::{
-    Bank, MangoAccountRef, PerpMarket, PerpMarketIndex, PerpPosition, Serum3MarketIndex, TokenIndex,
+    Bank, MangoAccountRef, PerpMarket, PerpMarketIndex, PerpPosition, Serum3MarketIndex,
+    Serum3Orders, TokenIndex,
 };
 
 use super::*;
@@ -237,6 +239,11 @@ pub struct Serum3Info {
     pub reserved_base: I80F48,
     pub reserved_quote: I80F48,
 
+    // Reserved amounts, converted to the opposite token, while using the most extreme order price
+    // May be zero if the extreme bid/ask price is not available (for orders placed in the past)
+    pub reserved_base_as_quote_lowest_ask: I80F48,
+    pub reserved_quote_as_base_highest_bid: I80F48,
+
     // Index into TokenInfos _not_ a TokenIndex
     pub base_info_index: usize,
     pub quote_info_index: usize,
@@ -248,6 +255,35 @@ pub struct Serum3Info {
 }
 
 impl Serum3Info {
+    fn new(
+        serum_account: &Serum3Orders,
+        open_orders: &impl OpenOrdersAmounts,
+        base_info_index: usize,
+        quote_info_index: usize,
+    ) -> Self {
+        // track the reserved amounts
+        let reserved_base = I80F48::from(open_orders.native_base_reserved());
+        let reserved_quote = I80F48::from(open_orders.native_quote_reserved());
+
+        let reserved_base_as_quote_lowest_ask =
+            reserved_base * I80F48::from_num(serum_account.lowest_placed_ask);
+        let reserved_quote_as_base_highest_bid =
+            reserved_quote * I80F48::from_num(serum_account.highest_placed_bid_inv);
+
+        Self {
+            reserved_base,
+            reserved_quote,
+            reserved_base_as_quote_lowest_ask,
+            reserved_quote_as_base_highest_bid,
+            base_info_index,
+            quote_info_index,
+            market_index: serum_account.market_index,
+            has_zero_funds: open_orders.native_base_total() == 0
+                && open_orders.native_quote_total() == 0
+                && open_orders.native_rebates() == 0,
+        }
+    }
+
     #[inline(always)]
     fn all_reserved_as_base(
         &self,
@@ -258,7 +294,13 @@ impl Serum3Info {
         let quote_asset = quote_info.prices.asset(health_type);
         let base_liab = base_info.prices.liab(health_type);
         // OPTIMIZATION: These divisions can be extremely expensive (up to 5k CU each)
-        self.reserved_base + self.reserved_quote * quote_asset / base_liab
+        let reserved_quote_as_base_oracle = self.reserved_quote * quote_asset / base_liab;
+        if self.reserved_quote_as_base_highest_bid != 0 {
+            self.reserved_base
+                + reserved_quote_as_base_oracle.min(self.reserved_quote_as_base_highest_bid)
+        } else {
+            self.reserved_base + reserved_quote_as_base_oracle
+        }
     }
 
     #[inline(always)]
@@ -271,7 +313,13 @@ impl Serum3Info {
         let base_asset = base_info.prices.asset(health_type);
         let quote_liab = quote_info.prices.liab(health_type);
         // OPTIMIZATION: These divisions can be extremely expensive (up to 5k CU each)
-        self.reserved_quote + self.reserved_base * base_asset / quote_liab
+        let reserved_base_as_quote_oracle = self.reserved_base * base_asset / quote_liab;
+        if self.reserved_base_as_quote_lowest_ask != 0 {
+            self.reserved_quote
+                + reserved_base_as_quote_oracle.min(self.reserved_base_as_quote_lowest_ask)
+        } else {
+            self.reserved_quote + reserved_base_as_quote_oracle
+        }
     }
 
     /// Compute the health contribution from active open orders.
@@ -800,42 +848,40 @@ impl HealthCache {
         Ok(())
     }
 
-    /// Changes the cached user account token and serum balances.
+    /// Recompute the cached information about a serum market.
     ///
     /// WARNING: You must also call recompute_token_weights() after all bank
     /// deposit/withdraw changes!
-    #[allow(clippy::too_many_arguments)]
-    pub fn adjust_serum3_reserved(
+    pub fn recompute_serum3_info(
         &mut self,
-        market_index: Serum3MarketIndex,
-        base_token_index: TokenIndex,
-        reserved_base_change: I80F48,
+        serum_account: &Serum3Orders,
+        open_orders: &OpenOrdersSlim,
         free_base_change: I80F48,
-        quote_token_index: TokenIndex,
-        reserved_quote_change: I80F48,
         free_quote_change: I80F48,
     ) -> Result<()> {
-        let base_entry_index = self.token_info_index(base_token_index)?;
-        let quote_entry_index = self.token_info_index(quote_token_index)?;
+        let serum_info_index = self
+            .serum3_infos
+            .iter_mut()
+            .position(|m| m.market_index == serum_account.market_index)
+            .ok_or_else(|| error_msg!("serum3 market {} not found", serum_account.market_index))?;
 
-        // Apply it to the tokens
+        let serum_info = &self.serum3_infos[serum_info_index];
         {
-            let base_entry = &mut self.token_infos[base_entry_index];
+            let base_entry = &mut self.token_infos[serum_info.base_info_index];
             base_entry.balance_spot += free_base_change;
         }
         {
-            let quote_entry = &mut self.token_infos[quote_entry_index];
+            let quote_entry = &mut self.token_infos[serum_info.quote_info_index];
             quote_entry.balance_spot += free_quote_change;
         }
 
-        // Apply it to the serum3 info
-        let market_entry = self
-            .serum3_infos
-            .iter_mut()
-            .find(|m| m.market_index == market_index)
-            .ok_or_else(|| error_msg!("serum3 market {} not found", market_index))?;
-        market_entry.reserved_base += reserved_base_change;
-        market_entry.reserved_quote += reserved_quote_change;
+        let serum_info = &mut self.serum3_infos[serum_info_index];
+        *serum_info = Serum3Info::new(
+            serum_account,
+            open_orders,
+            serum_info.base_info_index,
+            serum_info.quote_info_index,
+        );
         Ok(())
     }
 
@@ -1248,20 +1294,12 @@ fn new_health_cache_impl(
         let quote_info = &mut token_infos[quote_info_index];
         quote_info.balance_spot += quote_free;
 
-        // track the reserved amounts
-        let reserved_base = I80F48::from(oo.native_coin_total - oo.native_coin_free);
-        let reserved_quote = I80F48::from(oo.native_pc_total - oo.native_pc_free);
-
-        serum3_infos.push(Serum3Info {
-            reserved_base,
-            reserved_quote,
+        serum3_infos.push(Serum3Info::new(
+            serum_account,
+            oo,
             base_info_index,
             quote_info_index,
-            market_index: serum_account.market_index,
-            has_zero_funds: oo.native_coin_total == 0
-                && oo.native_pc_total == 0
-                && oo.referrer_rebates_accrued == 0,
-        });
+        ));
     }
 
     // health contribution from perp accounts
@@ -1423,6 +1461,7 @@ mod tests {
         perp1: (i64, i64, i64, i64),
         expected_health: f64,
         bank_settings: [BankSettings; 3],
+        extra: Option<fn(&mut MangoAccountValue)>,
     }
     fn test_health1_runner(testcase: &TestHealth1Case) {
         let buffer = MangoAccount::default_for_tests().try_to_vec().unwrap();
@@ -1500,6 +1539,10 @@ mod tests {
         );
         perpaccount.bids_base_lots = testcase.perp1.2;
         perpaccount.asks_base_lots = testcase.perp1.3;
+
+        if let Some(extra_fn) = testcase.extra {
+            extra_fn(&mut account);
+        }
 
         let oracle2_ai = oracle2.as_account_info();
         let ais = vec![
@@ -1713,6 +1756,50 @@ mod tests {
                 token1: 100,
                 perp1: (-1, -100, 0, 0),
                 expected_health: 1.2 * (100.0 - 100.0 - 1.2 * 1.0 * base_lots_to_quote),
+                ..Default::default()
+            },
+            TestHealth1Case {
+                // 14, reserved oo funds with max bid/min ask
+                token1: -100,
+                token2: -10,
+                token3: 0,
+                oo_1_2: (1, 1),
+                oo_1_3: (11, 1),
+                expected_health:
+                    // tokens
+                    -100.0 * 1.2 - 10.0 * 5.0 * 1.5
+                    // oo_1_2 (-> token1)
+                    + (1.0 + 3.0) * 1.2
+                    // oo_1_3 (-> token3)
+                    + (11.0 / 12.0 + 1.0) * 10.0 * 0.5,
+                extra: Some(|account: &mut MangoAccountValue| {
+                    let s2 = account.serum3_orders_mut(2).unwrap();
+                    s2.lowest_placed_ask = 3.0;
+                    let s3 = account.serum3_orders_mut(3).unwrap();
+                    s3.highest_placed_bid_inv = 1.0 / 12.0;
+                }),
+                ..Default::default()
+            },
+            TestHealth1Case {
+                // 15, reserved oo funds with max bid/min ask not crossing oracle
+                token1: -100,
+                token2: -10,
+                token3: 0,
+                oo_1_2: (1, 1),
+                oo_1_3: (11, 1),
+                expected_health:
+                    // tokens
+                    -100.0 * 1.2 - 10.0 * 5.0 * 1.5
+                    // oo_1_2 (-> token1)
+                    + (1.0 + 5.0) * 1.2
+                    // oo_1_3 (-> token3)
+                    + (11.0 / 10.0 + 1.0) * 10.0 * 0.5,
+                extra: Some(|account: &mut MangoAccountValue| {
+                    let s2 = account.serum3_orders_mut(2).unwrap();
+                    s2.lowest_placed_ask = 6.0;
+                    let s3 = account.serum3_orders_mut(3).unwrap();
+                    s3.highest_placed_bid_inv = 1.0 / 9.0;
+                }),
                 ..Default::default()
             },
         ];

--- a/programs/mango-v4/src/health/client.rs
+++ b/programs/mango-v4/src/health/client.rs
@@ -952,6 +952,8 @@ mod tests {
                     market_index: 0,
                     reserved_base: I80F48::from(30 / 3),
                     reserved_quote: I80F48::from(30 / 2),
+                    reserved_base_as_quote_lowest_ask: I80F48::ZERO,
+                    reserved_quote_as_base_highest_bid: I80F48::ZERO,
                     has_zero_funds: false,
                 }];
                 adjust_by_usdc(&mut health_cache, 0, -20.0);
@@ -1606,6 +1608,8 @@ mod tests {
             serum3_infos: vec![Serum3Info {
                 reserved_base: I80F48::ONE,
                 reserved_quote: I80F48::ZERO,
+                reserved_base_as_quote_lowest_ask: I80F48::ONE,
+                reserved_quote_as_base_highest_bid: I80F48::ZERO,
                 base_info_index: 1,
                 quote_info_index: 0,
                 market_index: 0,

--- a/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
@@ -1,10 +1,9 @@
 use anchor_lang::prelude::*;
 
-use super::{OpenOrdersAmounts, OpenOrdersSlim};
 use crate::accounts_ix::*;
 use crate::error::*;
 use crate::logs::Serum3OpenOrdersBalanceLogV2;
-use crate::serum3_cpi::load_open_orders_ref;
+use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::*;
 
 pub fn serum3_cancel_all_orders(ctx: Context<Serum3CancelAllOrders>, limit: u8) -> Result<()> {

--- a/programs/mango-v4/src/instructions/serum3_cancel_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_order.rs
@@ -5,10 +5,9 @@ use serum_dex::instruction::CancelOrderInstructionV2;
 use crate::error::*;
 use crate::state::*;
 
-use super::{OpenOrdersAmounts, OpenOrdersSlim};
 use crate::accounts_ix::*;
 use crate::logs::Serum3OpenOrdersBalanceLogV2;
-use crate::serum3_cpi::load_open_orders_ref;
+use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 
 pub fn serum3_cancel_order(
     ctx: Context<Serum3CancelOrder>,

--- a/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
@@ -4,9 +4,9 @@ use crate::accounts_ix::*;
 use crate::error::*;
 use crate::health::*;
 use crate::instructions::apply_settle_changes;
-use crate::instructions::{charge_loan_origination_fees, OpenOrdersAmounts, OpenOrdersSlim};
+use crate::instructions::charge_loan_origination_fees;
 use crate::logs::Serum3OpenOrdersBalanceLogV2;
-use crate::serum3_cpi::load_open_orders_ref;
+use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::*;
 
 pub fn serum3_liq_force_cancel_orders(

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -2,10 +2,10 @@ use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 
 use crate::error::*;
-use crate::serum3_cpi::load_open_orders_ref;
+use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::*;
 
-use super::{apply_settle_changes, OpenOrdersAmounts, OpenOrdersSlim};
+use super::apply_settle_changes;
 use crate::accounts_ix::*;
 use crate::logs::Serum3OpenOrdersBalanceLogV2;
 use crate::logs::{LoanOriginationFeeInstruction, WithdrawLoanLog};

--- a/programs/mango-v4/src/state/mango_account_components.rs
+++ b/programs/mango-v4/src/state/mango_account_components.rs
@@ -133,10 +133,25 @@ pub struct Serum3Orders {
     #[derivative(Debug = "ignore")]
     pub padding: [u8; 2],
 
+    /// Track something like the highest open bid / lowest open ask, in native/native units.
+    ///
+    /// Tracking it exactly isn't possible since we don't see fills. So instead track
+    /// the min/max of the _placed_ bids and asks.
+    ///
+    /// The value is reset in serum3_place_order when a new order is placed without an
+    /// existing one on the book.
+    ///
+    /// 0 is a special "unset" state.
+    pub highest_placed_bid_inv: f64,
+    pub lowest_placed_ask: f64,
+
     #[derivative(Debug = "ignore")]
-    pub reserved: [u8; 64],
+    pub reserved: [u8; 48],
 }
-const_assert_eq!(size_of::<Serum3Orders>(), 32 + 8 * 2 + 2 * 3 + 2 + 64);
+const_assert_eq!(
+    size_of::<Serum3Orders>(),
+    32 + 8 * 2 + 2 * 3 + 2 + 2 * 8 + 48
+);
 const_assert_eq!(size_of::<Serum3Orders>(), 120);
 const_assert_eq!(size_of::<Serum3Orders>() % 8, 0);
 
@@ -157,10 +172,12 @@ impl Default for Serum3Orders {
             market_index: Serum3MarketIndex::MAX,
             base_token_index: TokenIndex::MAX,
             quote_token_index: TokenIndex::MAX,
-            reserved: [0; 64],
             padding: Default::default(),
             base_borrows_without_fee: 0,
             quote_borrows_without_fee: 0,
+            highest_placed_bid_inv: 0.0,
+            lowest_placed_ask: 0.0,
+            reserved: [0; 48],
         }
     }
 }


### PR DESCRIPTION
When bids or asks crossed the oracle price, the serum3 health would be overestimated before.

The health code has no access to the open order quantites or prices and used to assume all orders are at oracle price.

Now we track an account's max bid and min ask in each market and use that as a worst-case price. The tracking isn't perfect for technical reasons (compute cost, no notifications on fill) but produces an upper bound on bids (lower bound on asks) that is sufficient to make health not overestimate.

The tracked price is reset every time the serum3 open orders on a book side are completely cleared.