### PR TITLE
Allow dusting when withdrawing if already zero

### DIFF
--- a/programs/mango-v4/src/state/bank.rs
+++ b/programs/mango-v4/src/state/bank.rs
@@ -594,7 +594,7 @@ impl Bank {
         require_gte!(native_amount, 0);
         let native_position = position.native(self);
 
-        if native_position.is_positive() {
+        if native_position.is_positive() || native_position.is_zero() {
             let new_native_position = native_position - native_amount;
             if !new_native_position.is_negative() {
                 // withdraw deposits only


### PR DESCRIPTION
Had a mango account stuck because it had an active token slot used by a token with a stuck oracle.

The UI close button just sends a withdraw, but that does not work when there is already zero in the account.
https://explorer.solana.com/tx/2SgeRVjg1kqhb7wVUcNHoQfPAkH5A5NwQfcHRCxN48iyfuqzCxhrDnrPcDGJJ1w7engSSo99YCpqQxKQkVq9uJGb?cluster=mainnet-beta

I dont know why this wasnt dusted the first time that a withdraw down to zero was done, but subsequent withdraws should dust.
<img width="1249" alt="Screen Shot 2023-11-21 at 5 33 46 PM" src="https://github.com/blockworks-foundation/mango-v4/assets/1320260/dd595799-8acc-45da-976e-8b314c8a2310">
