### PR TITLE
FlashLoan: Replace deposit fee by "swap fee"

### DIFF
--- a/mango_v4.json
+++ b/mango_v4.json
@@ -8343,6 +8343,72 @@
             "type": "i128"
           },
           {
+            "name": "depositFee",
+            "docs": [
+              "Deposit fee paid for positive change_amount.",
+              "",
+              "Not factored into change_amount."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "approvedAmount",
+            "docs": [
+              "The amount that was transfered out to the user"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FlashLoanTokenDetailV3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenIndex",
+            "type": "u16"
+          },
+          {
+            "name": "changeAmount",
+            "docs": [
+              "The amount by which the user's token position changed at the end",
+              "",
+              "So if the user repaid the approved_amount in full, it'd be 0.",
+              "",
+              "Does NOT include the loan_origination_fee or deposit_fee, so the true",
+              "change is `change_amount - loan_origination_fee - deposit_fee`."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loan",
+            "docs": [
+              "The amount that was a loan (<= approved_amount, depends on user's deposits)"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loanOriginationFee",
+            "docs": [
+              "The fee paid on the loan, not included in `loan` or `change_amount`"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "depositIndex",
+            "type": "i128"
+          },
+          {
+            "name": "borrowIndex",
+            "type": "i128"
+          },
+          {
+            "name": "price",
+            "type": "i128"
+          },
+          {
             "name": "swapFee",
             "docs": [
               "Swap fee paid on the in token of a swap.",
@@ -10653,6 +10719,37 @@
           "type": {
             "vec": {
               "defined": "FlashLoanTokenDetailV2"
+            }
+          },
+          "index": false
+        },
+        {
+          "name": "flashLoanType",
+          "type": {
+            "defined": "FlashLoanType"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FlashLoanLogV3",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "mangoAccount",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "tokenLoanDetails",
+          "type": {
+            "vec": {
+              "defined": "FlashLoanTokenDetailV3"
             }
           },
           "index": false

--- a/mango_v4.json
+++ b/mango_v4.json
@@ -594,7 +594,7 @@
           "type": "f32"
         },
         {
-          "name": "flashLoanDepositFeeRate",
+          "name": "flashLoanSwapFeeRate",
           "type": "f32"
         }
       ]
@@ -926,7 +926,7 @@
           }
         },
         {
-          "name": "flashLoanDepositFeeRateOpt",
+          "name": "flashLoanSwapFeeRateOpt",
           "type": {
             "option": "f32"
           }
@@ -7030,7 +7030,7 @@
             "type": "f32"
           },
           {
-            "name": "flashLoanDepositFeeRate",
+            "name": "flashLoanSwapFeeRate",
             "type": "f32"
           },
           {
@@ -8343,9 +8343,9 @@
             "type": "i128"
           },
           {
-            "name": "depositFee",
+            "name": "swapFee",
             "docs": [
-              "Deposit fee paid for positive change_amount.",
+              "Swap fee paid on the in token of a swap.",
               "",
               "Not factored into change_amount."
             ],

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -239,7 +239,6 @@ pub fn flash_loan_swap_begin<'key, 'accounts, 'remaining, 'info>(
         anchor_spl::associated_token::create_idempotent(ctx)?;
     }
 
-    #[cfg(feature = "enable-gpl")]
     flash_loan_begin(
         ctx.program_id,
         &ctx.accounts.account,
@@ -297,8 +296,8 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
     // Verify that each mentioned vault has a bank in the health accounts
     let mut vaults_with_banks = vec![false; vaults.len()];
 
-    // Biggest flash_loan_deposit_fee_rate over all involved banks
-    let mut max_deposit_fee_rate = 0.0f32;
+    // Biggest flash_loan_swap_fee_rate over all involved banks
+    let mut max_swap_fee_rate = 0.0f32;
 
     // Loop over the banks, finding matching vaults
     // TODO: must be moved into health.rs, because it assumes something about the health accounts structure
@@ -357,7 +356,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             change += repay;
         }
 
-        max_deposit_fee_rate = max_deposit_fee_rate.max(bank.flash_loan_deposit_fee_rate);
+        max_swap_fee_rate = max_swap_fee_rate.max(bank.flash_loan_swap_fee_rate);
 
         changes.push(TokenVaultChange {
             token_index: bank.token_index,
@@ -427,14 +426,14 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         let loan_origination_fee = loan * bank.loan_origination_fee_rate;
         bank.collected_fees_native += loan_origination_fee;
 
-        let deposit_fee = if change.amount > 0 {
-            change.amount * I80F48::from_num(max_deposit_fee_rate)
+        let swap_fee = if change.amount < 0 && flash_loan_type == FlashLoanType::Swap {
+            -change.amount * I80F48::from_num(max_swap_fee_rate)
         } else {
             I80F48::ZERO
         };
-        bank.collected_fees_native += deposit_fee;
+        bank.collected_fees_native += swap_fee;
 
-        let change_amount = change.amount - loan_origination_fee - deposit_fee;
+        let change_amount = change.amount - loan_origination_fee - swap_fee;
         let native_after_change = native + change_amount;
         if bank.are_deposits_reduce_only() {
             require!(
@@ -478,7 +477,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             deposit_index: bank.deposit_index.to_bits(),
             borrow_index: bank.borrow_index.to_bits(),
             price: oracle_price.to_bits(),
-            deposit_fee: deposit_fee.to_bits(),
+            swap_fee: swap_fee.to_bits(),
             approved_amount: approved_amount_u64,
         });
 

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -3,7 +3,7 @@ use crate::accounts_zerocopy::*;
 use crate::error::*;
 use crate::group_seeds;
 use crate::health::{new_fixed_order_account_retriever, new_health_cache, AccountRetriever};
-use crate::logs::{FlashLoanLogV2, FlashLoanTokenDetailV2, TokenBalanceLog};
+use crate::logs::{FlashLoanLogV3, FlashLoanTokenDetailV3, TokenBalanceLog};
 use crate::state::*;
 
 use anchor_lang::prelude::*;
@@ -469,7 +469,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         bank.flash_loan_approved_amount = 0;
         bank.flash_loan_token_account_initial = u64::MAX;
 
-        token_loan_details.push(FlashLoanTokenDetailV2 {
+        token_loan_details.push(FlashLoanTokenDetailV3 {
             token_index: position.token_index,
             change_amount: change.amount.to_bits(),
             loan: loan.to_bits(),
@@ -491,7 +491,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         });
     }
 
-    emit!(FlashLoanLogV2 {
+    emit!(FlashLoanLogV3 {
         mango_group: group.key(),
         mango_account: ctx.accounts.account.key(),
         flash_loan_type,

--- a/programs/mango-v4/src/instructions/token_edit.rs
+++ b/programs/mango-v4/src/instructions/token_edit.rs
@@ -41,7 +41,7 @@ pub fn token_edit(
     force_close_opt: Option<bool>,
     token_conditional_swap_taker_fee_rate_opt: Option<f32>,
     token_conditional_swap_maker_fee_rate_opt: Option<f32>,
-    flash_loan_deposit_fee_rate_opt: Option<f32>,
+    flash_loan_swap_fee_rate_opt: Option<f32>,
 ) -> Result<()> {
     let group = ctx.accounts.group.load()?;
 
@@ -329,14 +329,14 @@ pub fn token_edit(
             require_group_admin = true;
         }
 
-        if let Some(fee_rate) = flash_loan_deposit_fee_rate_opt {
+        if let Some(fee_rate) = flash_loan_swap_fee_rate_opt {
             msg!(
                 "Flash loan swap fee fraction old {:?}, new {:?}",
-                bank.flash_loan_deposit_fee_rate,
+                bank.flash_loan_swap_fee_rate,
                 fee_rate
             );
             require_gte!(fee_rate, 0.0); // values <0 are not currently supported
-            bank.flash_loan_deposit_fee_rate = fee_rate;
+            bank.flash_loan_swap_fee_rate = fee_rate;
             require_group_admin = true;
         }
     }

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -37,7 +37,7 @@ pub fn token_register(
     reduce_only: u8,
     token_conditional_swap_taker_fee_rate: f32,
     token_conditional_swap_maker_fee_rate: f32,
-    flash_loan_deposit_fee_rate: f32,
+    flash_loan_swap_fee_rate: f32,
 ) -> Result<()> {
     // Require token 0 to be in the insurance token
     if token_index == INSURANCE_TOKEN_INDEX {
@@ -107,7 +107,7 @@ pub fn token_register(
         fees_withdrawn: 0,
         token_conditional_swap_taker_fee_rate,
         token_conditional_swap_maker_fee_rate,
-        flash_loan_deposit_fee_rate,
+        flash_loan_swap_fee_rate: flash_loan_swap_fee_rate,
         reserved: [0; 2092],
     };
 

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -79,7 +79,7 @@ pub fn token_register_trustless(
         fees_withdrawn: 0,
         token_conditional_swap_taker_fee_rate: 0.0005,
         token_conditional_swap_maker_fee_rate: 0.0005,
-        flash_loan_deposit_fee_rate: 0.0005,
+        flash_loan_swap_fee_rate: 0.0005,
         reserved: [0; 2092],
     };
     require_gt!(bank.max_rate, MINIMUM_MAX_RATE);

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -147,7 +147,7 @@ pub mod mango_v4 {
         reduce_only: u8,
         token_conditional_swap_taker_fee_rate: f32,
         token_conditional_swap_maker_fee_rate: f32,
-        flash_loan_deposit_fee_rate: f32,
+        flash_loan_swap_fee_rate: f32,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::token_register(
@@ -174,7 +174,7 @@ pub mod mango_v4 {
             reduce_only,
             token_conditional_swap_taker_fee_rate,
             token_conditional_swap_maker_fee_rate,
-            flash_loan_deposit_fee_rate,
+            flash_loan_swap_fee_rate,
         )?;
         Ok(())
     }
@@ -218,7 +218,7 @@ pub mod mango_v4 {
         force_close_opt: Option<bool>,
         token_conditional_swap_taker_fee_rate_opt: Option<f32>,
         token_conditional_swap_maker_fee_rate_opt: Option<f32>,
-        flash_loan_deposit_fee_rate_opt: Option<f32>,
+        flash_loan_swap_fee_rate_opt: Option<f32>,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::token_edit(
@@ -249,7 +249,7 @@ pub mod mango_v4 {
             force_close_opt,
             token_conditional_swap_taker_fee_rate_opt,
             token_conditional_swap_maker_fee_rate_opt,
-            flash_loan_deposit_fee_rate_opt,
+            flash_loan_swap_fee_rate_opt,
         )?;
         Ok(())
     }

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -80,6 +80,37 @@ pub struct FlashLoanTokenDetailV2 {
     pub borrow_index: i128,
     pub price: i128,
 
+    /// Deposit fee paid for positive change_amount.
+    ///
+    /// Not factored into change_amount.
+    pub deposit_fee: i128,
+
+    /// The amount that was transfered out to the user
+    pub approved_amount: u64,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize)]
+pub struct FlashLoanTokenDetailV3 {
+    pub token_index: u16,
+
+    /// The amount by which the user's token position changed at the end
+    ///
+    /// So if the user repaid the approved_amount in full, it'd be 0.
+    ///
+    /// Does NOT include the loan_origination_fee or deposit_fee, so the true
+    /// change is `change_amount - loan_origination_fee - deposit_fee`.
+    pub change_amount: i128,
+
+    /// The amount that was a loan (<= approved_amount, depends on user's deposits)
+    pub loan: i128,
+
+    /// The fee paid on the loan, not included in `loan` or `change_amount`
+    pub loan_origination_fee: i128,
+
+    pub deposit_index: i128,
+    pub borrow_index: i128,
+    pub price: i128,
+
     /// Swap fee paid on the in token of a swap.
     ///
     /// Not factored into change_amount.
@@ -102,6 +133,14 @@ pub struct FlashLoanLogV2 {
     pub mango_group: Pubkey,
     pub mango_account: Pubkey,
     pub token_loan_details: Vec<FlashLoanTokenDetailV2>,
+    pub flash_loan_type: FlashLoanType,
+}
+
+#[event]
+pub struct FlashLoanLogV3 {
+    pub mango_group: Pubkey,
+    pub mango_account: Pubkey,
+    pub token_loan_details: Vec<FlashLoanTokenDetailV3>,
     pub flash_loan_type: FlashLoanType,
 }
 

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -80,10 +80,10 @@ pub struct FlashLoanTokenDetailV2 {
     pub borrow_index: i128,
     pub price: i128,
 
-    /// Deposit fee paid for positive change_amount.
+    /// Swap fee paid on the in token of a swap.
     ///
     /// Not factored into change_amount.
-    pub deposit_fee: i128,
+    pub swap_fee: i128,
 
     /// The amount that was transfered out to the user
     pub approved_amount: u64,

--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -146,7 +146,7 @@ pub struct Bank {
     pub token_conditional_swap_taker_fee_rate: f32,
     pub token_conditional_swap_maker_fee_rate: f32,
 
-    pub flash_loan_deposit_fee_rate: f32,
+    pub flash_loan_swap_fee_rate: f32,
 
     #[derivative(Debug = "ignore")]
     pub reserved: [u8; 2092],
@@ -259,7 +259,7 @@ impl Bank {
             fees_withdrawn: 0,
             token_conditional_swap_taker_fee_rate: 0.0,
             token_conditional_swap_maker_fee_rate: 0.0,
-            flash_loan_deposit_fee_rate: 0.0,
+            flash_loan_swap_fee_rate: 0.0,
             reserved: [0; 2092],
         }
     }
@@ -285,7 +285,7 @@ impl Bank {
         require_gte!(2, self.reduce_only);
         require_gte!(self.token_conditional_swap_taker_fee_rate, 0.0);
         require_gte!(self.token_conditional_swap_maker_fee_rate, 0.0);
-        require_gte!(self.flash_loan_deposit_fee_rate, 0.0);
+        require_gte!(self.flash_loan_swap_fee_rate, 0.0);
         Ok(())
     }
 

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -996,7 +996,7 @@ impl ClientInstruction for TokenRegisterInstruction {
             reduce_only: 0,
             token_conditional_swap_taker_fee_rate: 0.0,
             token_conditional_swap_maker_fee_rate: 0.0,
-            flash_loan_deposit_fee_rate: 0.0,
+            flash_loan_swap_fee_rate: 0.0,
         };
 
         let bank = Pubkey::find_program_address(
@@ -1240,7 +1240,7 @@ pub fn token_edit_instruction_default() -> mango_v4::instruction::TokenEdit {
         force_close_opt: None,
         token_conditional_swap_taker_fee_rate_opt: None,
         token_conditional_swap_maker_fee_rate_opt: None,
-        flash_loan_deposit_fee_rate_opt: None,
+        flash_loan_swap_fee_rate_opt: None,
     }
 }
 

--- a/ts/client/scripts/create-gov-ix.ts
+++ b/ts/client/scripts/create-gov-ix.ts
@@ -152,7 +152,7 @@ async function tokenEdit(): Promise<void> {
       params.forceClose,
       params.tokenConditionalSwapTakerFeeRate,
       params.tokenConditionalSwapMakerFeeRate,
-      params.flashLoanDepositFeeRate,
+      params.flashLoanSwapFeeRate,
     )
     .accounts({
       group: group.publicKey,

--- a/ts/client/src/accounts/bank.ts
+++ b/ts/client/src/accounts/bank.ts
@@ -124,7 +124,7 @@ export class Bank implements BankForHealth {
       feesWithdrawn: BN;
       tokenConditionalSwapTakerFeeRate: number;
       tokenConditionalSwapMakerFeeRate: number;
-      flashLoanDepositFeeRate: number;
+      flashLoanSwapFeeRate: number;
     },
   ): Bank {
     return new Bank(
@@ -175,7 +175,7 @@ export class Bank implements BankForHealth {
       obj.feesWithdrawn,
       obj.tokenConditionalSwapTakerFeeRate,
       obj.tokenConditionalSwapMakerFeeRate,
-      obj.flashLoanDepositFeeRate,
+      obj.flashLoanSwapFeeRate,
     );
   }
 
@@ -227,7 +227,7 @@ export class Bank implements BankForHealth {
     public feesWithdrawn: BN,
     public tokenConditionalSwapTakerFeeRate: number,
     public tokenConditionalSwapMakerFeeRate: number,
-    public flashLoanDepositFeeRate: number,
+    public flashLoanSwapFeeRate: number,
   ) {
     this.name = utf8.decode(new Uint8Array(name)).split('\x00')[0];
     this.oracleConfig = {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -409,7 +409,7 @@ export class MangoClient {
         params.reduceOnly,
         params.tokenConditionalSwapTakerFeeRate,
         params.tokenConditionalSwapMakerFeeRate,
-        params.flashLoanDepositFeeRate,
+        params.flashLoanSwapFeeRate,
       )
       .accounts({
         group: group.publicKey,
@@ -484,7 +484,7 @@ export class MangoClient {
         params.forceClose,
         params.tokenConditionalSwapTakerFeeRate,
         params.tokenConditionalSwapMakerFeeRate,
-        params.flashLoanDepositFeeRate,
+        params.flashLoanSwapFeeRate,
       )
       .accounts({
         group: group.publicKey,

--- a/ts/client/src/clientIxParamBuilder.ts
+++ b/ts/client/src/clientIxParamBuilder.ts
@@ -24,7 +24,7 @@ export interface TokenRegisterParams {
   reduceOnly: number;
   tokenConditionalSwapTakerFeeRate: number;
   tokenConditionalSwapMakerFeeRate: number;
-  flashLoanDepositFeeRate: number;
+  flashLoanSwapFeeRate: number;
 }
 
 export const DefaultTokenRegisterParams: TokenRegisterParams = {
@@ -59,7 +59,7 @@ export const DefaultTokenRegisterParams: TokenRegisterParams = {
   reduceOnly: 0,
   tokenConditionalSwapTakerFeeRate: 0.0005,
   tokenConditionalSwapMakerFeeRate: 0.0005,
-  flashLoanDepositFeeRate: 0.0005,
+  flashLoanSwapFeeRate: 0.0005,
 };
 
 export interface TokenEditParams {
@@ -89,7 +89,7 @@ export interface TokenEditParams {
   forceClose: boolean | null;
   tokenConditionalSwapTakerFeeRate: number | null;
   tokenConditionalSwapMakerFeeRate: number | null;
-  flashLoanDepositFeeRate: number | null;
+  flashLoanSwapFeeRate: number | null;
 }
 
 export const NullTokenEditParams: TokenEditParams = {
@@ -119,7 +119,7 @@ export const NullTokenEditParams: TokenEditParams = {
   forceClose: null,
   tokenConditionalSwapTakerFeeRate: null,
   tokenConditionalSwapMakerFeeRate: null,
-  flashLoanDepositFeeRate: null,
+  flashLoanSwapFeeRate: null,
 };
 
 export interface PerpEditParams {

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -8343,6 +8343,72 @@ export type MangoV4 = {
             "type": "i128"
           },
           {
+            "name": "depositFee",
+            "docs": [
+              "Deposit fee paid for positive change_amount.",
+              "",
+              "Not factored into change_amount."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "approvedAmount",
+            "docs": [
+              "The amount that was transfered out to the user"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FlashLoanTokenDetailV3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenIndex",
+            "type": "u16"
+          },
+          {
+            "name": "changeAmount",
+            "docs": [
+              "The amount by which the user's token position changed at the end",
+              "",
+              "So if the user repaid the approved_amount in full, it'd be 0.",
+              "",
+              "Does NOT include the loan_origination_fee or deposit_fee, so the true",
+              "change is `change_amount - loan_origination_fee - deposit_fee`."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loan",
+            "docs": [
+              "The amount that was a loan (<= approved_amount, depends on user's deposits)"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loanOriginationFee",
+            "docs": [
+              "The fee paid on the loan, not included in `loan` or `change_amount`"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "depositIndex",
+            "type": "i128"
+          },
+          {
+            "name": "borrowIndex",
+            "type": "i128"
+          },
+          {
+            "name": "price",
+            "type": "i128"
+          },
+          {
             "name": "swapFee",
             "docs": [
               "Swap fee paid on the in token of a swap.",
@@ -10653,6 +10719,37 @@ export type MangoV4 = {
           "type": {
             "vec": {
               "defined": "FlashLoanTokenDetailV2"
+            }
+          },
+          "index": false
+        },
+        {
+          "name": "flashLoanType",
+          "type": {
+            "defined": "FlashLoanType"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FlashLoanLogV3",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "mangoAccount",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "tokenLoanDetails",
+          "type": {
+            "vec": {
+              "defined": "FlashLoanTokenDetailV3"
             }
           },
           "index": false
@@ -21349,6 +21446,72 @@ export const IDL: MangoV4 = {
             "type": "i128"
           },
           {
+            "name": "depositFee",
+            "docs": [
+              "Deposit fee paid for positive change_amount.",
+              "",
+              "Not factored into change_amount."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "approvedAmount",
+            "docs": [
+              "The amount that was transfered out to the user"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FlashLoanTokenDetailV3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tokenIndex",
+            "type": "u16"
+          },
+          {
+            "name": "changeAmount",
+            "docs": [
+              "The amount by which the user's token position changed at the end",
+              "",
+              "So if the user repaid the approved_amount in full, it'd be 0.",
+              "",
+              "Does NOT include the loan_origination_fee or deposit_fee, so the true",
+              "change is `change_amount - loan_origination_fee - deposit_fee`."
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loan",
+            "docs": [
+              "The amount that was a loan (<= approved_amount, depends on user's deposits)"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "loanOriginationFee",
+            "docs": [
+              "The fee paid on the loan, not included in `loan` or `change_amount`"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "depositIndex",
+            "type": "i128"
+          },
+          {
+            "name": "borrowIndex",
+            "type": "i128"
+          },
+          {
+            "name": "price",
+            "type": "i128"
+          },
+          {
             "name": "swapFee",
             "docs": [
               "Swap fee paid on the in token of a swap.",
@@ -23659,6 +23822,37 @@ export const IDL: MangoV4 = {
           "type": {
             "vec": {
               "defined": "FlashLoanTokenDetailV2"
+            }
+          },
+          "index": false
+        },
+        {
+          "name": "flashLoanType",
+          "type": {
+            "defined": "FlashLoanType"
+          },
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "FlashLoanLogV3",
+      "fields": [
+        {
+          "name": "mangoGroup",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "mangoAccount",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "tokenLoanDetails",
+          "type": {
+            "vec": {
+              "defined": "FlashLoanTokenDetailV3"
             }
           },
           "index": false

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -594,7 +594,7 @@ export type MangoV4 = {
           "type": "f32"
         },
         {
-          "name": "flashLoanDepositFeeRate",
+          "name": "flashLoanSwapFeeRate",
           "type": "f32"
         }
       ]
@@ -926,7 +926,7 @@ export type MangoV4 = {
           }
         },
         {
-          "name": "flashLoanDepositFeeRateOpt",
+          "name": "flashLoanSwapFeeRateOpt",
           "type": {
             "option": "f32"
           }
@@ -7030,7 +7030,7 @@ export type MangoV4 = {
             "type": "f32"
           },
           {
-            "name": "flashLoanDepositFeeRate",
+            "name": "flashLoanSwapFeeRate",
             "type": "f32"
           },
           {
@@ -8343,9 +8343,9 @@ export type MangoV4 = {
             "type": "i128"
           },
           {
-            "name": "depositFee",
+            "name": "swapFee",
             "docs": [
-              "Deposit fee paid for positive change_amount.",
+              "Swap fee paid on the in token of a swap.",
               "",
               "Not factored into change_amount."
             ],
@@ -13600,7 +13600,7 @@ export const IDL: MangoV4 = {
           "type": "f32"
         },
         {
-          "name": "flashLoanDepositFeeRate",
+          "name": "flashLoanSwapFeeRate",
           "type": "f32"
         }
       ]
@@ -13932,7 +13932,7 @@ export const IDL: MangoV4 = {
           }
         },
         {
-          "name": "flashLoanDepositFeeRateOpt",
+          "name": "flashLoanSwapFeeRateOpt",
           "type": {
             "option": "f32"
           }
@@ -20036,7 +20036,7 @@ export const IDL: MangoV4 = {
             "type": "f32"
           },
           {
-            "name": "flashLoanDepositFeeRate",
+            "name": "flashLoanSwapFeeRate",
             "type": "f32"
           },
           {
@@ -21349,9 +21349,9 @@ export const IDL: MangoV4 = {
             "type": "i128"
           },
           {
-            "name": "depositFee",
+            "name": "swapFee",
             "docs": [
-              "Deposit fee paid for positive change_amount.",
+              "Swap fee paid on the in token of a swap.",
               "",
               "Not factored into change_amount."
             ],


### PR DESCRIPTION
Which applies to the in token amount of swaps only.

Charging a deposit fee on flash loans was a bad idea:
- It incentivizes flash loan users to make the deposit a separate instruction, defeating the purpose.
- For swaps, it makes traders pay a loan origination fee in in-token and a deposit fee in out-token, leading to more complex bookkeeping and ui display.

Instead, charge a fee on the in-token for all flash loans explicitly marked as swaps only.