### PR TITLE
Log emissions: Serialize to buffer on stack instead of using heap

### DIFF
--- a/programs/mango-v4/src/instructions/account_buyback_fees_with_mngo.rs
+++ b/programs/mango-v4/src/instructions/account_buyback_fees_with_mngo.rs
@@ -7,7 +7,7 @@ use crate::state::*;
 
 use crate::accounts_ix::*;
 
-use crate::logs::{AccountBuybackFeesWithMngoLog, TokenBalanceLog};
+use crate::logs::{emit_stack, AccountBuybackFeesWithMngoLog, TokenBalanceLog};
 
 pub fn account_buyback_fees_with_mngo(
     ctx: Context<AccountBuybackFeesWithMngo>,
@@ -105,7 +105,7 @@ pub fn account_buyback_fees_with_mngo(
     );
     let in_use =
         mngo_bank.withdraw_without_fee(account_mngo_token_position, max_buyback_mngo, now_ts)?;
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         token_index: mngo_bank.token_index,
@@ -137,7 +137,7 @@ pub fn account_buyback_fees_with_mngo(
         );
     }
     let in_use = fees_bank.deposit(account_fees_token_position, max_buyback_fees, now_ts)?;
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         token_index: fees_bank.token_index,
@@ -162,7 +162,7 @@ pub fn account_buyback_fees_with_mngo(
         max_buyback_fees,
     );
 
-    emit!(AccountBuybackFeesWithMngoLog {
+    emit_stack(AccountBuybackFeesWithMngoLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         buyback_fees: max_buyback_fees.to_bits(),

--- a/programs/mango-v4/src/instructions/compute_account_data.rs
+++ b/programs/mango-v4/src/instructions/compute_account_data.rs
@@ -20,6 +20,7 @@ pub fn compute_account_data(ctx: Context<ComputeAccountData>) -> Result<()> {
 
     let equity = compute_equity(&account.borrow(), &account_retriever)?;
 
+    // Potentially too big for the stack!
     emit!(MangoAccountData {
         init_health,
         maint_health,

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -3,7 +3,7 @@ use crate::accounts_zerocopy::*;
 use crate::error::*;
 use crate::group_seeds;
 use crate::health::{new_fixed_order_account_retriever, new_health_cache, AccountRetriever};
-use crate::logs::{FlashLoanLogV3, FlashLoanTokenDetailV3, TokenBalanceLog};
+use crate::logs::{emit_stack, FlashLoanLogV3, FlashLoanTokenDetailV3, TokenBalanceLog};
 use crate::state::*;
 
 use anchor_lang::prelude::*;
@@ -482,7 +482,7 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             approved_amount: approved_amount_u64,
         });
 
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: group.key(),
             mango_account: ctx.accounts.account.key(),
             token_index: bank.token_index as u16,
@@ -492,11 +492,11 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         });
     }
 
-    emit!(FlashLoanLogV3 {
+    emit_stack(FlashLoanLogV3 {
         mango_group: group.key(),
         mango_account: ctx.accounts.account.key(),
         flash_loan_type,
-        token_loan_details
+        token_loan_details,
     });
 
     // Check health after account position changes

--- a/programs/mango-v4/src/instructions/perp_consume_events.rs
+++ b/programs/mango-v4/src/instructions/perp_consume_events.rs
@@ -5,7 +5,7 @@ use crate::error::MangoError;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::{emit_perp_balances, FillLogV3};
+use crate::logs::{emit_perp_balances, emit_stack, FillLogV3};
 
 /// Load a mango account by key from the list of account infos.
 ///
@@ -131,7 +131,7 @@ pub fn perp_consume_events(ctx: Context<PerpConsumeEvents>, limit: usize) -> Res
                     let taker_closed_pnl = taker_after_pnl - taker_before_pnl;
                     (maker_closed_pnl, taker_closed_pnl)
                 };
-                emit!(FillLogV3 {
+                emit_stack(FillLogV3 {
                     mango_group: group_key,
                     market_index: perp_market_index,
                     taker_side: fill.taker_side as u8,
@@ -149,7 +149,7 @@ pub fn perp_consume_events(ctx: Context<PerpConsumeEvents>, limit: usize) -> Res
                     price: fill.price,
                     quantity: fill.quantity,
                     maker_closed_pnl: maker_closed_pnl.to_num(),
-                    taker_closed_pnl: taker_closed_pnl.to_num()
+                    taker_closed_pnl: taker_closed_pnl.to_num(),
                 });
             }
             EventType::Out => {

--- a/programs/mango-v4/src/instructions/perp_create_market.rs
+++ b/programs/mango-v4/src/instructions/perp_create_market.rs
@@ -7,7 +7,7 @@ use crate::state::*;
 use crate::util::fill_from_str;
 
 use crate::accounts_ix::*;
-use crate::logs::PerpMarketMetaDataLog;
+use crate::logs::{emit_stack, PerpMarketMetaDataLog};
 
 #[allow(clippy::too_many_arguments)]
 pub fn perp_create_market(
@@ -111,7 +111,7 @@ pub fn perp_create_market(
     };
     orderbook.init();
 
-    emit!(PerpMarketMetaDataLog {
+    emit_stack(PerpMarketMetaDataLog {
         mango_group: ctx.accounts.group.key(),
         perp_market: ctx.accounts.perp_market.key(),
         perp_market_index,

--- a/programs/mango-v4/src/instructions/perp_edit_market.rs
+++ b/programs/mango-v4/src/instructions/perp_edit_market.rs
@@ -4,7 +4,7 @@ use anchor_lang::prelude::*;
 use fixed::types::I80F48;
 
 use crate::accounts_ix::*;
-use crate::logs::PerpMarketMetaDataLog;
+use crate::logs::{emit_stack, PerpMarketMetaDataLog};
 
 #[allow(clippy::too_many_arguments)]
 pub fn perp_edit_market(
@@ -358,7 +358,7 @@ pub fn perp_edit_market(
         );
     }
 
-    emit!(PerpMarketMetaDataLog {
+    emit_stack(PerpMarketMetaDataLog {
         mango_group: ctx.accounts.group.key(),
         perp_market: ctx.accounts.perp_market.key(),
         perp_market_index: perp_market.perp_market_index,

--- a/programs/mango-v4/src/instructions/perp_force_close_position.rs
+++ b/programs/mango-v4/src/instructions/perp_force_close_position.rs
@@ -4,7 +4,7 @@ use crate::accounts_ix::*;
 
 use crate::accounts_zerocopy::AccountInfoRef;
 use crate::error::MangoError;
-use crate::logs::{emit_perp_balances, PerpForceClosePositionLog};
+use crate::logs::{emit_perp_balances, emit_stack, PerpForceClosePositionLog};
 use crate::state::*;
 use fixed::types::I80F48;
 
@@ -56,7 +56,7 @@ pub fn perp_force_close_position(ctx: Context<PerpForceClosePosition>) -> Result
         &perp_market,
     );
 
-    emit!(PerpForceClosePositionLog {
+    emit_stack(PerpForceClosePositionLog {
         mango_group: ctx.accounts.group.key(),
         perp_market_index: perp_market.perp_market_index,
         account_a: ctx.accounts.account_a.key(),

--- a/programs/mango-v4/src/instructions/perp_liq_base_or_positive_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_base_or_positive_pnl.rs
@@ -8,7 +8,7 @@ use crate::health::*;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::{emit_perp_balances, PerpLiqBaseOrPositivePnlLog, TokenBalanceLog};
+use crate::logs::{emit_perp_balances, emit_stack, PerpLiqBaseOrPositivePnlLog, TokenBalanceLog};
 
 /// This instruction deals with increasing health by:
 /// - reducing the liqee's base position
@@ -131,7 +131,7 @@ pub fn perp_liq_base_or_positive_pnl(
         let liqee_token_position = liqee.token_position(settle_token_index)?;
         let liqor_token_position = liqor.token_position(settle_token_index)?;
 
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: ctx.accounts.group.key(),
             mango_account: ctx.accounts.liqee.key(),
             token_index: settle_token_index,
@@ -140,7 +140,7 @@ pub fn perp_liq_base_or_positive_pnl(
             borrow_index: settle_bank.borrow_index.to_bits(),
         });
 
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: ctx.accounts.group.key(),
             mango_account: ctx.accounts.liqor.key(),
             token_index: settle_token_index,
@@ -151,7 +151,7 @@ pub fn perp_liq_base_or_positive_pnl(
     }
 
     if base_transfer != 0 || pnl_transfer != 0 {
-        emit!(PerpLiqBaseOrPositivePnlLog {
+        emit_stack(PerpLiqBaseOrPositivePnlLog {
             mango_group: ctx.accounts.group.key(),
             perp_market_index: perp_market.perp_market_index,
             liqor: ctx.accounts.liqor.key(),

--- a/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/perp_liq_negative_pnl_or_bankruptcy.rs
@@ -10,7 +10,8 @@ use crate::accounts_zerocopy::AccountInfoRef;
 use crate::error::*;
 use crate::health::*;
 use crate::logs::{
-    emit_perp_balances, PerpLiqBankruptcyLog, PerpLiqNegativePnlOrBankruptcyLog, TokenBalanceLog,
+    emit_perp_balances, emit_stack, PerpLiqBankruptcyLog, PerpLiqNegativePnlOrBankruptcyLog,
+    TokenBalanceLog,
 };
 use crate::state::*;
 
@@ -136,7 +137,7 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
     if settlement > 0 {
         let settle_bank = ctx.accounts.settle_bank.load()?;
         let liqor_token_position = liqor.token_position(settle_token_index)?;
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group,
             mango_account: ctx.accounts.liqor.key(),
             token_index: settle_token_index,
@@ -146,7 +147,7 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
         });
 
         let liqee_token_position = liqee.token_position(settle_token_index)?;
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group,
             mango_account: ctx.accounts.liqee.key(),
             token_index: settle_token_index,
@@ -159,7 +160,7 @@ pub fn perp_liq_negative_pnl_or_bankruptcy(
     if insurance_transfer > 0 {
         let insurance_bank = ctx.accounts.insurance_bank.load()?;
         let liqor_token_position = liqor.token_position(insurance_bank.token_index)?;
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group,
             mango_account: ctx.accounts.liqor.key(),
             token_index: insurance_bank.token_index,
@@ -281,7 +282,7 @@ pub(crate) fn liquidation_action(
             settle_bank.withdraw_without_fee(liqee_token_position, settlement, now_ts)?;
             liqee_health_cache.adjust_token_balance(&settle_bank, -settlement)?;
 
-            emit!(PerpLiqNegativePnlOrBankruptcyLog {
+            emit_stack(PerpLiqNegativePnlOrBankruptcyLog {
                 mango_group: group_key,
                 liqee: liqee_key,
                 liqor: liqor_key,
@@ -402,7 +403,7 @@ pub(crate) fn liquidation_action(
             msg!("socialized loss: {}", socialized_loss);
         }
 
-        emit!(PerpLiqBankruptcyLog {
+        emit_stack(PerpLiqBankruptcyLog {
             mango_group: group_key,
             liqee: liqee_key,
             liqor: liqor_key,

--- a/programs/mango-v4/src/instructions/perp_settle_fees.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_fees.rs
@@ -8,7 +8,7 @@ use crate::health::{compute_health, new_fixed_order_account_retriever, HealthTyp
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::{emit_perp_balances, PerpSettleFeesLog, TokenBalanceLog};
+use crate::logs::{emit_perp_balances, emit_stack, PerpSettleFeesLog, TokenBalanceLog};
 
 pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) -> Result<()> {
     // max_settle_amount must greater than zero
@@ -100,7 +100,7 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
     // Update the settled balance on the market itself
     perp_market.fees_settled += settlement;
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         token_index: perp_market.settle_token_index,
@@ -109,7 +109,7 @@ pub fn perp_settle_fees(ctx: Context<PerpSettleFees>, max_settle_amount: u64) ->
         borrow_index: settle_bank.borrow_index.to_bits(),
     });
 
-    emit!(PerpSettleFeesLog {
+    emit_stack(PerpSettleFeesLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         perp_market_index: perp_market.perp_market_index,

--- a/programs/mango-v4/src/instructions/perp_settle_pnl.rs
+++ b/programs/mango-v4/src/instructions/perp_settle_pnl.rs
@@ -6,7 +6,7 @@ use crate::accounts_ix::*;
 use crate::accounts_zerocopy::*;
 use crate::error::*;
 use crate::health::{new_health_cache, HealthType, ScanningAccountRetriever};
-use crate::logs::{emit_perp_balances, PerpSettlePnlLog, TokenBalanceLog};
+use crate::logs::{emit_perp_balances, emit_stack, PerpSettlePnlLog, TokenBalanceLog};
 use crate::state::*;
 
 pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
@@ -189,7 +189,7 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
     // settled back and forth repeatedly.
     settle_bank.withdraw_without_fee(b_token_position, settlement, now_ts)?;
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account_a.key(),
         token_index: settle_token_index,
@@ -198,7 +198,7 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
         borrow_index: settle_bank.borrow_index.to_bits(),
     });
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account_b.key(),
         token_index: settle_token_index,
@@ -224,7 +224,7 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
         settler.ensure_token_position(settle_token_index)?;
     let settler_token_position_active = settle_bank.deposit(settler_token_position, fee, now_ts)?;
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.settler.key(),
         token_index: settler_token_position.token_index,
@@ -238,7 +238,7 @@ pub fn perp_settle_pnl(ctx: Context<PerpSettlePnl>) -> Result<()> {
             .deactivate_token_position_and_log(settler_token_raw_index, ctx.accounts.settler.key());
     }
 
-    emit!(PerpSettlePnlLog {
+    emit_stack(PerpSettlePnlLog {
         mango_group: ctx.accounts.group.key(),
         mango_account_a: ctx.accounts.account_a.key(),
         mango_account_b: ctx.accounts.account_b.key(),

--- a/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_all_orders.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
 use crate::error::*;
-use crate::logs::Serum3OpenOrdersBalanceLogV2;
+use crate::logs::{emit_stack, Serum3OpenOrdersBalanceLogV2};
 use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::*;
 
@@ -39,7 +39,7 @@ pub fn serum3_cancel_all_orders(ctx: Context<Serum3CancelAllOrders>, limit: u8) 
     let oo_ai = &ctx.accounts.open_orders.as_ref();
     let open_orders = load_open_orders_ref(oo_ai)?;
     let after_oo = OpenOrdersSlim::from_oo(&open_orders);
-    emit!(Serum3OpenOrdersBalanceLogV2 {
+    emit_stack(Serum3OpenOrdersBalanceLogV2 {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         market_index: serum_market.market_index,

--- a/programs/mango-v4/src/instructions/serum3_cancel_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_cancel_order.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::Serum3OpenOrdersBalanceLogV2;
+use crate::logs::{emit_stack, Serum3OpenOrdersBalanceLogV2};
 use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 
 pub fn serum3_cancel_order(
@@ -49,7 +49,7 @@ pub fn serum3_cancel_order(
     let oo_ai = &ctx.accounts.open_orders.as_ref();
     let open_orders = load_open_orders_ref(oo_ai)?;
     let after_oo = OpenOrdersSlim::from_oo(&open_orders);
-    emit!(Serum3OpenOrdersBalanceLogV2 {
+    emit_stack(Serum3OpenOrdersBalanceLogV2 {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         market_index: serum_market.market_index,

--- a/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
+++ b/programs/mango-v4/src/instructions/serum3_liq_force_cancel_orders.rs
@@ -5,7 +5,7 @@ use crate::error::*;
 use crate::health::*;
 use crate::instructions::apply_settle_changes;
 use crate::instructions::charge_loan_origination_fees;
-use crate::logs::Serum3OpenOrdersBalanceLogV2;
+use crate::logs::{emit_stack, Serum3OpenOrdersBalanceLogV2};
 use crate::serum3_cpi::{load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim};
 use crate::state::*;
 
@@ -117,7 +117,7 @@ pub fn serum3_liq_force_cancel_orders(
         let open_orders = load_open_orders_ref(oo_ai)?;
         after_oo = OpenOrdersSlim::from_oo(&open_orders);
 
-        emit!(Serum3OpenOrdersBalanceLogV2 {
+        emit_stack(Serum3OpenOrdersBalanceLogV2 {
             mango_group: ctx.accounts.group.key(),
             mango_account: ctx.accounts.account.key(),
             market_index: serum_market.market_index,

--- a/programs/mango-v4/src/instructions/serum3_place_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_place_order.rs
@@ -5,7 +5,7 @@ use crate::i80f48::ClampToInt;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::{Serum3OpenOrdersBalanceLogV2, TokenBalanceLog};
+use crate::logs::{emit_stack, Serum3OpenOrdersBalanceLogV2, TokenBalanceLog};
 use crate::serum3_cpi::{
     load_market_state, load_open_orders_ref, OpenOrdersAmounts, OpenOrdersSlim,
 };
@@ -216,7 +216,7 @@ pub fn serum3_place_order(
         }
     }
 
-    emit!(Serum3OpenOrdersBalanceLogV2 {
+    emit_stack(Serum3OpenOrdersBalanceLogV2 {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         market_index: serum_market.market_index,
@@ -412,7 +412,7 @@ fn apply_vault_difference(
         *borrows_without_fee = (*borrows_without_fee).saturating_sub(needed_change.to_num::<u64>());
     }
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: bank.group,
         mango_account: account_pk,
         token_index: bank.token_index,

--- a/programs/mango-v4/src/instructions/serum3_register_market.rs
+++ b/programs/mango-v4/src/instructions/serum3_register_market.rs
@@ -6,7 +6,7 @@ use crate::state::*;
 use crate::util::fill_from_str;
 
 use crate::accounts_ix::*;
-use crate::logs::Serum3RegisterMarketLog;
+use crate::logs::{emit_stack, Serum3RegisterMarketLog};
 
 pub fn serum3_register_market(
     ctx: Context<Serum3RegisterMarket>,
@@ -55,7 +55,7 @@ pub fn serum3_register_market(
         reserved: [0; 38],
     };
 
-    emit!(Serum3RegisterMarketLog {
+    emit_stack(Serum3RegisterMarketLog {
         mango_group: ctx.accounts.group.key(),
         serum_market: ctx.accounts.serum_market.key(),
         market_index,

--- a/programs/mango-v4/src/instructions/serum3_settle_funds.rs
+++ b/programs/mango-v4/src/instructions/serum3_settle_funds.rs
@@ -7,8 +7,9 @@ use crate::state::*;
 
 use super::apply_settle_changes;
 use crate::accounts_ix::*;
-use crate::logs::Serum3OpenOrdersBalanceLogV2;
-use crate::logs::{LoanOriginationFeeInstruction, WithdrawLoanLog};
+use crate::logs::{
+    emit_stack, LoanOriginationFeeInstruction, Serum3OpenOrdersBalanceLogV2, WithdrawLoanLog,
+};
 
 use crate::accounts_zerocopy::AccountInfoRef;
 
@@ -132,7 +133,7 @@ pub fn serum3_settle_funds<'info>(
         v2.map(|d| d.quote_oracle.as_ref()),
     )?;
 
-    emit!(Serum3OpenOrdersBalanceLogV2 {
+    emit_stack(Serum3OpenOrdersBalanceLogV2 {
         mango_group: accounts.group.key(),
         mango_account: accounts.account.key(),
         market_index: serum_market.market_index,
@@ -188,14 +189,14 @@ pub fn charge_loan_origination_fees(
             })
             .transpose()?;
 
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: *group_pubkey,
             mango_account: *account_pubkey,
             token_index: base_bank.token_index,
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
-            price: base_oracle_price.map(|p| p.to_bits())
+            price: base_oracle_price.map(|p| p.to_bits()),
         });
     }
 
@@ -224,14 +225,14 @@ pub fn charge_loan_origination_fees(
             })
             .transpose()?;
 
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: *group_pubkey,
             mango_account: *account_pubkey,
             token_index: quote_bank.token_index,
             loan_amount: withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::Serum3SettleFunds,
-            price: quote_oracle_price.map(|p| p.to_bits())
+            price: quote_oracle_price.map(|p| p.to_bits()),
         });
     }
 

--- a/programs/mango-v4/src/instructions/token_conditional_swap_cancel.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_cancel.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
 use crate::error::MangoError;
-use crate::logs::TokenConditionalSwapCancelLog;
+use crate::logs::{emit_stack, TokenConditionalSwapCancelLog};
 use crate::state::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -31,7 +31,7 @@ pub fn token_conditional_swap_cancel(
     );
     *tcs = TokenConditionalSwap::default();
 
-    emit!(TokenConditionalSwapCancelLog {
+    emit_stack(TokenConditionalSwapCancelLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         id: token_conditional_swap_id,

--- a/programs/mango-v4/src/instructions/token_conditional_swap_create.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_create.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
-use crate::logs::TokenConditionalSwapCreateLogV3;
+use crate::logs::{emit_stack, TokenConditionalSwapCreateLogV3};
 use crate::state::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -56,7 +56,7 @@ pub fn token_conditional_swap_create(
     require_gte!(tcs.price_lower_limit, 0.0);
     require_gte!(tcs.price_upper_limit, 0.0);
 
-    emit!(TokenConditionalSwapCreateLogV3 {
+    emit_stack(TokenConditionalSwapCreateLogV3 {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         id,

--- a/programs/mango-v4/src/instructions/token_conditional_swap_start.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_start.rs
@@ -5,8 +5,7 @@ use crate::accounts_ix::*;
 use crate::error::*;
 use crate::health::*;
 use crate::i80f48::ClampToInt;
-use crate::logs::TokenBalanceLog;
-use crate::logs::TokenConditionalSwapStartLog;
+use crate::logs::{emit_stack, TokenBalanceLog, TokenConditionalSwapStartLog};
 use crate::state::*;
 
 #[allow(clippy::too_many_arguments)]
@@ -95,7 +94,7 @@ pub fn token_conditional_swap_start(
     health_cache
         .adjust_token_balance(sell_bank, liqee_sell_post_balance - liqee_sell_pre_balance)?;
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: *group_pk,
         mango_account: liqee_key,
         token_index: sell_token_index,
@@ -103,7 +102,7 @@ pub fn token_conditional_swap_start(
         deposit_index: sell_bank.deposit_index.to_bits(),
         borrow_index: sell_bank.borrow_index.to_bits(),
     });
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: *group_pk,
         mango_account: liqor_key,
         token_index: sell_token_index,
@@ -111,7 +110,7 @@ pub fn token_conditional_swap_start(
         deposit_index: sell_bank.deposit_index.to_bits(),
         borrow_index: sell_bank.borrow_index.to_bits(),
     });
-    emit!(TokenConditionalSwapStartLog {
+    emit_stack(TokenConditionalSwapStartLog {
         mango_group: *group_pk,
         mango_account: liqee_key,
         caller: liqor_key,

--- a/programs/mango-v4/src/instructions/token_conditional_swap_trigger.rs
+++ b/programs/mango-v4/src/instructions/token_conditional_swap_trigger.rs
@@ -5,10 +5,9 @@ use crate::accounts_ix::*;
 use crate::error::*;
 use crate::health::*;
 use crate::i80f48::ClampToInt;
-use crate::logs::TokenConditionalSwapCancelLog;
 use crate::logs::{
-    LoanOriginationFeeInstruction, TokenBalanceLog, TokenConditionalSwapTriggerLogV3,
-    WithdrawLoanLog,
+    emit_stack, LoanOriginationFeeInstruction, TokenBalanceLog, TokenConditionalSwapCancelLog,
+    TokenConditionalSwapTriggerLogV3, WithdrawLoanLog,
 };
 use crate::state::*;
 
@@ -73,7 +72,7 @@ pub fn token_conditional_swap_trigger(
         liqee.token_decrement_dust_deactivate(sell_bank, now_ts, liqee_key)?;
 
         msg!("TokenConditionalSwap is expired, removing");
-        emit!(TokenConditionalSwapCancelLog {
+        emit_stack(TokenConditionalSwapCancelLog {
             mango_group: ctx.accounts.group.key(),
             mango_account: ctx.accounts.liqee.key(),
             id: token_conditional_swap_id,
@@ -347,7 +346,7 @@ fn action(
     // Log info
 
     // liqee buy token
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqee_key,
         token_index: tcs.buy_token_index,
@@ -356,7 +355,7 @@ fn action(
         borrow_index: buy_bank.borrow_index.to_bits(),
     });
     // liqee sell token
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqee_key,
         token_index: tcs.sell_token_index,
@@ -365,7 +364,7 @@ fn action(
         borrow_index: sell_bank.borrow_index.to_bits(),
     });
     // liqor buy token
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqor_key,
         token_index: tcs.buy_token_index,
@@ -374,7 +373,7 @@ fn action(
         borrow_index: buy_bank.borrow_index.to_bits(),
     });
     // liqor sell token
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqor_key,
         token_index: tcs.sell_token_index,
@@ -384,7 +383,7 @@ fn action(
     });
 
     if liqor_buy_withdraw.has_loan() {
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: liqee.fixed.group,
             mango_account: liqor_key,
             token_index: tcs.buy_token_index,
@@ -395,7 +394,7 @@ fn action(
         });
     }
     if liqee_sell_withdraw.has_loan() {
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: liqee.fixed.group,
             mango_account: liqee_key,
             token_index: tcs.sell_token_index,
@@ -488,7 +487,7 @@ fn action(
         liqee.token_decrement_dust_deactivate(sell_bank, now_ts, liqee_key)?;
     }
 
-    emit!(TokenConditionalSwapTriggerLogV3 {
+    emit_stack(TokenConditionalSwapTriggerLogV3 {
         mango_group: liqee.fixed.group,
         liqee: liqee_key,
         liqor: liqor_key,

--- a/programs/mango-v4/src/instructions/token_deposit.rs
+++ b/programs/mango-v4/src/instructions/token_deposit.rs
@@ -10,7 +10,7 @@ use crate::health::*;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::{DepositLog, TokenBalanceLog};
+use crate::logs::*;
 
 struct DepositCommon<'a, 'info> {
     pub group: &'a AccountLoader<'info, Group>,
@@ -100,7 +100,7 @@ impl<'a, 'info> DepositCommon<'a, 'info> {
         let amount_usd = (amount_i80f48 * unsafe_oracle_price).to_num::<i64>();
         account.fixed.net_deposits += amount_usd;
 
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: self.group.key(),
             mango_account: self.account.key(),
             token_index,
@@ -163,7 +163,20 @@ impl<'a, 'info> DepositCommon<'a, 'info> {
             account.deactivate_token_position_and_log(raw_token_index, self.account.key());
         }
 
-        emit!(DepositLog {
+        unsafe {
+            const POS_PTR: *mut usize = 0x300000000 as usize as *mut usize;
+            msg!("heap {}", *POS_PTR);
+        }
+
+        // emit_stack(DepositLog {
+        //     mango_group: self.group.key(),
+        //     mango_account: self.account.key(),
+        //     signer: self.token_authority.key(),
+        //     token_index,
+        //     quantity: amount_i80f48.to_num::<u64>(),
+        //     price: unsafe_oracle_price.to_bits(),
+        // });
+        emit_stack(DepositLog {
             mango_group: self.group.key(),
             mango_account: self.account.key(),
             signer: self.token_authority.key(),
@@ -171,6 +184,11 @@ impl<'a, 'info> DepositCommon<'a, 'info> {
             quantity: amount_i80f48.to_num::<u64>(),
             price: unsafe_oracle_price.to_bits(),
         });
+
+        unsafe {
+            const POS_PTR: *mut usize = 0x300000000 as usize as *mut usize;
+            msg!("heap {}", *POS_PTR);
+        }
 
         Ok(())
     }

--- a/programs/mango-v4/src/instructions/token_edit.rs
+++ b/programs/mango-v4/src/instructions/token_edit.rs
@@ -8,7 +8,7 @@ use crate::error::MangoError;
 use crate::state::*;
 
 use crate::accounts_ix::*;
-use crate::logs::TokenMetaDataLog;
+use crate::logs::{emit_stack, TokenMetaDataLog};
 use crate::util::fill_from_str;
 
 #[allow(unused_variables)]
@@ -456,7 +456,7 @@ pub fn token_edit(
     let bank = ctx.remaining_accounts.first().unwrap().load_mut::<Bank>()?;
     bank.verify()?;
 
-    emit!(TokenMetaDataLog {
+    emit_stack(TokenMetaDataLog {
         mango_group: ctx.accounts.group.key(),
         mint: mint_info.mint.key(),
         token_index: bank.token_index,

--- a/programs/mango-v4/src/instructions/token_force_close_borrows_with_token.rs
+++ b/programs/mango-v4/src/instructions/token_force_close_borrows_with_token.rs
@@ -1,7 +1,7 @@
 use crate::accounts_ix::*;
 use crate::error::*;
 use crate::health::*;
-use crate::logs::{TokenBalanceLog, TokenForceCloseBorrowsWithTokenLog};
+use crate::logs::{emit_stack, TokenBalanceLog, TokenForceCloseBorrowsWithTokenLog};
 use crate::state::*;
 use anchor_lang::prelude::*;
 use fixed::types::I80F48;
@@ -131,7 +131,7 @@ pub fn token_force_close_borrows_with_token(
         );
 
         // liqee asset
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: liqee.fixed.group,
             mango_account: liqee_key,
             token_index: asset_token_index,
@@ -140,7 +140,7 @@ pub fn token_force_close_borrows_with_token(
             borrow_index: asset_bank.borrow_index.to_bits(),
         });
         // liqee liab
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: liqee.fixed.group,
             mango_account: liqee_key,
             token_index: liab_token_index,
@@ -149,7 +149,7 @@ pub fn token_force_close_borrows_with_token(
             borrow_index: liab_bank.borrow_index.to_bits(),
         });
         // liqor asset
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: liqee.fixed.group,
             mango_account: liqor_key,
             token_index: asset_token_index,
@@ -158,7 +158,7 @@ pub fn token_force_close_borrows_with_token(
             borrow_index: asset_bank.borrow_index.to_bits(),
         });
         // liqor liab
-        emit!(TokenBalanceLog {
+        emit_stack(TokenBalanceLog {
             mango_group: liqee.fixed.group,
             mango_account: liqor_key,
             token_index: liab_token_index,
@@ -167,7 +167,7 @@ pub fn token_force_close_borrows_with_token(
             borrow_index: liab_bank.borrow_index.to_bits(),
         });
 
-        emit!(TokenForceCloseBorrowsWithTokenLog {
+        emit_stack(TokenForceCloseBorrowsWithTokenLog {
             mango_group: liqee.fixed.group,
             liqee: liqee_key,
             liqor: liqor_key,
@@ -222,7 +222,7 @@ pub fn token_force_close_borrows_with_token(
     require!(liqor_health >= 0, MangoError::HealthMustBePositive);
 
     // TODO log
-    // emit!(TokenForceCloseBorrowWithToken
+    // emit_stack(TokenForceCloseBorrowWithToken
 
     Ok(())
 }

--- a/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
+++ b/programs/mango-v4/src/instructions/token_liq_bankruptcy.rs
@@ -9,7 +9,8 @@ use crate::state::*;
 
 use crate::accounts_ix::*;
 use crate::logs::{
-    LoanOriginationFeeInstruction, TokenBalanceLog, TokenLiqBankruptcyLog, WithdrawLoanLog,
+    emit_stack, LoanOriginationFeeInstruction, TokenBalanceLog, TokenLiqBankruptcyLog,
+    WithdrawLoanLog,
 };
 
 pub fn token_liq_bankruptcy(
@@ -137,7 +138,7 @@ pub fn token_liq_bankruptcy(
                 quote_bank.deposit(liqor_quote, insurance_transfer_i80f48, now_ts)?;
 
             // liqor quote
-            emit!(TokenBalanceLog {
+            emit_stack(TokenBalanceLog {
                 mango_group: ctx.accounts.group.key(),
                 mango_account: ctx.accounts.liqor.key(),
                 token_index: INSURANCE_TOKEN_INDEX,
@@ -153,7 +154,7 @@ pub fn token_liq_bankruptcy(
                 liab_bank.withdraw_with_fee(liqor_liab, liab_transfer, now_ts)?;
 
             // liqor liab
-            emit!(TokenBalanceLog {
+            emit_stack(TokenBalanceLog {
                 mango_group: ctx.accounts.group.key(),
                 mango_account: ctx.accounts.liqor.key(),
                 token_index: liab_token_index,
@@ -177,14 +178,14 @@ pub fn token_liq_bankruptcy(
                 .loan_origination_fee
                 .is_positive()
             {
-                emit!(WithdrawLoanLog {
+                emit_stack(WithdrawLoanLog {
                     mango_group: ctx.accounts.group.key(),
                     mango_account: ctx.accounts.liqor.key(),
                     token_index: liab_token_index,
                     loan_amount: liqor_liab_withdraw_result.loan_amount.to_bits(),
                     loan_origination_fee: liqor_liab_withdraw_result.loan_origination_fee.to_bits(),
                     instruction: LoanOriginationFeeInstruction::LiqTokenBankruptcy,
-                    price: Some(liab_oracle_price.to_bits())
+                    price: Some(liab_oracle_price.to_bits()),
                 });
             }
 
@@ -256,7 +257,7 @@ pub fn token_liq_bankruptcy(
     }
 
     // liqee liab
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.liqee.key(),
         token_index: liab_token_index,
@@ -279,7 +280,7 @@ pub fn token_liq_bankruptcy(
         liqee.deactivate_token_position_and_log(liqee_raw_token_index, ctx.accounts.liqee.key());
     }
 
-    emit!(TokenLiqBankruptcyLog {
+    emit_stack(TokenLiqBankruptcyLog {
         mango_group: ctx.accounts.group.key(),
         liqee: ctx.accounts.liqee.key(),
         liqor: ctx.accounts.liqor.key(),
@@ -290,7 +291,7 @@ pub fn token_liq_bankruptcy(
         insurance_transfer: insurance_transfer_i80f48.to_bits(),
         socialized_loss: socialized_loss.to_bits(),
         starting_liab_deposit_index: starting_deposit_index.to_bits(),
-        ending_liab_deposit_index: liab_deposit_index.to_bits()
+        ending_liab_deposit_index: liab_deposit_index.to_bits(),
     });
 
     Ok(())

--- a/programs/mango-v4/src/instructions/token_liq_with_token.rs
+++ b/programs/mango-v4/src/instructions/token_liq_with_token.rs
@@ -5,7 +5,8 @@ use crate::accounts_ix::*;
 use crate::error::*;
 use crate::health::*;
 use crate::logs::{
-    LoanOriginationFeeInstruction, TokenBalanceLog, TokenLiqWithTokenLog, WithdrawLoanLog,
+    emit_stack, LoanOriginationFeeInstruction, TokenBalanceLog, TokenLiqWithTokenLog,
+    WithdrawLoanLog,
 };
 use crate::state::*;
 
@@ -257,7 +258,7 @@ pub(crate) fn liquidation_action(
     );
 
     // liqee asset
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqee_key,
         token_index: asset_token_index,
@@ -266,7 +267,7 @@ pub(crate) fn liquidation_action(
         borrow_index: asset_bank.borrow_index.to_bits(),
     });
     // liqee liab
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqee_key,
         token_index: liab_token_index,
@@ -275,7 +276,7 @@ pub(crate) fn liquidation_action(
         borrow_index: liab_bank.borrow_index.to_bits(),
     });
     // liqor asset
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqor_key,
         token_index: asset_token_index,
@@ -284,7 +285,7 @@ pub(crate) fn liquidation_action(
         borrow_index: asset_bank.borrow_index.to_bits(),
     });
     // liqor liab
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: liqee.fixed.group,
         mango_account: liqor_key,
         token_index: liab_token_index,
@@ -297,14 +298,14 @@ pub(crate) fn liquidation_action(
         .loan_origination_fee
         .is_positive()
     {
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: liqee.fixed.group,
             mango_account: liqor_key,
             token_index: liab_token_index,
             loan_amount: liqor_liab_withdraw_result.loan_amount.to_bits(),
             loan_origination_fee: liqor_liab_withdraw_result.loan_origination_fee.to_bits(),
             instruction: LoanOriginationFeeInstruction::LiqTokenWithToken,
-            price: Some(liab_oracle_price.to_bits())
+            price: Some(liab_oracle_price.to_bits()),
         });
     }
 
@@ -328,7 +329,7 @@ pub(crate) fn liquidation_action(
         .fixed
         .maybe_recover_from_being_liquidated(liqee_liq_end_health);
 
-    emit!(TokenLiqWithTokenLog {
+    emit_stack(TokenLiqWithTokenLog {
         mango_group: liqee.fixed.group,
         liqee: liqee_key,
         liqor: liqor_key,
@@ -339,7 +340,7 @@ pub(crate) fn liquidation_action(
         asset_price: asset_oracle_price.to_bits(),
         liab_price: liab_oracle_price.to_bits(),
         bankruptcy: !liqee_health_cache.has_phase2_liquidatable()
-            & liqee_liq_end_health.is_negative()
+            & liqee_liq_end_health.is_negative(),
     });
 
     Ok(())

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::state::*;
 use crate::util::fill_from_str;
 
-use crate::logs::TokenMetaDataLog;
+use crate::logs::{emit_stack, TokenMetaDataLog};
 
 pub const INDEX_START: I80F48 = I80F48::from_bits(1_000_000 * I80F48::ONE.to_bits());
 
@@ -150,7 +150,7 @@ pub fn token_register(
     mint_info.banks[0] = ctx.accounts.bank.key();
     mint_info.vaults[0] = ctx.accounts.vault.key();
 
-    emit!(TokenMetaDataLog {
+    emit_stack(TokenMetaDataLog {
         mango_group: ctx.accounts.group.key(),
         mint: ctx.accounts.mint.key(),
         token_index,

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -7,7 +7,7 @@ use crate::instructions::INDEX_START;
 use crate::state::*;
 use crate::util::fill_from_str;
 
-use crate::logs::TokenMetaDataLog;
+use crate::logs::{emit_stack, TokenMetaDataLog};
 
 use crate::accounts_ix::*;
 
@@ -133,7 +133,7 @@ pub fn token_register_trustless(
     mint_info.banks[0] = ctx.accounts.bank.key();
     mint_info.vaults[0] = ctx.accounts.vault.key();
 
-    emit!(TokenMetaDataLog {
+    emit_stack(TokenMetaDataLog {
         mango_group: ctx.accounts.group.key(),
         mint: ctx.accounts.mint.key(),
         token_index,

--- a/programs/mango-v4/src/instructions/token_update_index_and_rate.rs
+++ b/programs/mango-v4/src/instructions/token_update_index_and_rate.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::accounts_ix::*;
 use crate::error::MangoError;
-use crate::logs::{UpdateIndexLog, UpdateRateLogV2};
+use crate::logs::{emit_stack, UpdateIndexLog, UpdateRateLogV2};
 use crate::state::HOUR;
 use crate::{
     accounts_zerocopy::{AccountInfoRef, LoadMutZeroCopyRef, LoadZeroCopyRef},
@@ -104,7 +104,7 @@ pub fn token_update_index_and_rate(ctx: Context<TokenUpdateIndexAndRate>) -> Res
         let maint_shift_done = some_bank.maint_weight_shift_duration_inv.is_positive()
             && now_ts >= some_bank.maint_weight_shift_end;
 
-        emit!(UpdateIndexLog {
+        emit_stack(UpdateIndexLog {
             mango_group: mint_info.group.key(),
             token_index: mint_info.token_index,
             deposit_index: deposit_index.to_bits(),
@@ -182,7 +182,7 @@ pub fn token_update_index_and_rate(ctx: Context<TokenUpdateIndexAndRate>) -> Res
             let scaling = some_bank.interest_curve_scaling;
             let target_util = some_bank.interest_target_utilization;
 
-            emit!(UpdateRateLogV2 {
+            emit_stack(UpdateRateLogV2 {
                 mango_group: mint_info.group.key(),
                 token_index: mint_info.token_index,
                 rate0: rate0.to_bits(),

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -7,7 +7,9 @@ use anchor_spl::token;
 use fixed::types::I80F48;
 
 use crate::accounts_ix::*;
-use crate::logs::{LoanOriginationFeeInstruction, TokenBalanceLog, WithdrawLoanLog, WithdrawLog};
+use crate::logs::{
+    emit_stack, LoanOriginationFeeInstruction, TokenBalanceLog, WithdrawLoanLog, WithdrawLog,
+};
 
 pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bool) -> Result<()> {
     require_msg!(amount > 0, "withdraw amount must be positive");
@@ -103,7 +105,7 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
 
     let native_position_after = position.native(&bank);
 
-    emit!(TokenBalanceLog {
+    emit_stack(TokenBalanceLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         token_index,
@@ -151,7 +153,7 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         account.deactivate_token_position_and_log(raw_token_index, ctx.accounts.account.key());
     }
 
-    emit!(WithdrawLog {
+    emit_stack(WithdrawLog {
         mango_group: ctx.accounts.group.key(),
         mango_account: ctx.accounts.account.key(),
         signer: ctx.accounts.owner.key(),
@@ -161,7 +163,7 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
     });
 
     if withdraw_result.loan_origination_fee.is_positive() {
-        emit!(WithdrawLoanLog {
+        emit_stack(WithdrawLoanLog {
             mango_group: ctx.accounts.group.key(),
             mango_account: ctx.accounts.account.key(),
             token_index,

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -13,7 +13,7 @@ pub fn emit_stack<T: anchor_lang::Event>(e: T) {
     let mut buffer = [0u8; 3000];
 
     let mut cursor = Cursor::new(&mut buffer[..]);
-    cursor.write(&T::DISCRIMINATOR).unwrap();
+    cursor.write_all(&T::DISCRIMINATOR).unwrap();
     e.serialize(&mut cursor)
         .expect("event must fit into stack buffer");
 

--- a/programs/mango-v4/src/logs.rs
+++ b/programs/mango-v4/src/logs.rs
@@ -13,10 +13,9 @@ pub fn emit_stack<T: anchor_lang::Event>(e: T) {
     let mut buffer = [0u8; 3000];
 
     let mut cursor = Cursor::new(&mut buffer[..]);
-    cursor
-        .write(&T::DISCRIMINATOR)
+    cursor.write(&T::DISCRIMINATOR).unwrap();
+    e.serialize(&mut cursor)
         .expect("event must fit into stack buffer");
-    e.serialize(&mut cursor).unwrap();
 
     let pos = cursor.position() as usize;
     anchor_lang::solana_program::log::sol_log_data(&[&buffer[..pos]]);

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -13,7 +13,7 @@ use static_assertions::const_assert_eq;
 
 use crate::error::*;
 use crate::health::{HealthCache, HealthType};
-use crate::logs::{DeactivatePerpPositionLog, DeactivateTokenPositionLog};
+use crate::logs::{emit_stack, DeactivatePerpPositionLog, DeactivateTokenPositionLog};
 use crate::util;
 
 use super::BookSideOrderTree;
@@ -1014,7 +1014,7 @@ impl<
         let mango_group = self.fixed().group;
         let token_position = self.token_position_mut_by_raw_index(raw_index);
         assert!(token_position.in_use_count == 0);
-        emit!(DeactivateTokenPositionLog {
+        emit_stack(DeactivateTokenPositionLog {
             mango_group,
             mango_account: mango_account_pubkey,
             token_index: token_position.token_index,
@@ -1168,7 +1168,7 @@ impl<
         let mango_group = self.fixed().group;
         let perp_position = self.perp_position_mut(perp_market_index)?;
 
-        emit!(DeactivatePerpPositionLog {
+        emit_stack(DeactivatePerpPositionLog {
             mango_group,
             mango_account: mango_account_pubkey,
             market_index: perp_market_index,

--- a/programs/mango-v4/src/state/orderbook/book.rs
+++ b/programs/mango-v4/src/state/orderbook/book.rs
@@ -1,9 +1,6 @@
-use crate::logs::{FilledPerpOrderLog, PerpTakerTradeLog};
-use crate::state::MangoAccountRefMut;
-use crate::{
-    error::*,
-    state::{orderbook::bookside::*, EventQueue, PerpMarket},
-};
+use crate::error::*;
+use crate::logs::{emit_stack, FilledPerpOrderLog, PerpTakerTradeLog};
+use crate::state::{orderbook::bookside::*, EventQueue, MangoAccountRefMut, PerpMarket};
 use anchor_lang::prelude::*;
 use bytemuck::cast;
 use fixed::types::I80F48;
@@ -205,7 +202,7 @@ impl<'a> Orderbook<'a> {
             event_queue.push_back(cast(fill)).unwrap();
             limit -= 1;
 
-            emit!(FilledPerpOrderLog {
+            emit_stack(FilledPerpOrderLog {
                 mango_group: market.group.key(),
                 perp_market_index: market.perp_market_index,
                 seq_num,
@@ -226,7 +223,7 @@ impl<'a> Orderbook<'a> {
                 mango_account,
                 total_quote_lots_taken - decremented_quote_lots,
             )?;
-            emit!(PerpTakerTradeLog {
+            emit_stack(PerpTakerTradeLog {
                 mango_group: market.group.key(),
                 mango_account: *mango_account_pk,
                 perp_market_index: market.perp_market_index,

--- a/programs/mango-v4/src/state/perp_market.rs
+++ b/programs/mango-v4/src/state/perp_market.rs
@@ -8,7 +8,7 @@ use static_assertions::const_assert_eq;
 
 use crate::accounts_zerocopy::KeyedAccountReader;
 use crate::error::MangoError;
-use crate::logs::PerpUpdateFundingLogV2;
+use crate::logs::{emit_stack, PerpUpdateFundingLogV2};
 use crate::state::orderbook::Side;
 use crate::state::{oracle, TokenIndex};
 use crate::util;
@@ -343,7 +343,7 @@ impl PerpMarket {
         self.stable_price_model
             .update(now_ts, oracle_price.to_num());
 
-        emit!(PerpUpdateFundingLogV2 {
+        emit_stack(PerpUpdateFundingLogV2 {
             mango_group: self.group,
             market_index: self.perp_market_index,
             long_funding: self.long_funding.to_bits(),


### PR DESCRIPTION
Emitting many events could previously cause heap exhaustion.