### PR TITLE
Group: Limit fast-listing tokens per week

### DIFF
--- a/mango_v4.json
+++ b/mango_v4.json
@@ -271,6 +271,12 @@
           "type": {
             "option": "u64"
           }
+        },
+        {
+          "name": "allowedFastListingsPerIntervalOpt",
+          "type": {
+            "option": "u16"
+          }
         }
       ]
     },
@@ -604,7 +610,7 @@
       "accounts": [
         {
           "name": "group",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -7145,11 +7151,27 @@
             "type": "u64"
           },
           {
+            "name": "fastListingIntervalStart",
+            "docs": [
+              "Fast-listings are limited per week, this is the start of the current fast-listing interval",
+              "in seconds since epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fastListingsInInterval",
+            "type": "u16"
+          },
+          {
+            "name": "allowedFastListingsPerInterval",
+            "type": "u16"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                1824
+                1812
               ]
             }
           }

--- a/programs/mango-v4/src/accounts_ix/token_register_trustless.rs
+++ b/programs/mango-v4/src/accounts_ix/token_register_trustless.rs
@@ -9,7 +9,8 @@ const FIRST_BANK_NUM: u32 = 0;
 #[instruction(token_index: TokenIndex)]
 pub struct TokenRegisterTrustless<'info> {
     #[account(
-        constraint = group.load()?.admin == admin.key() || group.load()?.fast_listing_admin == admin.key() ,
+        mut,
+        constraint = group.load()?.admin == admin.key() || group.load()?.fast_listing_admin == admin.key(),
         constraint = group.load()?.is_ix_enabled(IxGate::TokenRegisterTrustless) @ MangoError::IxIsDisabled,
     )]
     pub group: AccountLoader<'info, Group>,

--- a/programs/mango-v4/src/instructions/group_edit.rs
+++ b/programs/mango-v4/src/instructions/group_edit.rs
@@ -18,6 +18,7 @@ pub fn group_edit(
     buyback_fees_swap_mango_account_opt: Option<Pubkey>,
     mngo_token_index_opt: Option<TokenIndex>,
     buyback_fees_expiry_interval_opt: Option<u64>,
+    allowed_fast_listings_per_interval_opt: Option<u16>,
 ) -> Result<()> {
     let mut group = ctx.accounts.group.load_mut()?;
 
@@ -104,6 +105,15 @@ pub fn group_edit(
             buyback_fees_expiry_interval
         );
         group.buyback_fees_expiry_interval = buyback_fees_expiry_interval;
+    }
+
+    if let Some(allowed_fast_listings_per_interval) = allowed_fast_listings_per_interval_opt {
+        msg!(
+            "Allowed fast listings per week old {:?}, new {:?}",
+            group.allowed_fast_listings_per_interval,
+            allowed_fast_listings_per_interval
+        );
+        group.allowed_fast_listings_per_interval = allowed_fast_listings_per_interval;
     }
 
     Ok(())

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -82,6 +82,7 @@ pub mod mango_v4 {
         buyback_fees_swap_mango_account_opt: Option<Pubkey>,
         mngo_token_index_opt: Option<TokenIndex>,
         buyback_fees_expiry_interval_opt: Option<u64>,
+        allowed_fast_listings_per_interval_opt: Option<u16>,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::group_edit(
@@ -97,6 +98,7 @@ pub mod mango_v4 {
             buyback_fees_swap_mango_account_opt,
             mngo_token_index_opt,
             buyback_fees_expiry_interval_opt,
+            allowed_fast_listings_per_interval_opt,
         )?;
         Ok(())
     }

--- a/programs/mango-v4/src/state/group.rs
+++ b/programs/mango-v4/src/state/group.rs
@@ -88,11 +88,18 @@ pub struct Group {
     /// When set to 0, there's no expiry of buyback fees.
     pub buyback_fees_expiry_interval: u64,
 
-    pub reserved: [u8; 1824],
+    /// Fast-listings are limited per week, this is the start of the current fast-listing interval
+    /// in seconds since epoch
+    pub fast_listing_interval_start: u64,
+
+    pub fast_listings_in_interval: u16,
+    pub allowed_fast_listings_per_interval: u16,
+
+    pub reserved: [u8; 1812],
 }
 const_assert_eq!(
     size_of::<Group>(),
-    32 + 4 + 32 * 2 + 4 + 32 * 2 + 4 + 4 + 20 * 32 + 32 + 8 + 16 + 32 + 8 + 1824
+    32 + 4 + 32 * 2 + 4 + 32 * 2 + 4 + 4 + 20 * 32 + 32 + 8 + 16 + 32 + 8 + 8 + 2 * 2 + 1812
 );
 const_assert_eq!(size_of::<Group>(), 2736);
 const_assert_eq!(size_of::<Group>() % 8, 0);

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -1787,6 +1787,7 @@ pub fn group_edit_instruction_default() -> mango_v4::instruction::GroupEdit {
         buyback_fees_swap_mango_account_opt: None,
         mngo_token_index_opt: None,
         buyback_fees_expiry_interval_opt: None,
+        allowed_fast_listings_per_interval_opt: None,
     }
 }
 

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -261,6 +261,7 @@ export class MangoClient {
     feesSwapMangoAccount?: PublicKey,
     feesMngoTokenIndex?: TokenIndex,
     feesExpiryInterval?: BN,
+    allowedFastListingsPerInterval?: number,
   ): Promise<MangoSignatureStatus> {
     const ix = await this.program.methods
       .groupEdit(
@@ -275,6 +276,7 @@ export class MangoClient {
         feesSwapMangoAccount ?? null,
         feesMngoTokenIndex ?? null,
         feesExpiryInterval ?? null,
+        allowedFastListingsPerInterval ?? null,
       )
       .accounts({
         group: group.publicKey,

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -271,6 +271,12 @@ export type MangoV4 = {
           "type": {
             "option": "u64"
           }
+        },
+        {
+          "name": "allowedFastListingsPerIntervalOpt",
+          "type": {
+            "option": "u16"
+          }
         }
       ]
     },
@@ -604,7 +610,7 @@ export type MangoV4 = {
       "accounts": [
         {
           "name": "group",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -7145,11 +7151,27 @@ export type MangoV4 = {
             "type": "u64"
           },
           {
+            "name": "fastListingIntervalStart",
+            "docs": [
+              "Fast-listings are limited per week, this is the start of the current fast-listing interval",
+              "in seconds since epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fastListingsInInterval",
+            "type": "u16"
+          },
+          {
+            "name": "allowedFastListingsPerInterval",
+            "type": "u16"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                1824
+                1812
               ]
             }
           }
@@ -13374,6 +13396,12 @@ export const IDL: MangoV4 = {
           "type": {
             "option": "u64"
           }
+        },
+        {
+          "name": "allowedFastListingsPerIntervalOpt",
+          "type": {
+            "option": "u16"
+          }
         }
       ]
     },
@@ -13707,7 +13735,7 @@ export const IDL: MangoV4 = {
       "accounts": [
         {
           "name": "group",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {
@@ -20248,11 +20276,27 @@ export const IDL: MangoV4 = {
             "type": "u64"
           },
           {
+            "name": "fastListingIntervalStart",
+            "docs": [
+              "Fast-listings are limited per week, this is the start of the current fast-listing interval",
+              "in seconds since epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fastListingsInInterval",
+            "type": "u16"
+          },
+          {
+            "name": "allowedFastListingsPerInterval",
+            "type": "u16"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                1824
+                1812
               ]
             }
           }


### PR DESCRIPTION
To avoid potential abuse of fast listing while even when the dao is unresponsive.