### PR TITLE
Bank: allow maint weights to change over time

### DIFF
--- a/programs/mango-v4/src/health/cache.rs
+++ b/programs/mango-v4/src/health/cache.rs
@@ -94,9 +94,10 @@ pub fn compute_health_from_fixed_accounts(
     account: &MangoAccountRef,
     health_type: HealthType,
     ais: &[AccountInfo],
+    now_ts: u64,
 ) -> Result<I80F48> {
     let retriever = new_fixed_order_account_retriever(ais, account)?;
-    Ok(new_health_cache(account, &retriever)?.health(health_type))
+    Ok(new_health_cache(account, &retriever, now_ts)?.health(health_type))
 }
 
 /// Compute health with an arbitrary AccountRetriever
@@ -104,8 +105,9 @@ pub fn compute_health(
     account: &MangoAccountRef,
     health_type: HealthType,
     retriever: &impl AccountRetriever,
+    now_ts: u64,
 ) -> Result<I80F48> {
-    Ok(new_health_cache(account, retriever)?.health(health_type))
+    Ok(new_health_cache(account, retriever, now_ts)?.health(health_type))
 }
 
 /// How much of a token can be taken away before health decreases to zero?
@@ -1221,8 +1223,9 @@ pub(crate) fn find_token_info_index(infos: &[TokenInfo], token_index: TokenIndex
 pub fn new_health_cache(
     account: &MangoAccountRef,
     retriever: &impl AccountRetriever,
+    now_ts: u64,
 ) -> Result<HealthCache> {
-    new_health_cache_impl(account, retriever, false)
+    new_health_cache_impl(account, retriever, now_ts, false)
 }
 
 /// Generate a special HealthCache for an account and its health accounts
@@ -1233,13 +1236,15 @@ pub fn new_health_cache(
 pub fn new_health_cache_skipping_bad_oracles(
     account: &MangoAccountRef,
     retriever: &impl AccountRetriever,
+    now_ts: u64,
 ) -> Result<HealthCache> {
-    new_health_cache_impl(account, retriever, true)
+    new_health_cache_impl(account, retriever, now_ts, true)
 }
 
 fn new_health_cache_impl(
     account: &MangoAccountRef,
     retriever: &impl AccountRetriever,
+    now_ts: u64,
     // If an oracle is stale or inconfident and the health contribution would
     // not be negative, skip it. This decreases health, but maybe overall it's
     // still positive?
@@ -1268,12 +1273,15 @@ fn new_health_cache_impl(
         // Use the liab price for computing weight scaling, because it's pessimistic and
         // causes the most unfavorable scaling.
         let liab_price = prices.liab(HealthType::Init);
+
+        let (maint_asset_weight, maint_liab_weight) = bank.maint_weights(now_ts);
+
         token_infos.push(TokenInfo {
             token_index: bank.token_index,
-            maint_asset_weight: bank.maint_asset_weight,
+            maint_asset_weight,
             init_asset_weight: bank.init_asset_weight,
             init_scaled_asset_weight: bank.scaled_init_asset_weight(liab_price),
-            maint_liab_weight: bank.maint_liab_weight,
+            maint_liab_weight,
             init_liab_weight: bank.init_liab_weight,
             init_scaled_liab_weight: bank.scaled_init_liab_weight(liab_price),
             prices,
@@ -1443,7 +1451,7 @@ mod tests {
         // for bank2/oracle2
         let health2 = (-10.0 + 3.0) * 5.0 * 1.5;
         assert!(health_eq(
-            compute_health(&account.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             health1 + health2
         ));
     }
@@ -1568,7 +1576,7 @@ mod tests {
         let retriever = ScanningAccountRetriever::new_with_staleness(&ais, &group, None).unwrap();
 
         assert!(health_eq(
-            compute_health(&account.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             testcase.expected_health
         ));
     }

--- a/programs/mango-v4/src/health/client.rs
+++ b/programs/mango-v4/src/health/client.rs
@@ -1264,7 +1264,7 @@ mod tests {
         let retriever = ScanningAccountRetriever::new_with_staleness(&ais, &group, None).unwrap();
 
         assert!(health_eq(
-            compute_health(&account.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             // token
             0.8 * (100.0
             // perp base
@@ -1353,27 +1353,27 @@ mod tests {
         let retriever = ScanningAccountRetriever::new_with_staleness(&ais, &group, None).unwrap();
 
         assert!(health_eq(
-            compute_health(&account.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             0.8 * 0.5 * 100.0
         ));
         assert!(health_eq(
-            compute_health(&account.borrow(), HealthType::Maint, &retriever).unwrap(),
+            compute_health(&account.borrow(), HealthType::Maint, &retriever, 0).unwrap(),
             0.9 * 1.0 * 100.0
         ));
         assert!(health_eq(
-            compute_health(&account2.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account2.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             -1.2 * 1.0 * 100.0
         ));
         assert!(health_eq(
-            compute_health(&account2.borrow(), HealthType::Maint, &retriever).unwrap(),
+            compute_health(&account2.borrow(), HealthType::Maint, &retriever, 0).unwrap(),
             -1.1 * 1.0 * 100.0
         ));
         assert!(health_eq(
-            compute_health(&account3.borrow(), HealthType::Init, &retriever).unwrap(),
+            compute_health(&account3.borrow(), HealthType::Init, &retriever, 0).unwrap(),
             1.2 * (0.8 * 0.5 * 10.0 * 10.0 - 100.0)
         ));
         assert!(health_eq(
-            compute_health(&account3.borrow(), HealthType::Maint, &retriever).unwrap(),
+            compute_health(&account3.borrow(), HealthType::Maint, &retriever, 0).unwrap(),
             1.1 * (0.9 * 1.0 * 10.0 * 10.0 - 100.0)
         ));
     }

--- a/programs/mango-v4/src/instructions/compute_account_data.rs
+++ b/programs/mango-v4/src/instructions/compute_account_data.rs
@@ -13,7 +13,8 @@ pub fn compute_account_data(ctx: Context<ComputeAccountData>) -> Result<()> {
 
     let account_retriever = ScanningAccountRetriever::new(ctx.remaining_accounts, &group_pk)?;
 
-    let health_cache = new_health_cache(&account.borrow(), &account_retriever)?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let health_cache = new_health_cache(&account.borrow(), &account_retriever, now_ts)?;
     let init_health = health_cache.health(HealthType::Init);
     let maint_health = health_cache.health(HealthType::Maint);
 

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -388,7 +388,8 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
 
     // Check health before balance adjustments
     let retriever = new_fixed_order_account_retriever(health_ais, &account.borrow())?;
-    let health_cache = new_health_cache(&account.borrow(), &retriever)?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let health_cache = new_health_cache(&account.borrow(), &retriever, now_ts)?;
     let pre_init_health = account.check_health_pre(&health_cache)?;
 
     // Prices for logging and net borrow checks
@@ -500,7 +501,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
 
     // Check health after account position changes
     let retriever = new_fixed_order_account_retriever(health_ais, &account.borrow())?;
-    let health_cache = new_health_cache(&account.borrow(), &retriever)?;
+    let health_cache = new_health_cache(&account.borrow(), &retriever, now_ts)?;
     account.check_health_post(&health_cache, pre_init_health)?;
 
     // Deactivate inactive token accounts after health check

--- a/programs/mango-v4/src/instructions/health_region.rs
+++ b/programs/mango-v4/src/instructions/health_region.rs
@@ -87,7 +87,8 @@ pub fn health_region_begin<'key, 'accounts, 'remaining, 'info>(
         .context("create account retriever")?;
 
     // Compute pre-health and store it on the account
-    let health_cache = new_health_cache(&account.borrow(), &account_retriever)?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let health_cache = new_health_cache(&account.borrow(), &account_retriever, now_ts)?;
     let pre_init_health = account.check_health_pre(&health_cache)?;
     account.fixed.health_region_begin_init_health = pre_init_health.ceil().to_num();
 
@@ -107,7 +108,8 @@ pub fn health_region_end<'key, 'accounts, 'remaining, 'info>(
     let group = account.fixed.group;
     let account_retriever = ScanningAccountRetriever::new(ctx.remaining_accounts, &group)
         .context("create account retriever")?;
-    let health_cache = new_health_cache(&account.borrow(), &account_retriever)?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let health_cache = new_health_cache(&account.borrow(), &account_retriever, now_ts)?;
 
     let pre_init_health = I80F48::from(account.fixed.health_region_begin_init_health);
     account.check_health_post(&health_cache, pre_init_health)?;

--- a/programs/mango-v4/src/instructions/perp_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_force_cancel_orders.rs
@@ -11,10 +11,11 @@ pub fn perp_liq_force_cancel_orders(
 ) -> Result<()> {
     let mut account = ctx.accounts.account.load_full_mut()?;
 
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
     let mut health_cache = {
         let retriever =
             new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-        new_health_cache(&account.borrow(), &retriever).context("create health cache")?
+        new_health_cache(&account.borrow(), &retriever, now_ts).context("create health cache")?
     };
 
     let mut perp_market = ctx.accounts.perp_market.load_mut()?;

--- a/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
@@ -71,7 +71,7 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
 
     let retriever = ScanningAccountRetriever::new(ctx.remaining_accounts, &mango_group)
         .context("create account retriever")?;
-    let mut liqee_health_cache = new_health_cache(&liqee.borrow(), &retriever)?;
+    let mut liqee_health_cache = new_health_cache(&liqee.borrow(), &retriever, now_ts)?;
     drop(retriever);
     let liqee_liq_end_health = liqee_health_cache.health(HealthType::LiquidationEnd);
 
@@ -197,8 +197,13 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
     if !liqor.fixed.is_in_health_region() {
         let account_retriever =
             ScanningAccountRetriever::new(ctx.remaining_accounts, &mango_group)?;
-        let liqor_health = compute_health(&liqor.borrow(), HealthType::Init, &account_retriever)
-            .context("compute liqor health")?;
+        let liqor_health = compute_health(
+            &liqor.borrow(),
+            HealthType::Init,
+            &account_retriever,
+            now_ts,
+        )
+        .context("compute liqor health")?;
         require!(liqor_health >= 0, MangoError::HealthMustBePositive);
     }
 
@@ -509,7 +514,7 @@ mod tests {
                     ScanningAccountRetriever::new_with_staleness(&ais, &setup.group, None).unwrap();
 
                 liqee_health_cache =
-                    health::new_health_cache(&setup.liqee.borrow(), &retriever).unwrap();
+                    health::new_health_cache(&setup.liqee.borrow(), &retriever, 0).unwrap();
                 liqee_liq_end_health = liqee_health_cache.health(HealthType::LiquidationEnd);
             }
 

--- a/programs/mango-v4/src/instructions/perp_place_order.rs
+++ b/programs/mango-v4/src/instructions/perp_place_order.rs
@@ -67,8 +67,8 @@ pub fn perp_place_order(
     let pre_health_opt = if !account.fixed.is_in_health_region() {
         let retriever =
             new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-        let health_cache =
-            new_health_cache(&account.borrow(), &retriever).context("pre-withdraw init health")?;
+        let health_cache = new_health_cache(&account.borrow(), &retriever, now_ts)
+            .context("pre-withdraw init health")?;
         let pre_init_health = account.check_health_pre(&health_cache)?;
         Some((health_cache, pre_init_health))
     } else {

--- a/programs/mango-v4/src/instructions/perp_settle_fees.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_fees.rs
@@ -122,7 +122,8 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
 
     // Verify that the result of settling did not violate the health of the account that lost money
     let retriever = new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-    let health = compute_health(&account.borrow(), HealthType::Init, &retriever)?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let health = compute_health(&account.borrow(), HealthType::Init, &retriever, now_ts)?;
     require!(health >= 0, MangoError::HealthMustBePositive);
 
     msg!("settled fees = {}", settlement);

--- a/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
@@ -57,8 +57,9 @@ pub fn serum3_liq_force_cancel_orders(
         let mut account = ctx.accounts.account.load_full_mut()?;
         let retriever =
             new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-        let health_cache =
-            new_health_cache(&account.borrow(), &retriever).context("create health cache")?;
+        let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+        let health_cache = new_health_cache(&account.borrow(), &retriever, now_ts)
+            .context("create health cache")?;
 
         let liquidatable = account.check_liquidatable(&health_cache)?;
         let can_force_cancel = !account.fixed.is_operational()

--- a/programs/mango-v4/src/instructions/serum3_place_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_place_order.rs
@@ -76,8 +76,9 @@ pub fn serum3_place_order(
     //
     let mut account = ctx.accounts.account.load_full_mut()?;
     let retriever = new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-    let mut health_cache =
-        new_health_cache(&account.borrow(), &retriever).context("pre-withdraw init health")?;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+    let mut health_cache = new_health_cache(&account.borrow(), &retriever, now_ts)
+        .context("pre-withdraw init health")?;
     let pre_health_opt = if !account.fixed.is_in_health_region() {
         let pre_init_health = account.check_health_pre(&health_cache)?;
         Some(pre_init_health)

--- a/programs/mango-v4/src/instructions/token_conditional_swap_start.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_start.rs
@@ -44,7 +44,7 @@ pub fn token_conditional_swap_start(
         MangoError::TokenConditionalSwapTypeNotStartable
     );
 
-    let mut health_cache = new_health_cache(&liqee.borrow(), &account_retriever)
+    let mut health_cache = new_health_cache(&liqee.borrow(), &account_retriever, now_ts)
         .context("create liqee health cache")?;
     let pre_init_health = liqee.check_health_pre(&health_cache)?;
 

--- a/programs/mango-v4/src/instructions/token_conditional_swap_trigger.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_trigger.rs
@@ -87,7 +87,7 @@ pub fn token_conditional_swap_trigger(
     // changes when the tcs was created.
     liqee.ensure_token_position(buy_token_index)?;
     liqee.ensure_token_position(sell_token_index)?;
-    let mut liqee_health_cache = new_health_cache(&liqee.borrow(), &account_retriever)
+    let mut liqee_health_cache = new_health_cache(&liqee.borrow(), &account_retriever, now_ts)
         .context("create liqee health cache")?;
 
     let (buy_bank, buy_token_price, sell_bank_and_oracle_opt) =
@@ -118,8 +118,13 @@ pub fn token_conditional_swap_trigger(
     );
 
     // Check liqor health, liqee health is checked inside (has to be, since tcs closure depends on it)
-    let liqor_health = compute_health(&liqor.borrow(), HealthType::Init, &account_retriever)
-        .context("compute liqor health")?;
+    let liqor_health = compute_health(
+        &liqor.borrow(),
+        HealthType::Init,
+        &account_retriever,
+        now_ts,
+    )
+    .context("compute liqor health")?;
     require!(liqor_health >= 0, MangoError::HealthMustBePositive);
 
     Ok(())
@@ -797,7 +802,7 @@ mod tests {
             let retriever =
                 ScanningAccountRetriever::new_with_staleness(&ais, &setup.group, None).unwrap();
             let mut liqee_health_cache =
-                crate::health::new_health_cache(&setup.liqee.borrow(), &retriever).unwrap();
+                crate::health::new_health_cache(&setup.liqee.borrow(), &retriever, 0).unwrap();
 
             action(
                 &mut self.liqor.borrow_mut(),

--- a/programs/mango-v4/src/instructions/token_deposit.rs
+++ b/programs/mango-v4/src/instructions/token_deposit.rs
@@ -114,11 +114,12 @@ impl<'a, 'info> DepositCommon<'a, 'info> {
         // Health computation
         //
         let retriever = new_fixed_order_account_retriever(remaining_accounts, &account.borrow())?;
+        let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
 
         // We only compute health to check if the account leaves the being_liquidated state.
         // So it's ok to possibly skip token positions for bad oracles and compute a health
         // value that is too low.
-        let cache = new_health_cache_skipping_bad_oracles(&account.borrow(), &retriever)?;
+        let cache = new_health_cache_skipping_bad_oracles(&account.borrow(), &retriever, now_ts)?;
 
         // Since depositing can only increase health, we can skip the usual pre-health computation.
         // Also, TokenDeposit is one of the rare instructions that is allowed even during being_liquidated.

--- a/programs/mango-v4/src/instructions/token_force_close_borrows_with_token.rs
+++ b/programs/mango-v4/src/instructions/token_force_close_borrows_with_token.rs
@@ -186,7 +186,8 @@ pub fn token_force_close_borrows_with_token(
             MangoError::SomeError
         );
 
-        let liqee_health_cache = new_health_cache(&liqee.borrow(), &mut account_retriever)
+        let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
+        let liqee_health_cache = new_health_cache(&liqee.borrow(), &mut account_retriever, now_ts)
             .context("create liqee health cache")?;
         let liqee_liq_end_health = liqee_health_cache.health(HealthType::LiquidationEnd);
         liqee
@@ -211,8 +212,13 @@ pub fn token_force_close_borrows_with_token(
     // Check liqor's health
     // This should always improve liqor health, since we decrease the zero-asset-weight
     // liab token and gain some asset token, this check is just for denfensive measure
-    let liqor_health = compute_health(&liqor.borrow(), HealthType::Init, &mut account_retriever)
-        .context("compute liqor health")?;
+    let liqor_health = compute_health(
+        &liqor.borrow(),
+        HealthType::Init,
+        &mut account_retriever,
+        now_ts,
+    )
+    .context("compute liqor health")?;
     require!(liqor_health >= 0, MangoError::HealthMustBePositive);
 
     // TODO log

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -113,7 +113,12 @@ pub fn token_register(
         interest_target_utilization,
         interest_curve_scaling: interest_curve_scaling.into(),
         deposits_in_serum: 0,
-        reserved: [0; 2072],
+        maint_weight_shift_start: 0,
+        maint_weight_shift_end: 0,
+        maint_weight_shift_duration_inv: I80F48::ZERO,
+        maint_weight_shift_asset_target: I80F48::ZERO,
+        maint_weight_shift_liab_target: I80F48::ZERO,
+        reserved: [0; 2008],
     };
 
     if let Ok(oracle_price) =

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -97,7 +97,12 @@ pub fn token_register_trustless(
         interest_target_utilization: 0.5,
         interest_curve_scaling: 4.0,
         deposits_in_serum: 0,
-        reserved: [0; 2072],
+        maint_weight_shift_start: 0,
+        maint_weight_shift_end: 0,
+        maint_weight_shift_duration_inv: I80F48::ZERO,
+        maint_weight_shift_asset_target: I80F48::ZERO,
+        maint_weight_shift_liab_target: I80F48::ZERO,
+        reserved: [0; 2008],
     };
 
     if let Ok(oracle_price) =

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -14,6 +14,7 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
 
     let group = ctx.accounts.group.load()?;
     let token_index = ctx.accounts.bank.load()?.token_index;
+    let now_ts: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
 
     // Create the account's position for that token index
     let mut account = ctx.accounts.account.load_full_mut()?;
@@ -23,8 +24,8 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
     let pre_health_opt = if !account.fixed.is_in_health_region() {
         let retriever =
             new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-        let hc_result =
-            new_health_cache(&account.borrow(), &retriever).context("pre-withdraw health cache");
+        let hc_result = new_health_cache(&account.borrow(), &retriever, now_ts)
+            .context("pre-withdraw health cache");
         if hc_result.is_oracle_error() {
             // We allow NOT checking the pre init health. That means later on the health
             // check will be stricter (post_init > 0, without the post_init >= pre_init option)
@@ -132,8 +133,9 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
             // Note that this must include the normal pre and post health checks.
             let retriever =
                 new_fixed_order_account_retriever(ctx.remaining_accounts, &account.borrow())?;
-            let health_cache = new_health_cache_skipping_bad_oracles(&account.borrow(), &retriever)
-                .context("special post-withdraw health-cache")?;
+            let health_cache =
+                new_health_cache_skipping_bad_oracles(&account.borrow(), &retriever, now_ts)
+                    .context("special post-withdraw health-cache")?;
             let post_init_health = health_cache.health(HealthType::Init);
             account.check_health_pre_checks(&health_cache, post_init_health)?;
             account.check_health_post_checks(I80F48::MAX, post_init_health)?;

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -227,6 +227,11 @@ pub mod mango_v4 {
         flash_loan_swap_fee_rate_opt: Option<f32>,
         interest_curve_scaling_opt: Option<f32>,
         interest_target_utilization_opt: Option<f32>,
+        maint_weight_shift_start_opt: Option<u64>,
+        maint_weight_shift_end_opt: Option<u64>,
+        maint_weight_shift_asset_target_opt: Option<f32>,
+        maint_weight_shift_liab_target_opt: Option<f32>,
+        maint_weight_shift_abort: bool,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::token_edit(
@@ -260,6 +265,11 @@ pub mod mango_v4 {
             flash_loan_swap_fee_rate_opt,
             interest_curve_scaling_opt,
             interest_target_utilization_opt,
+            maint_weight_shift_start_opt,
+            maint_weight_shift_end_opt,
+            maint_weight_shift_asset_target_opt,
+            maint_weight_shift_liab_target_opt,
+            maint_weight_shift_abort,
         )?;
         Ok(())
     }

--- a/programs/mango-v4/tests/program_test/mango_client.rs
+++ b/programs/mango-v4/tests/program_test/mango_client.rs
@@ -386,6 +386,17 @@ pub async fn account_init_health(solana: &SolanaCookie, account: Pubkey) -> f64 
     health_data.init_health.to_num::<f64>()
 }
 
+pub async fn account_maint_health(solana: &SolanaCookie, account: Pubkey) -> f64 {
+    send_tx(solana, ComputeAccountDataInstruction { account })
+        .await
+        .unwrap();
+    let health_data = solana
+        .program_log_events::<mango_v4::events::MangoAccountData>()
+        .pop()
+        .unwrap();
+    health_data.maint_health.to_num::<f64>()
+}
+
 // Verifies that the "post_health: ..." log emitted by the previous instruction
 // matches the init health of the account.
 pub async fn check_prev_instruction_post_health(solana: &SolanaCookie, account: Pubkey) {
@@ -1245,6 +1256,11 @@ pub fn token_edit_instruction_default() -> mango_v4::instruction::TokenEdit {
         flash_loan_swap_fee_rate_opt: None,
         interest_curve_scaling_opt: None,
         interest_target_utilization_opt: None,
+        maint_weight_shift_start_opt: None,
+        maint_weight_shift_end_opt: None,
+        maint_weight_shift_asset_target_opt: None,
+        maint_weight_shift_liab_target_opt: None,
+        maint_weight_shift_abort: false,
     }
 }
 


### PR DESCRIPTION
- token_edit can set it up to gradually scale to new target values
- security admin can abort an ongoing change via token_edit
- all health computations are now time dependent and get the weight based on it
- when the change is done, the keeper "cleans up" and moves the new values into the default fields