### PR TITLE
bins: Fix restarting on new or changed listings

### DIFF
--- a/bin/cli/src/save_snapshot.rs
+++ b/bin/cli/src/save_snapshot.rs
@@ -31,14 +31,9 @@ pub async fn save_snapshot(
     let oracles_and_vaults = group_context
         .tokens
         .values()
-        .map(|value| value.mint_info.oracle)
-        .chain(group_context.perp_markets.values().map(|p| p.market.oracle))
-        .chain(
-            group_context
-                .tokens
-                .values()
-                .flat_map(|value| value.mint_info.vaults),
-        )
+        .map(|value| value.oracle)
+        .chain(group_context.perp_markets.values().map(|p| p.oracle))
+        .chain(group_context.tokens.values().flat_map(|value| value.vaults))
         .unique()
         .filter(|pk| *pk != Pubkey::default())
         .collect::<Vec<Pubkey>>();
@@ -46,7 +41,7 @@ pub async fn save_snapshot(
     let serum_programs = group_context
         .serum3_markets
         .values()
-        .map(|s3| s3.market.serum_program)
+        .map(|s3| s3.serum_program)
         .unique()
         .collect_vec();
 

--- a/bin/keeper/src/taker.rs
+++ b/bin/keeper/src/taker.rs
@@ -25,7 +25,7 @@ pub async fn runner(
 
     let mut price_arcs = HashMap::new();
     for s3_market in mango_client.context.serum3_markets.values() {
-        let base_token_index = s3_market.market.base_token_index;
+        let base_token_index = s3_market.base_token_index;
         let price = mango_client
             .bank_oracle_price(base_token_index)
             .await
@@ -47,11 +47,8 @@ pub async fn runner(
         .map(|s3_market| {
             loop_blocking_orders(
                 mango_client.clone(),
-                s3_market.market.name().to_string(),
-                price_arcs
-                    .get(&s3_market.market.base_token_index)
-                    .unwrap()
-                    .clone(),
+                s3_market.name.clone(),
+                price_arcs.get(&s3_market.base_token_index).unwrap().clone(),
             )
         })
         .collect::<Vec<_>>();
@@ -70,7 +67,7 @@ async fn ensure_oo(mango_client: &Arc<MangoClient>) -> Result<(), anyhow::Error>
     for (market_index, serum3_market) in mango_client.context.serum3_markets.iter() {
         if account.serum3_orders(*market_index).is_err() {
             mango_client
-                .serum3_create_open_orders(serum3_market.market.name())
+                .serum3_create_open_orders(&serum3_market.name)
                 .await?;
         }
     }

--- a/bin/liquidator/src/liquidate.rs
+++ b/bin/liquidator/src/liquidate.rs
@@ -178,7 +178,6 @@ impl<'a> LiquidateHelper<'a> {
             let max_perp_unsettled_leverage = I80F48::from_num(0.95);
             let perp_unsettled_cost = I80F48::ONE
                 - perp
-                    .market
                     .init_overall_asset_weight
                     .min(max_perp_unsettled_leverage);
             let max_pnl_transfer = allowed_usdc_borrow / perp_unsettled_cost;
@@ -334,7 +333,7 @@ impl<'a> LiquidateHelper<'a> {
                 asset_usdc_equivalent.is_positive()
                     && self
                         .allowed_asset_tokens
-                        .contains(&self.client.context.token(*asset_token_index).mint_info.mint)
+                        .contains(&self.client.context.token(*asset_token_index).mint)
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -350,7 +349,7 @@ impl<'a> LiquidateHelper<'a> {
                 liab_usdc_equivalent.is_negative()
                     && self
                         .allowed_liab_tokens
-                        .contains(&self.client.context.token(*liab_token_index).mint_info.mint)
+                        .contains(&self.client.context.token(*liab_token_index).mint)
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -414,7 +413,7 @@ impl<'a> LiquidateHelper<'a> {
                 liab_usdc_equivalent.is_negative()
                     && self
                         .allowed_liab_tokens
-                        .contains(&self.client.context.token(*liab_token_index).mint_info.mint)
+                        .contains(&self.client.context.token(*liab_token_index).mint)
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -569,13 +568,7 @@ pub async fn maybe_liquidate_account(
 
     let maint_health = health_cache.health(HealthType::Maint);
 
-    let all_token_mints = HashSet::from_iter(
-        mango_client
-            .context
-            .tokens
-            .values()
-            .map(|c| c.mint_info.mint),
-    );
+    let all_token_mints = HashSet::from_iter(mango_client.context.tokens.values().map(|c| c.mint));
 
     // try liquidating
     let maybe_txsig = LiquidateHelper {

--- a/bin/liquidator/src/main.rs
+++ b/bin/liquidator/src/main.rs
@@ -219,15 +219,15 @@ async fn main() -> anyhow::Result<()> {
     let mango_oracles = group_context
         .tokens
         .values()
-        .map(|value| value.mint_info.oracle)
-        .chain(group_context.perp_markets.values().map(|p| p.market.oracle))
+        .map(|value| value.oracle)
+        .chain(group_context.perp_markets.values().map(|p| p.oracle))
         .unique()
         .collect::<Vec<Pubkey>>();
 
     let serum_programs = group_context
         .serum3_markets
         .values()
-        .map(|s3| s3.market.serum_program)
+        .map(|s3| s3.serum_program)
         .unique()
         .collect_vec();
 
@@ -553,6 +553,12 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    let check_changes_for_abort_job =
+        tokio::spawn(MangoClient::loop_check_for_context_changes_and_abort(
+            mango_client.clone(),
+            Duration::from_secs(300),
+        ));
+
     if cli.telemetry == BoolArg::True {
         tokio::spawn(telemetry::report_regularly(
             mango_client,
@@ -566,6 +572,7 @@ async fn main() -> anyhow::Result<()> {
         rebalance_job,
         liquidation_job,
         token_swap_info_job,
+        check_changes_for_abort_job,
     ]
     .into_iter()
     .collect();

--- a/bin/liquidator/src/rebalance.rs
+++ b/bin/liquidator/src/rebalance.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use mango_v4::accounts_zerocopy::KeyedAccountSharedData;
 use mango_v4::state::{
-    Bank, BookSide, MangoAccountValue, PerpPosition, PlaceOrderType, Side, TokenIndex,
+    Bank, BookSide, MangoAccountValue, PerpMarket, PerpPosition, PlaceOrderType, Side, TokenIndex,
     QUOTE_TOKEN_INDEX,
 };
 use mango_v4_client::{
@@ -34,7 +34,7 @@ fn token_bank(
     token: &TokenContext,
     account_fetcher: &chain_data::AccountFetcher,
 ) -> anyhow::Result<Bank> {
-    account_fetcher.fetch::<Bank>(&token.mint_info.first_bank())
+    account_fetcher.fetch::<Bank>(&token.first_bank())
 }
 
 pub struct Rebalancer {
@@ -121,8 +121,8 @@ impl Rebalancer {
                 .get("SOL") // TODO: better use mint
                 .unwrap(),
         );
-        let quote_mint = quote_token.mint_info.mint;
-        let sol_mint = sol_token.mint_info.mint;
+        let quote_mint = quote_token.mint;
+        let sol_mint = sol_token.mint;
         let jupiter_version = self.config.jupiter_version;
 
         let full_route_job = self.jupiter_quote(
@@ -143,7 +143,7 @@ impl Rebalancer {
         // For the SOL -> output route we need to adjust the in amount by the SOL price
         let sol_price = self
             .account_fetcher
-            .fetch_bank_price(&sol_token.mint_info.first_bank())?;
+            .fetch_bank_price(&sol_token.first_bank())?;
         let in_amount_sol = (I80F48::from(in_amount_quote) / sol_price)
             .ceil()
             .to_num::<u64>();
@@ -199,8 +199,8 @@ impl Rebalancer {
                 .get("SOL") // TODO: better use mint
                 .unwrap(),
         );
-        let quote_mint = quote_token.mint_info.mint;
-        let sol_mint = sol_token.mint_info.mint;
+        let quote_mint = quote_token.mint;
+        let sol_mint = sol_token.mint;
         let jupiter_version = self.config.jupiter_version;
 
         let full_route_job =
@@ -305,10 +305,8 @@ impl Rebalancer {
             {
                 continue;
             }
-            let token_mint = token.mint_info.mint;
-            let token_price = self
-                .account_fetcher
-                .fetch_bank_price(&token.mint_info.first_bank())?;
+            let token_mint = token.mint;
+            let token_price = self.account_fetcher.fetch_bank_price(&token.first_bank())?;
 
             // It's not always possible to bring the native balance to 0 through swaps:
             // Consider a price <1. You need to sell a bunch of tokens to get 1 USDC native and
@@ -419,7 +417,7 @@ impl Rebalancer {
     #[instrument(
         skip_all,
         fields(
-            perp_market_name = perp.market.name(),
+            perp_market_name = perp.name,
             base_lots = perp_position.base_position_lots(),
             effective_lots = perp_position.effective_base_position_lots(),
             quote_native = %perp_position.quote_position_native()
@@ -438,28 +436,28 @@ impl Rebalancer {
         let base_lots = perp_position.base_position_lots();
         let effective_lots = perp_position.effective_base_position_lots();
         let quote_native = perp_position.quote_position_native();
+        let perp_market: PerpMarket = self.account_fetcher.fetch(&perp.address)?;
 
         if effective_lots != 0 {
             // send an ioc order to reduce the base position
-            let oracle_account_data = self.account_fetcher.fetch_raw(&perp.market.oracle)?;
-            let oracle_account =
-                KeyedAccountSharedData::new(perp.market.oracle, oracle_account_data);
-            let oracle_price = perp.market.oracle_price(&oracle_account, None)?;
-            let oracle_price_lots = perp.market.native_price_to_lot(oracle_price);
+            let oracle_account_data = self.account_fetcher.fetch_raw(&perp.oracle)?;
+            let oracle_account = KeyedAccountSharedData::new(perp.oracle, oracle_account_data);
+            let oracle_price = perp_market.oracle_price(&oracle_account, None)?;
+            let oracle_price_lots = perp_market.native_price_to_lot(oracle_price);
             let (side, order_price, oo_lots) = if effective_lots > 0 {
                 (
                     Side::Ask,
-                    oracle_price * (I80F48::ONE - perp.market.base_liquidation_fee),
+                    oracle_price * (I80F48::ONE - perp_market.base_liquidation_fee),
                     perp_position.asks_base_lots,
                 )
             } else {
                 (
                     Side::Bid,
-                    oracle_price * (I80F48::ONE + perp.market.base_liquidation_fee),
+                    oracle_price * (I80F48::ONE + perp_market.base_liquidation_fee),
                     perp_position.bids_base_lots,
                 )
             };
-            let price_lots = perp.market.native_price_to_lot(order_price);
+            let price_lots = perp_market.native_price_to_lot(order_price);
             let max_base_lots = effective_lots.abs() - oo_lots;
             if max_base_lots <= 0 {
                 warn!(?side, oo_lots, "cannot place reduce-only order",);
@@ -470,8 +468,8 @@ impl Rebalancer {
             // even match anything. That way we don't need to pay the tx fee and
             // ioc penalty fee unnecessarily.
             let opposite_side_key = match side.invert_side() {
-                Side::Bid => perp.market.bids,
-                Side::Ask => perp.market.asks,
+                Side::Bid => perp.bids,
+                Side::Ask => perp.asks,
             };
             let bookside = Box::new(self.account_fetcher.fetch::<BookSide>(&opposite_side_key)?);
             if bookside.quantity_at_price(price_lots, now_ts, oracle_price_lots) <= 0 {

--- a/bin/liquidator/src/token_swap_info.rs
+++ b/bin/liquidator/src/token_swap_info.rs
@@ -94,8 +94,8 @@ impl TokenSwapInfoUpdater {
             return Ok(());
         }
 
-        let token_mint = self.mango_client.context.mint_info(token_index).mint;
-        let quote_mint = self.mango_client.context.mint_info(quote_index).mint;
+        let token_mint = self.mango_client.context.token(token_index).mint;
+        let quote_mint = self.mango_client.context.token(quote_index).mint;
 
         // these prices are in USD, which doesn't exist on chain
         let token_price = self

--- a/bin/liquidator/src/trigger_tcs.rs
+++ b/bin/liquidator/src/trigger_tcs.rs
@@ -365,7 +365,7 @@ impl Context {
         &self,
         token_index: TokenIndex,
     ) -> anyhow::Result<(Bank, I80F48, Pubkey)> {
-        let info = self.mango_client.context.mint_info(token_index);
+        let info = self.mango_client.context.token(token_index);
         let (bank, price) = self
             .account_fetcher
             .fetch_bank_and_price(&info.first_bank())?;

--- a/bin/liquidator/src/util.rs
+++ b/bin/liquidator/src/util.rs
@@ -58,10 +58,8 @@ pub fn max_swap_source(
         mango_v4_client::health_cache::new_sync(&client.context, account_fetcher, &account)
             .expect("always ok");
 
-    let source_bank: Bank =
-        account_fetcher.fetch(&client.context.mint_info(source).first_bank())?;
-    let target_bank: Bank =
-        account_fetcher.fetch(&client.context.mint_info(target).first_bank())?;
+    let source_bank: Bank = account_fetcher.fetch(&client.context.token(source).first_bank())?;
+    let target_bank: Bank = account_fetcher.fetch(&client.context.token(target).first_bank())?;
 
     let source_price = health_cache.token_info(source).unwrap().prices.oracle;
 
@@ -100,10 +98,10 @@ pub fn max_swap_source_ignore_net_borrows(
             .expect("always ok");
 
     let mut source_bank: Bank =
-        account_fetcher.fetch(&client.context.mint_info(source).first_bank())?;
+        account_fetcher.fetch(&client.context.token(source).first_bank())?;
     source_bank.net_borrow_limit_per_window_quote = -1;
     let mut target_bank: Bank =
-        account_fetcher.fetch(&client.context.mint_info(target).first_bank())?;
+        account_fetcher.fetch(&client.context.token(target).first_bank())?;
     target_bank.net_borrow_limit_per_window_quote = -1;
 
     let source_price = health_cache.token_info(source).unwrap().prices.oracle;

--- a/bin/service-mango-crank/src/main.rs
+++ b/bin/service-mango-crank/src/main.rs
@@ -83,14 +83,14 @@ async fn main() -> anyhow::Result<()> {
     let perp_queue_pks: Vec<_> = group_context
         .perp_markets
         .values()
-        .map(|context| (context.address, context.market.event_queue))
+        .map(|context| (context.address, context.event_queue))
         .collect();
 
     // fetch all serum/openbook markets to find their event queues
     let serum_market_pks: Vec<_> = group_context
         .serum3_markets
         .values()
-        .map(|context| context.market.serum_market_external)
+        .map(|context| context.serum_market_external)
         .collect();
 
     let serum_market_ais = client

--- a/bin/service-mango-fills/src/main.rs
+++ b/bin/service-mango-fills/src/main.rs
@@ -384,23 +384,22 @@ async fn main() -> anyhow::Result<()> {
         .perp_markets
         .values()
         .map(|context| {
-            let quote_decimals = match group_context.tokens.get(&context.market.settle_token_index)
-            {
+            let quote_decimals = match group_context.tokens.get(&context.settle_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default to 6 for usdc?
             };
             (
                 context.address,
                 MarketConfig {
-                    name: context.market.name().to_owned(),
-                    bids: context.market.bids,
-                    asks: context.market.asks,
-                    event_queue: context.market.event_queue,
-                    oracle: context.market.oracle,
-                    base_decimals: context.market.base_decimals,
+                    name: context.name.clone(),
+                    bids: context.bids,
+                    asks: context.asks,
+                    event_queue: context.event_queue,
+                    oracle: context.oracle,
+                    base_decimals: context.base_decimals,
                     quote_decimals,
-                    base_lot_size: context.market.base_lot_size,
-                    quote_lot_size: context.market.quote_lot_size,
+                    base_lot_size: context.base_lot_size,
+                    quote_lot_size: context.quote_lot_size,
                 },
             )
         })
@@ -410,18 +409,18 @@ async fn main() -> anyhow::Result<()> {
         .serum3_markets
         .values()
         .map(|context| {
-            let base_decimals = match group_context.tokens.get(&context.market.base_token_index) {
+            let base_decimals = match group_context.tokens.get(&context.base_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default?
             };
-            let quote_decimals = match group_context.tokens.get(&context.market.quote_token_index) {
+            let quote_decimals = match group_context.tokens.get(&context.quote_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default to 6 for usdc?
             };
             (
-                context.market.serum_market_external,
+                context.serum_market_external,
                 MarketConfig {
-                    name: context.market.name().to_owned(),
+                    name: context.name.clone(),
                     bids: context.bids,
                     asks: context.asks,
                     event_queue: context.event_q,
@@ -438,7 +437,7 @@ async fn main() -> anyhow::Result<()> {
     let perp_queue_pks: Vec<(Pubkey, Pubkey)> = group_context
         .perp_markets
         .values()
-        .map(|context| (context.address, context.market.event_queue))
+        .map(|context| (context.address, context.event_queue))
         .collect();
 
     let _a: Vec<(String, String)> = group_context
@@ -446,20 +445,15 @@ async fn main() -> anyhow::Result<()> {
         .values()
         .map(|context| {
             (
-                context.market.serum_market_external.to_string(),
-                context.market.name().to_owned(),
+                context.serum_market_external.to_string(),
+                context.name.clone(),
             )
         })
         .collect();
     let b: Vec<(String, String)> = group_context
         .perp_markets
         .values()
-        .map(|context| {
-            (
-                context.address.to_string(),
-                context.market.name().to_owned(),
-            )
-        })
+        .map(|context| (context.address.to_string(), context.name.clone()))
         .collect();
     let market_pubkey_strings: HashMap<String, String> = [b].concat().into_iter().collect();
 

--- a/bin/service-mango-orderbook/src/main.rs
+++ b/bin/service-mango-orderbook/src/main.rs
@@ -368,23 +368,22 @@ async fn main() -> anyhow::Result<()> {
         .perp_markets
         .values()
         .map(|context| {
-            let quote_decimals = match group_context.tokens.get(&context.market.settle_token_index)
-            {
+            let quote_decimals = match group_context.tokens.get(&context.settle_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default to 6 for usdc?
             };
             (
                 context.address,
                 MarketConfig {
-                    name: context.market.name().to_owned(),
-                    bids: context.market.bids,
-                    asks: context.market.asks,
-                    event_queue: context.market.event_queue,
-                    oracle: context.market.oracle,
-                    base_decimals: context.market.base_decimals,
+                    name: context.name.clone(),
+                    bids: context.bids,
+                    asks: context.asks,
+                    event_queue: context.event_queue,
+                    oracle: context.oracle,
+                    base_decimals: context.base_decimals,
                     quote_decimals,
-                    base_lot_size: context.market.base_lot_size,
-                    quote_lot_size: context.market.quote_lot_size,
+                    base_lot_size: context.base_lot_size,
+                    quote_lot_size: context.quote_lot_size,
                 },
             )
         })
@@ -394,18 +393,18 @@ async fn main() -> anyhow::Result<()> {
         .serum3_markets
         .values()
         .map(|context| {
-            let base_decimals = match group_context.tokens.get(&context.market.base_token_index) {
+            let base_decimals = match group_context.tokens.get(&context.base_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default?
             };
-            let quote_decimals = match group_context.tokens.get(&context.market.quote_token_index) {
+            let quote_decimals = match group_context.tokens.get(&context.quote_token_index) {
                 Some(token) => token.decimals,
                 None => panic!("token not found for market"), // todo: default to 6 for usdc?
             };
             (
-                context.market.serum_market_external,
+                context.serum_market_external,
                 MarketConfig {
-                    name: context.market.name().to_owned(),
+                    name: context.name.clone(),
                     bids: context.bids,
                     asks: context.asks,
                     event_queue: context.event_q,

--- a/bin/service-mango-pnl/src/main.rs
+++ b/bin/service-mango-pnl/src/main.rs
@@ -65,7 +65,6 @@ async fn compute_pnl(
                 .perp_markets
                 .get(&pp.market_index)
                 .unwrap()
-                .market
                 .settle_token_index;
             let perp_settle_health = health_cache.perp_max_settle(settle_token_index).unwrap();
             let settleable_pnl = if pnl > 0 {

--- a/bin/settler/src/settle.rs
+++ b/bin/settler/src/settle.rs
@@ -42,7 +42,7 @@ fn perp_markets_and_prices(
 
             let settle_token = mango_client.context.token(perp_market.settle_token_index);
             let settle_token_price =
-                account_fetcher.fetch_bank_price(&settle_token.mint_info.first_bank())?;
+                account_fetcher.fetch_bank_price(&settle_token.first_bank())?;
 
             Ok((
                 *market_index,

--- a/bin/settler/src/tcs_start.rs
+++ b/bin/settler/src/tcs_start.rs
@@ -112,7 +112,7 @@ impl State {
 
             // Clear newly created token positions, so the liqor account is mostly empty
             for token_index in startable_chunk.iter().map(|(_, _, ti)| *ti).unique() {
-                let mint = mango_client.context.token(token_index).mint_info.mint;
+                let mint = mango_client.context.token(token_index).mint;
                 instructions.append(mango_client.token_withdraw_instructions(
                     &liqor_account,
                     mint,
@@ -166,12 +166,7 @@ impl State {
     }
 
     fn oracle_for_token(&self, token_index: TokenIndex) -> anyhow::Result<I80F48> {
-        let bank_pk = self
-            .mango_client
-            .context
-            .token(token_index)
-            .mint_info
-            .first_bank();
+        let bank_pk = self.mango_client.context.token(token_index).first_bank();
         self.account_fetcher.fetch_bank_price(&bank_pk)
     }
 
@@ -201,7 +196,6 @@ impl State {
             .mango_client
             .context
             .token(tcs.sell_token_index)
-            .mint_info
             .first_bank();
         let mut sell_bank: Bank = self.account_fetcher.fetch(&sell_bank_pk)?;
         let sell_pos = account.token_position(tcs.sell_token_index)?;

--- a/lib/client/src/jupiter/v4.rs
+++ b/lib/client/src/jupiter/v4.rs
@@ -211,25 +211,19 @@ impl<'a> JupiterV4<'a> {
                 .position(|ix| !is_setup_ix(ix.program_id))
                 .unwrap();
 
-        let bank_ams = [
-            source_token.mint_info.first_bank(),
-            target_token.mint_info.first_bank(),
-        ]
-        .into_iter()
-        .map(util::to_writable_account_meta)
-        .collect::<Vec<_>>();
+        let bank_ams = [source_token.first_bank(), target_token.first_bank()]
+            .into_iter()
+            .map(util::to_writable_account_meta)
+            .collect::<Vec<_>>();
 
-        let vault_ams = [
-            source_token.mint_info.first_vault(),
-            target_token.mint_info.first_vault(),
-        ]
-        .into_iter()
-        .map(util::to_writable_account_meta)
-        .collect::<Vec<_>>();
+        let vault_ams = [source_token.first_vault(), target_token.first_vault()]
+            .into_iter()
+            .map(util::to_writable_account_meta)
+            .collect::<Vec<_>>();
 
         let owner = self.mango_client.owner();
 
-        let token_ams = [source_token.mint_info.mint, target_token.mint_info.mint]
+        let token_ams = [source_token.mint, target_token.mint]
             .into_iter()
             .map(|mint| {
                 util::to_writable_account_meta(
@@ -270,7 +264,7 @@ impl<'a> JupiterV4<'a> {
             spl_associated_token_account::instruction::create_associated_token_account_idempotent(
                 &owner,
                 &owner,
-                &source_token.mint_info.mint,
+                &source_token.mint,
                 &Token::id(),
             ),
         );

--- a/lib/client/src/jupiter/v6.rs
+++ b/lib/client/src/jupiter/v6.rs
@@ -220,25 +220,19 @@ impl<'a> JupiterV6<'a> {
         let source_token = self.mango_client.context.token_by_mint(&input_mint)?;
         let target_token = self.mango_client.context.token_by_mint(&output_mint)?;
 
-        let bank_ams = [
-            source_token.mint_info.first_bank(),
-            target_token.mint_info.first_bank(),
-        ]
-        .into_iter()
-        .map(util::to_writable_account_meta)
-        .collect::<Vec<_>>();
+        let bank_ams = [source_token.first_bank(), target_token.first_bank()]
+            .into_iter()
+            .map(util::to_writable_account_meta)
+            .collect::<Vec<_>>();
 
-        let vault_ams = [
-            source_token.mint_info.first_vault(),
-            target_token.mint_info.first_vault(),
-        ]
-        .into_iter()
-        .map(util::to_writable_account_meta)
-        .collect::<Vec<_>>();
+        let vault_ams = [source_token.first_vault(), target_token.first_vault()]
+            .into_iter()
+            .map(util::to_writable_account_meta)
+            .collect::<Vec<_>>();
 
         let owner = self.mango_client.owner();
 
-        let token_ams = [source_token.mint_info.mint, target_token.mint_info.mint]
+        let token_ams = [source_token.mint, target_token.mint]
             .into_iter()
             .map(|mint| {
                 util::to_writable_account_meta(
@@ -303,7 +297,7 @@ impl<'a> JupiterV6<'a> {
             spl_associated_token_account::instruction::create_associated_token_account_idempotent(
                 &owner,
                 &owner,
-                &source_token.mint_info.mint,
+                &source_token.mint,
                 &Token::id(),
             ),
         );

--- a/lib/client/src/lib.rs
+++ b/lib/client/src/lib.rs
@@ -10,7 +10,7 @@ mod chain_data_fetcher;
 mod client;
 mod context;
 pub mod error_tracking;
-mod gpa;
+pub mod gpa;
 pub mod health_cache;
 pub mod jupiter;
 pub mod perp_pnl;


### PR DESCRIPTION
- Don't just restart on new listings, but also on significant changes to old listings such as oracle changes.
- Cover the liquidator and settler in addition to the keeper.