### PR TITLE
Allow ATA offcurve authority

### DIFF
--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -1312,6 +1312,8 @@ export class MangoClient {
     const tokenAccountPk = await getAssociatedTokenAddress(
       mintPk,
       mangoAccount.owner,
+      // Allow ATA authority to be a PDA
+      true,
     );
 
     let wrappedSolAccount: PublicKey | undefined;


### PR DESCRIPTION
This PR makes it possible for wallets powered by account abstraction (PDA wallets) to deposit into Mango accounts via the mango ui.

