### PR TITLE
rust client: ix cu limits based on health compute cost

### DIFF
--- a/bin/liquidator/src/trigger_tcs.rs
+++ b/bin/liquidator/src/trigger_tcs.rs
@@ -1122,7 +1122,7 @@ impl Context {
         };
 
         let liqee = self.account_fetcher.fetch_mango_account(&pending.pubkey)?;
-        let trigger_ix = self
+        let mut trigger_ixs = self
             .mango_client
             .token_conditional_swap_trigger_instruction(
                 (&pending.pubkey, &liqee),
@@ -1134,7 +1134,9 @@ impl Context {
                 &allowed_tokens,
             )
             .await?;
-        tx_builder.instructions.push(trigger_ix);
+        tx_builder
+            .instructions
+            .append(&mut trigger_ixs.instructions);
 
         let txsig = tx_builder
             .send_and_confirm(&self.mango_client.client)

--- a/lib/client/src/health_cache.rs
+++ b/lib/client/src/health_cache.rs
@@ -13,7 +13,7 @@ pub async fn new(
     let active_token_len = account.active_token_positions().count();
     let active_perp_len = account.active_perp_positions().count();
 
-    let metas =
+    let (metas, _health_cu) =
         context.derive_health_check_remaining_account_metas(account, vec![], vec![], vec![])?;
     let accounts: anyhow::Result<Vec<KeyedAccountSharedData>> = stream::iter(metas.iter())
         .then(|meta| async {
@@ -44,7 +44,7 @@ pub fn new_sync(
     let active_token_len = account.active_token_positions().count();
     let active_perp_len = account.active_perp_positions().count();
 
-    let metas =
+    let (metas, _health_cu) =
         context.derive_health_check_remaining_account_metas(account, vec![], vec![], vec![])?;
     let accounts = metas
         .iter()

--- a/lib/client/src/jupiter/v4.rs
+++ b/lib/client/src/jupiter/v4.rs
@@ -249,7 +249,7 @@ impl<'a> JupiterV4<'a> {
         let num_loans: u8 = loan_amounts.len().try_into().unwrap();
 
         // This relies on the fact that health account banks will be identical to the first_bank above!
-        let health_ams = self
+        let (health_ams, _health_cu) = self
             .mango_client
             .derive_health_check_remaining_account_metas(
                 vec![source_token.token_index, target_token.token_index],

--- a/lib/client/src/jupiter/v6.rs
+++ b/lib/client/src/jupiter/v6.rs
@@ -256,7 +256,7 @@ impl<'a> JupiterV6<'a> {
         let num_loans: u8 = loan_amounts.len().try_into().unwrap();
 
         // This relies on the fact that health account banks will be identical to the first_bank above!
-        let health_ams = self
+        let (health_ams, _health_cu) = self
             .mango_client
             .derive_health_check_remaining_account_metas(
                 vec![source_token.token_index, target_token.token_index],

--- a/programs/mango-v4/tests/cases/test_perp.rs
+++ b/programs/mango-v4/tests/cases/test_perp.rs
@@ -217,6 +217,7 @@ async fn test_perp_fixed() -> Result<(), TransportError> {
             account: account_0,
             perp_market,
             owner,
+            limit: 10,
         },
     )
     .await
@@ -268,6 +269,7 @@ async fn test_perp_fixed() -> Result<(), TransportError> {
             account: account_0,
             perp_market,
             owner,
+            limit: 10,
         },
     )
     .await
@@ -1208,6 +1210,231 @@ async fn test_perp_reducing_when_liquidatable() -> Result<(), TransportError> {
     )
     .await;
     assert!(err.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_perp_compute() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+    let solana = &context.solana.clone();
+
+    let admin = TestKeypair::new();
+    let owner = context.users[0].key;
+    let payer = context.users[1].key;
+    let mints = &context.mints[0..2];
+
+    //
+    // SETUP: Create a group and an account
+    //
+
+    let GroupWithTokens { group, tokens, .. } = GroupWithTokensConfig {
+        admin,
+        payer,
+        mints: mints.to_vec(),
+        ..GroupWithTokensConfig::default()
+    }
+    .create(solana)
+    .await;
+
+    let deposit_amount = 100_000;
+    let account_0 = create_funded_account(
+        &solana,
+        group,
+        owner,
+        0,
+        &context.users[1],
+        mints,
+        deposit_amount,
+        0,
+    )
+    .await;
+    let account_1 = create_funded_account(
+        &solana,
+        group,
+        owner,
+        1,
+        &context.users[1],
+        mints,
+        deposit_amount,
+        0,
+    )
+    .await;
+
+    //
+    // TEST: Create a perp market
+    //
+    let mango_v4::accounts::PerpCreateMarket { perp_market, .. } = send_tx(
+        solana,
+        PerpCreateMarketInstruction {
+            group,
+            admin,
+            payer,
+            perp_market_index: 0,
+            quote_lot_size: 10,
+            base_lot_size: 100,
+            maint_base_asset_weight: 0.975,
+            init_base_asset_weight: 0.95,
+            maint_base_liab_weight: 1.025,
+            init_base_liab_weight: 1.05,
+            base_liquidation_fee: 0.012,
+            maker_fee: 0.0000,
+            taker_fee: 0.0000,
+            settle_pnl_limit_factor: -1.0,
+            settle_pnl_limit_window_size_ts: 24 * 60 * 60,
+            ..PerpCreateMarketInstruction::with_new_book_and_queue(&solana, &tokens[1]).await
+        },
+    )
+    .await
+    .unwrap();
+
+    let perp_market_data = solana.get_account::<PerpMarket>(perp_market).await;
+    let price_lots = perp_market_data.native_price_to_lot(I80F48::from(1000));
+    set_perp_stub_oracle_price(solana, group, perp_market, &tokens[1], admin, 1000.0).await;
+
+    //
+    // TEST: check compute per order match
+    //
+
+    for limit in 1..6 {
+        for bid in price_lots..price_lots + 6 {
+            send_tx(
+                solana,
+                PerpPlaceOrderInstruction {
+                    account: account_0,
+                    perp_market,
+                    owner,
+                    side: Side::Bid,
+                    price_lots: bid,
+                    max_base_lots: 1,
+                    client_order_id: 5,
+                    ..PerpPlaceOrderInstruction::default()
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let result = send_tx_get_metadata(
+            solana,
+            PerpPlaceOrderInstruction {
+                account: account_1,
+                perp_market,
+                owner,
+                side: Side::Ask,
+                price_lots,
+                max_base_lots: 10,
+                client_order_id: 6,
+                limit,
+                ..PerpPlaceOrderInstruction::default()
+            },
+        )
+        .await
+        .unwrap();
+        println!(
+            "CU for perp_place_order matching {limit} orders in sequence: {}",
+            result.metadata.unwrap().compute_units_consumed
+        );
+
+        send_tx(
+            solana,
+            PerpCancelAllOrdersInstruction {
+                account: account_0,
+                perp_market,
+                owner,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        send_tx(
+            solana,
+            PerpCancelAllOrdersInstruction {
+                account: account_1,
+                perp_market,
+                owner,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+
+        send_tx(
+            solana,
+            PerpConsumeEventsInstruction {
+                perp_market,
+                mango_accounts: vec![account_0, account_1],
+            },
+        )
+        .await
+        .unwrap();
+        send_tx(
+            solana,
+            PerpConsumeEventsInstruction {
+                perp_market,
+                mango_accounts: vec![account_0, account_1],
+            },
+        )
+        .await
+        .unwrap();
+        send_tx(
+            solana,
+            PerpConsumeEventsInstruction {
+                perp_market,
+                mango_accounts: vec![account_0, account_1],
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    //
+    // TEST: check compute per order cancel
+    //
+
+    for count in 1..6 {
+        for bid in price_lots..price_lots + count {
+            send_tx(
+                solana,
+                PerpPlaceOrderInstruction {
+                    account: account_0,
+                    perp_market,
+                    owner,
+                    side: Side::Bid,
+                    price_lots: bid,
+                    max_base_lots: 1,
+                    client_order_id: 5,
+                    ..PerpPlaceOrderInstruction::default()
+                },
+            )
+            .await
+            .unwrap();
+        }
+        let result = send_tx_get_metadata(
+            solana,
+            PerpCancelAllOrdersInstruction {
+                account: account_0,
+                perp_market,
+                owner,
+                limit: 10,
+            },
+        )
+        .await
+        .unwrap();
+        println!(
+            "CU for perp_cancel_all_orders matching {count} orders: {}",
+            result.metadata.unwrap().compute_units_consumed
+        );
+
+        send_tx(
+            solana,
+            PerpConsumeEventsInstruction {
+                perp_market,
+                mango_accounts: vec![account_0],
+            },
+        )
+        .await
+        .unwrap();
+    }
 
     Ok(())
 }

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -3506,6 +3506,7 @@ pub struct PerpPlaceOrderInstruction {
     pub reduce_only: bool,
     pub client_order_id: u64,
     pub self_trade_behavior: SelfTradeBehavior,
+    pub limit: u8,
 }
 impl Default for PerpPlaceOrderInstruction {
     fn default() -> Self {
@@ -3520,6 +3521,7 @@ impl Default for PerpPlaceOrderInstruction {
             reduce_only: false,
             client_order_id: 0,
             self_trade_behavior: SelfTradeBehavior::DecrementTake,
+            limit: 10,
         }
     }
 }
@@ -3542,7 +3544,7 @@ impl ClientInstruction for PerpPlaceOrderInstruction {
             self_trade_behavior: self.self_trade_behavior,
             reduce_only: self.reduce_only,
             expiry_timestamp: 0,
-            limit: 10,
+            limit: self.limit,
         };
 
         let perp_market: PerpMarket = account_loader.load(&self.perp_market).await.unwrap();
@@ -3728,6 +3730,7 @@ pub struct PerpCancelAllOrdersInstruction {
     pub account: Pubkey,
     pub perp_market: Pubkey,
     pub owner: TestKeypair,
+    pub limit: u8,
 }
 #[async_trait::async_trait(?Send)]
 impl ClientInstruction for PerpCancelAllOrdersInstruction {
@@ -3738,7 +3741,7 @@ impl ClientInstruction for PerpCancelAllOrdersInstruction {
         account_loader: impl ClientAccountLoader + 'async_trait,
     ) -> (Self::Accounts, instruction::Instruction) {
         let program_id = mango_v4::id();
-        let instruction = Self::Instruction { limit: 5 };
+        let instruction = Self::Instruction { limit: self.limit };
         let perp_market: PerpMarket = account_loader.load(&self.perp_market).await.unwrap();
         let accounts = Self::Accounts {
             group: perp_market.group,


### PR DESCRIPTION
Many instructions now return PreparedInstructions instead of a direct Instruction or Vec<Instruction>. That way they can keep track of the expected cu cost of the instructions for the compute limit instruction that gets added once all instructions are made.