### PR TITLE
Deposit limits

### DIFF
--- a/bin/liquidator/src/liquidate.rs
+++ b/bin/liquidator/src/liquidate.rs
@@ -308,7 +308,7 @@ impl<'a> LiquidateHelper<'a> {
         // TODO: This is where we could multiply in the liquidation fee factors
         let price = source_price / target_price;
 
-        util::max_swap_source(
+        util::max_swap_source_ignoring_limits(
             self.client,
             self.account_fetcher,
             &liqor,

--- a/bin/liquidator/src/trigger_tcs.rs
+++ b/bin/liquidator/src/trigger_tcs.rs
@@ -26,10 +26,9 @@ use crate::{token_swap_info, util, ErrorTracking};
 /// making the whole execution fail.
 const SLIPPAGE_BUFFER: f64 = 0.01; // 1%
 
-/// If a tcs gets limited due to exhausted net borrows, don't trigger execution if
-/// the possible value is below this amount. This avoids spamming executions when net
-/// borrows are exhausted.
-const NET_BORROW_EXECUTION_THRESHOLD: u64 = 1_000_000; // 1 USD
+/// If a tcs gets limited due to exhausted net borrows or deposit limits, don't trigger execution if
+/// the possible value is below this amount. This avoids spamming executions when limits are exhausted.
+const EXECUTION_THRESHOLD: u64 = 1_000_000; // 1 USD
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Mode {
@@ -440,12 +439,17 @@ impl Context {
     /// This includes
     /// - tcs restrictions (remaining buy/sell, create borrows/deposits)
     /// - reduce only banks
-    /// - net borrow limits on BOTH sides, even though the buy side is technically
-    ///   a liqor limitation: the liqor could acquire the token before trying the
-    ///   execution... but in practice the liqor will work on margin
+    /// - net borrow limits:
+    ///   - the account may borrow the sell token (and the liqor side may not be a repay)
+    ///   - the liqor may borrow the buy token (and the account side may not be a repay)
+    ///     this is technically a liqor limitation: the liqor could acquire the token before trying the
+    ///     execution... but in practice the liqor may work on margin
+    /// - deposit limits:
+    ///   - the account may deposit the buy token (while the liqor borrowed it)
+    ///   - the liqor may deposit the sell token (while the account borrowed it)
     ///
     /// Returns Some((native buy amount, native sell amount)) if execution is sensible
-    /// Returns None if the execution should be skipped (due to net borrow limits...)
+    /// Returns None if the execution should be skipped (due to limits)
     pub fn tcs_max_liqee_execution(
         &self,
         account: &MangoAccountValue,
@@ -458,18 +462,18 @@ impl Context {
         let premium_price = tcs.premium_price(base_price.to_num(), self.now_ts);
         let maker_price = tcs.maker_price(premium_price);
 
-        let buy_position = account
+        let liqee_buy_position = account
             .token_position(tcs.buy_token_index)
             .map(|p| p.native(&buy_bank))
             .unwrap_or(I80F48::ZERO);
-        let sell_position = account
+        let liqee_sell_position = account
             .token_position(tcs.sell_token_index)
             .map(|p| p.native(&sell_bank))
             .unwrap_or(I80F48::ZERO);
 
         // this is in "buy token received per sell token given" units
         let swap_price = I80F48::from_num((1.0 - SLIPPAGE_BUFFER) / maker_price);
-        let max_sell_ignoring_net_borrows = util::max_swap_source_ignore_net_borrows(
+        let max_sell_ignoring_limits = util::max_swap_source_ignoring_limits(
             &self.mango_client,
             &self.account_fetcher,
             account,
@@ -480,41 +484,31 @@ impl Context {
         )?
         .floor()
         .to_num::<u64>()
-        .min(tcs.max_sell_for_position(sell_position, &sell_bank));
+        .min(tcs.max_sell_for_position(liqee_sell_position, &sell_bank));
 
-        let max_buy_ignoring_net_borrows = tcs.max_buy_for_position(buy_position, &buy_bank);
+        let max_buy_ignoring_limits = tcs.max_buy_for_position(liqee_buy_position, &buy_bank);
 
-        // What follows is a complex manual handling of net borrow limits, for the following reason:
+        // What follows is a complex manual handling of net borrow/deposit limits, for
+        // the following reason:
         // Usually, we want to execute tcs even for small amounts because that will close the
         // tcs order: either due to full execution or due to the health threshold being reached.
         //
-        // However, when the net borrow limits are hit, it will not closed when no further execution
-        // is possible, because net borrow limit issues are considered transient. Furthermore, we
-        // don't even want to send a tiny tcs trigger transactions, because there's a good chance we
-        // would then be sending lot of those as oracle prices fluctuate.
+        // However, when the limits are hit, it will not closed when no further execution
+        // is possible, because limit issues are transient. Furthermore, we don't want to send
+        // tiny tcs trigger transactions, because there's a good chance we would then be sending
+        // lot of those as oracle prices fluctuate.
         //
         // Thus, we need to detect if the possible execution amount is tiny _because_ of the
-        // net borrow limits. Then skip. If it's tiny for other reasons we can proceed.
+        // limits. Then skip. If it's tiny for other reasons we can proceed.
 
-        fn available_borrows(bank: &Bank, price: I80F48) -> u64 {
-            (bank.remaining_net_borrows_quote(price) / price).clamp_to_u64()
-        }
-        let available_buy_borrows = available_borrows(&buy_bank, buy_token_price);
-        let available_sell_borrows = available_borrows(&sell_bank, sell_token_price);
-
-        // New borrows if max_sell_ignoring_net_borrows was withdrawn on the liqee
-        let sell_borrows = (I80F48::from(max_sell_ignoring_net_borrows)
-            - sell_position.max(I80F48::ZERO))
-        .clamp_to_u64();
-
-        // On the buy side, the liqor might need to borrow
-        let buy_borrows = match self.config.mode {
+        // Do the liqor buy tokens come from deposits or are they borrowed?
+        let mut liqor_buy_borrows = match self.config.mode {
             Mode::BorrowBuyToken => {
                 // Assume that the liqor has enough buy token if it's collateral
                 if tcs.buy_token_index == self.config.collateral_token_index {
                     0
                 } else {
-                    max_buy_ignoring_net_borrows
+                    max_buy_ignoring_limits
                 }
             }
             Mode::SwapCollateralIntoBuy { .. } => 0,
@@ -525,19 +519,77 @@ impl Context {
             }
         };
 
-        // New maximums adjusted for net borrow limits
-        let max_sell =
-            max_sell_ignoring_net_borrows - sell_borrows + sell_borrows.min(available_sell_borrows);
-        let max_buy =
-            max_buy_ignoring_net_borrows - buy_borrows + buy_borrows.min(available_buy_borrows);
+        // First, net borrow limits
+        let max_sell_net_borrows;
+        let max_buy_net_borrows;
+        {
+            fn available_borrows(bank: &Bank, price: I80F48) -> u64 {
+                bank.remaining_net_borrows_quote(price)
+                    .saturating_div(price)
+                    .clamp_to_u64()
+            }
+            let available_buy_borrows = available_borrows(&buy_bank, buy_token_price);
+            let available_sell_borrows = available_borrows(&sell_bank, sell_token_price);
 
-        let tiny_due_to_net_borrows = {
-            let buy_threshold = I80F48::from(NET_BORROW_EXECUTION_THRESHOLD) / buy_token_price;
-            let sell_threshold = I80F48::from(NET_BORROW_EXECUTION_THRESHOLD) / sell_token_price;
-            max_buy < buy_threshold && max_buy_ignoring_net_borrows > buy_threshold
-                || max_sell < sell_threshold && max_sell_ignoring_net_borrows > sell_threshold
+            // New borrows if max_sell_ignoring_limits was withdrawn on the liqee
+            // We assume that on the liqor side the position is >= 0, so these are true
+            // new borrows.
+            let sell_borrows = (I80F48::from(max_sell_ignoring_limits)
+                - liqee_sell_position.max(I80F48::ZERO))
+            .ceil()
+            .clamp_to_u64();
+
+            // On the buy side, the liqor might need to borrow, see liqor_buy_borrows.
+            // On the liqee side, the bought tokens may repay a borrow, reducing net borrows again
+            let buy_borrows = (I80F48::from(liqor_buy_borrows)
+                + liqee_buy_position.min(I80F48::ZERO))
+            .ceil()
+            .clamp_to_u64();
+
+            // New maximums adjusted for net borrow limits
+            max_sell_net_borrows = max_sell_ignoring_limits
+                - (sell_borrows - sell_borrows.min(available_sell_borrows));
+            max_buy_net_borrows =
+                max_buy_ignoring_limits - (buy_borrows - buy_borrows.min(available_buy_borrows));
+            liqor_buy_borrows = liqor_buy_borrows.min(max_buy_net_borrows);
+        }
+
+        // Second, deposit limits
+        let max_sell;
+        let max_buy;
+        {
+            let available_buy_deposits = buy_bank.remaining_deposits_until_limit().clamp_to_u64();
+            let available_sell_deposits = sell_bank.remaining_deposits_until_limit().clamp_to_u64();
+
+            // New deposits on the liqee side (reduced by repaid borrows)
+            let liqee_buy_deposits = (I80F48::from(max_buy_net_borrows)
+                + liqee_buy_position.min(I80F48::ZERO))
+            .ceil()
+            .clamp_to_u64();
+            // the net new deposits can only be as big as the liqor borrows
+            // (assume no borrows, then deposits only move from liqor to liqee)
+            let buy_deposits = liqee_buy_deposits.min(liqor_buy_borrows);
+
+            // We assume the liqor position is always >= 0, meaning there are new sell token deposits if
+            // the sell token gets borrowed on the liqee side.
+            let sell_deposits = (I80F48::from(max_sell_net_borrows)
+                - liqee_sell_position.max(I80F48::ZERO))
+            .ceil()
+            .clamp_to_u64();
+
+            max_sell =
+                max_sell_net_borrows - (sell_deposits - sell_deposits.min(available_sell_deposits));
+            max_buy =
+                max_buy_net_borrows - (buy_deposits - buy_deposits.min(available_buy_deposits));
+        }
+
+        let tiny_due_to_limits = {
+            let buy_threshold = I80F48::from(EXECUTION_THRESHOLD) / buy_token_price;
+            let sell_threshold = I80F48::from(EXECUTION_THRESHOLD) / sell_token_price;
+            max_buy < buy_threshold && max_buy_ignoring_limits > buy_threshold
+                || max_sell < sell_threshold && max_sell_ignoring_limits > sell_threshold
         };
-        if tiny_due_to_net_borrows {
+        if tiny_due_to_limits {
             return Ok(None);
         }
 
@@ -715,7 +767,7 @@ impl Context {
             .0
             .native(&buy_bank);
         let liqor_available_buy_token = match mode {
-            Mode::BorrowBuyToken => util::max_swap_source(
+            Mode::BorrowBuyToken => util::max_swap_source_with_limits(
                 &self.mango_client,
                 &self.account_fetcher,
                 &liqor,
@@ -734,7 +786,7 @@ impl Context {
                         self.token_bank_price_mint(collateral_token_index)?;
                     let buy_per_collateral_price = (collateral_price / buy_token_price)
                         * I80F48::from_num(jupiter_slippage_fraction);
-                    let collateral_amount = util::max_swap_source(
+                    let collateral_amount = util::max_swap_source_with_limits(
                         &self.mango_client,
                         &self.account_fetcher,
                         &liqor,
@@ -751,7 +803,7 @@ impl Context {
                 // How big can the sell -> buy swap be?
                 let buy_per_sell_price =
                     (I80F48::from(1) / taker_price) * I80F48::from_num(jupiter_slippage_fraction);
-                let max_sell = util::max_swap_source(
+                let max_sell = util::max_swap_source_with_limits(
                     &self.mango_client,
                     &self.account_fetcher,
                     &liqor,

--- a/bin/liquidator/src/util.rs
+++ b/bin/liquidator/src/util.rs
@@ -38,7 +38,9 @@ pub fn is_perp_market<'a>(
 }
 
 /// Convenience wrapper for getting max swap amounts for a token pair
-pub fn max_swap_source(
+///
+/// This applies net borrow and deposit limits, which is useful for true swaps.
+pub fn max_swap_source_with_limits(
     client: &MangoClient,
     account_fetcher: &chain_data::AccountFetcher,
     account: &MangoAccountValue,
@@ -64,7 +66,7 @@ pub fn max_swap_source(
     let source_price = health_cache.token_info(source).unwrap().prices.oracle;
 
     let amount = health_cache
-        .max_swap_source_for_health_ratio(
+        .max_swap_source_for_health_ratio_with_limits(
             &account,
             &source_bank,
             source_price,
@@ -77,7 +79,10 @@ pub fn max_swap_source(
 }
 
 /// Convenience wrapper for getting max swap amounts for a token pair
-pub fn max_swap_source_ignore_net_borrows(
+///
+/// This is useful for liquidations, which don't increase deposits or net borrows.
+/// Tcs execution can also increase deposits/net borrows.
+pub fn max_swap_source_ignoring_limits(
     client: &MangoClient,
     account_fetcher: &chain_data::AccountFetcher,
     account: &MangoAccountValue,
@@ -97,17 +102,13 @@ pub fn max_swap_source_ignore_net_borrows(
         mango_v4_client::health_cache::new_sync(&client.context, account_fetcher, &account)
             .expect("always ok");
 
-    let mut source_bank: Bank =
-        account_fetcher.fetch(&client.context.token(source).first_bank())?;
-    source_bank.net_borrow_limit_per_window_quote = -1;
-    let mut target_bank: Bank =
-        account_fetcher.fetch(&client.context.token(target).first_bank())?;
-    target_bank.net_borrow_limit_per_window_quote = -1;
+    let source_bank: Bank = account_fetcher.fetch(&client.context.token(source).first_bank())?;
+    let target_bank: Bank = account_fetcher.fetch(&client.context.token(target).first_bank())?;
 
     let source_price = health_cache.token_info(source).unwrap().prices.oracle;
 
     let amount = health_cache
-        .max_swap_source_for_health_ratio(
+        .max_swap_source_for_health_ratio_ignoring_limits(
             &account,
             &source_bank,
             source_price,

--- a/mango_v4.json
+++ b/mango_v4.json
@@ -614,6 +614,10 @@
         {
           "name": "groupInsuranceFund",
           "type": "bool"
+        },
+        {
+          "name": "depositLimit",
+          "type": "u64"
         }
       ]
     },
@@ -988,6 +992,12 @@
         {
           "name": "maintWeightShiftAbort",
           "type": "bool"
+        },
+        {
+          "name": "depositLimitOpt",
+          "type": {
+            "option": "u64"
+          }
         }
       ]
     },
@@ -2357,6 +2367,10 @@
         {
           "name": "name",
           "type": "string"
+        },
+        {
+          "name": "oraclePriceBand",
+          "type": "f32"
         }
       ]
     },
@@ -2399,6 +2413,12 @@
           "name": "nameOpt",
           "type": {
             "option": "string"
+          }
+        },
+        {
+          "name": "oraclePriceBandOpt",
+          "type": {
+            "option": "f32"
           }
         }
       ]
@@ -2742,6 +2762,9 @@
     },
     {
       "name": "serum3PlaceOrderV2",
+      "docs": [
+        "requires the receiver_bank in the health account list to be writable"
+      ],
       "accounts": [
         {
           "name": "group",
@@ -7335,11 +7358,9 @@
             "name": "potentialSerumTokens",
             "docs": [
               "Largest amount of tokens that might be added the the bank based on",
-              "serum open order execution.",
-              "",
-              "Can be negative with multiple banks, then it'd need to be balanced in the keeper."
+              "serum open order execution."
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "maintWeightShiftStart",
@@ -7368,11 +7389,18 @@
             }
           },
           {
+            "name": "depositLimit",
+            "docs": [
+              "zero means none, in token native"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                2008
+                2000
               ]
             }
           }
@@ -8492,9 +8520,19 @@
             "type": {
               "array": [
                 "u8",
-                5
+                1
               ]
             }
+          },
+          {
+            "name": "oraclePriceBand",
+            "docs": [
+              "Limit orders must be <= oracle * (1+band) and >= oracle / (1+band)",
+              "",
+              "Zero value is the default due to migration and disables the limit,",
+              "same as f32::MAX."
+            ],
+            "type": "f32"
           },
           {
             "name": "registrationTime",
@@ -13557,6 +13595,16 @@
       "code": 6060,
       "name": "HealthAccountBankNotWritable",
       "msg": "a bank in the health account list should be writable but is not"
+    },
+    {
+      "code": 6061,
+      "name": "Serum3PriceBandExceeded",
+      "msg": "the market does not allow limit orders too far from the current oracle value"
+    },
+    {
+      "code": 6062,
+      "name": "BankDepositLimit",
+      "msg": "deposit crosses the token's deposit limit"
     }
   ]
 }

--- a/programs/mango-v4/src/error.rs
+++ b/programs/mango-v4/src/error.rs
@@ -129,6 +129,8 @@ pub enum MangoError {
     HealthAccountBankNotWritable,
     #[msg("the market does not allow limit orders too far from the current oracle value")]
     Serum3PriceBandExceeded,
+    #[msg("deposit crosses the token's deposit limit")]
+    BankDepositLimit,
 }
 
 impl MangoError {

--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -467,6 +467,10 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
             bank.check_net_borrows(*oracle_price)?;
         }
 
+        if change_amount > 0 && native_after_change > 0 {
+            bank.check_deposit_and_oo_limit()?;
+        }
+
         bank.flash_loan_approved_amount = 0;
         bank.flash_loan_token_account_initial = u64::MAX;
 

--- a/programs/mango-v4/src/instructions/token_edit.rs
+++ b/programs/mango-v4/src/instructions/token_edit.rs
@@ -50,6 +50,7 @@ pub fn token_edit(
     maint_weight_shift_liab_target_opt: Option<f32>,
     maint_weight_shift_abort: bool,
     set_fallback_oracle: bool,
+    deposit_limit_opt: Option<u64>,
 ) -> Result<()> {
     let group = ctx.accounts.group.load()?;
 
@@ -446,6 +447,16 @@ pub fn token_edit(
                 was_enabled,
                 bank.maint_weight_shift_duration_inv.is_positive(),
             );
+        }
+
+        if let Some(deposit_limit) = deposit_limit_opt {
+            msg!(
+                "Deposit limit old {:?}, new {:?}",
+                bank.deposit_limit,
+                deposit_limit
+            );
+            bank.deposit_limit = deposit_limit;
+            require_group_admin = true;
         }
     }
 

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -41,6 +41,7 @@ pub fn token_register(
     interest_curve_scaling: f32,
     interest_target_utilization: f32,
     group_insurance_fund: bool,
+    deposit_limit: u64,
 ) -> Result<()> {
     // Require token 0 to be in the insurance token
     if token_index == INSURANCE_TOKEN_INDEX {
@@ -120,7 +121,8 @@ pub fn token_register(
         maint_weight_shift_asset_target: I80F48::ZERO,
         maint_weight_shift_liab_target: I80F48::ZERO,
         fallback_oracle: ctx.accounts.fallback_oracle.key(),
-        reserved: [0; 1976],
+        deposit_limit,
+        reserved: [0; 1968],
     };
 
     if let Ok(oracle_price) =

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -103,7 +103,8 @@ pub fn token_register_trustless(
         maint_weight_shift_asset_target: I80F48::ZERO,
         maint_weight_shift_liab_target: I80F48::ZERO,
         fallback_oracle: ctx.accounts.fallback_oracle.key(),
-        reserved: [0; 1976],
+        deposit_limit: 0,
+        reserved: [0; 1968],
     };
 
     if let Ok(oracle_price) =

--- a/programs/mango-v4/src/lib.rs
+++ b/programs/mango-v4/src/lib.rs
@@ -153,6 +153,7 @@ pub mod mango_v4 {
         interest_curve_scaling: f32,
         interest_target_utilization: f32,
         group_insurance_fund: bool,
+        deposit_limit: u64,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::token_register(
@@ -183,6 +184,7 @@ pub mod mango_v4 {
             interest_curve_scaling,
             interest_target_utilization,
             group_insurance_fund,
+            deposit_limit,
         )?;
         Ok(())
     }
@@ -235,6 +237,7 @@ pub mod mango_v4 {
         maint_weight_shift_liab_target_opt: Option<f32>,
         maint_weight_shift_abort: bool,
         set_fallback_oracle: bool,
+        deposit_limit_opt: Option<u64>,
     ) -> Result<()> {
         #[cfg(feature = "enable-gpl")]
         instructions::token_edit(
@@ -274,6 +277,7 @@ pub mod mango_v4 {
             maint_weight_shift_liab_target_opt,
             maint_weight_shift_abort,
             set_fallback_oracle,
+            deposit_limit_opt,
         )?;
         Ok(())
     }
@@ -638,6 +642,7 @@ pub mod mango_v4 {
         Ok(())
     }
 
+    /// requires the receiver_bank in the health account list to be writable
     #[allow(clippy::too_many_arguments)]
     pub fn serum3_place_order_v2(
         ctx: Context<Serum3PlaceOrder>,

--- a/programs/mango-v4/tests/cases/test_basic.rs
+++ b/programs/mango-v4/tests/cases/test_basic.rs
@@ -514,3 +514,174 @@ async fn test_bank_maint_weight_shift() -> Result<(), TransportError> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_bank_deposit_limit() -> Result<(), TransportError> {
+    let context = TestContext::new().await;
+    let solana = &context.solana.clone();
+
+    let admin = TestKeypair::new();
+    let owner = context.users[0].key;
+    let payer = context.users[1].key;
+    let payer_token_account = context.users[1].token_accounts[0];
+    let mints = &context.mints[0..1];
+
+    let mango_setup::GroupWithTokens { group, .. } = mango_setup::GroupWithTokensConfig {
+        admin,
+        payer,
+        mints: mints.to_vec(),
+        zero_token_is_quote: true,
+        ..mango_setup::GroupWithTokensConfig::default()
+    }
+    .create(solana)
+    .await;
+
+    let funding_amount = 0;
+    let account1 = create_funded_account(
+        &solana,
+        group,
+        owner,
+        1,
+        &context.users[1],
+        &mints[0..0],
+        funding_amount,
+        0,
+    )
+    .await;
+    let account2 = create_funded_account(
+        &solana,
+        group,
+        owner,
+        2,
+        &context.users[1],
+        &mints[0..0],
+        funding_amount,
+        0,
+    )
+    .await;
+
+    send_tx(
+        solana,
+        TokenEdit {
+            group,
+            admin,
+            mint: mints[0].pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(2000),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    let default_deposit_ix = TokenDepositInstruction {
+        amount: 0,
+        reduce_only: false,
+        account: Pubkey::default(),
+        owner,
+        token_account: payer_token_account,
+        token_authority: payer,
+        bank_index: 0,
+    };
+
+    send_tx_expect_error!(
+        solana,
+        TokenDepositInstruction {
+            amount: 2001,
+            account: account1,
+            ..default_deposit_ix
+        },
+        MangoError::BankDepositLimit
+    );
+
+    send_tx(
+        solana,
+        TokenDepositInstruction {
+            amount: 1001,
+            account: account1,
+            ..default_deposit_ix
+        },
+    )
+    .await
+    .unwrap();
+
+    send_tx_expect_error!(
+        solana,
+        TokenDepositInstruction {
+            amount: 1000,
+            account: account1,
+            ..default_deposit_ix
+        },
+        MangoError::BankDepositLimit
+    );
+
+    send_tx_expect_error!(
+        solana,
+        TokenDepositInstruction {
+            amount: 1000,
+            account: account2,
+            ..default_deposit_ix
+        },
+        MangoError::BankDepositLimit
+    );
+
+    send_tx(
+        solana,
+        TokenDepositInstruction {
+            amount: 998, // 999 does not work due to rounding
+            account: account2,
+            ..default_deposit_ix
+        },
+    )
+    .await
+    .unwrap();
+
+    send_tx_expect_error!(
+        solana,
+        TokenDepositInstruction {
+            amount: 1,
+            account: account2,
+            ..default_deposit_ix
+        },
+        MangoError::BankDepositLimit
+    );
+
+    send_tx(
+        solana,
+        TokenWithdrawInstruction {
+            amount: 5,
+            allow_borrow: false,
+            account: account2,
+            owner,
+            token_account: payer_token_account,
+            bank_index: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    send_tx_expect_error!(
+        solana,
+        TokenDepositInstruction {
+            amount: 6,
+            account: account2,
+            ..default_deposit_ix
+        },
+        MangoError::BankDepositLimit
+    );
+
+    send_tx(
+        solana,
+        TokenDepositInstruction {
+            amount: 5,
+            account: account2,
+            ..default_deposit_ix
+        },
+    )
+    .await
+    .unwrap();
+
+    Ok(())
+}

--- a/programs/mango-v4/tests/cases/test_margin_trade.rs
+++ b/programs/mango-v4/tests/cases/test_margin_trade.rs
@@ -614,3 +614,118 @@ async fn test_flash_loan_creates_ata_accounts() -> Result<(), BanksClientError> 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_margin_trade_deposit_limit() -> Result<(), BanksClientError> {
+    let mut test_builder = TestContextBuilder::new();
+    test_builder.test().set_compute_max_units(100_000);
+    let context = test_builder.start_default().await;
+    let solana = &context.solana.clone();
+
+    let admin = TestKeypair::new();
+    let owner = context.users[0].key;
+    let payer = context.users[1].key;
+    let mints = &context.mints[0..2];
+    let payer_mint0_account = context.users[1].token_accounts[0];
+
+    //
+    // SETUP: Create a group, account, register a token (mint0)
+    //
+
+    let GroupWithTokens { group, tokens, .. } = GroupWithTokensConfig {
+        admin,
+        payer,
+        mints: mints.to_vec(),
+        ..GroupWithTokensConfig::default()
+    }
+    .create(solana)
+    .await;
+    let bank = tokens[0].bank;
+
+    //
+    // SETUP: deposit limit
+    //
+    send_tx(
+        solana,
+        TokenEdit {
+            group,
+            admin,
+            mint: tokens[0].mint.pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(1000),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    //
+    // create the test user account
+    //
+
+    let deposit_amount_initial = 100;
+    let account = create_funded_account(
+        &solana,
+        group,
+        owner,
+        0,
+        &context.users[1],
+        &mints[..1],
+        deposit_amount_initial,
+        0,
+    )
+    .await;
+
+    //
+    // TEST: Margin trade
+    //
+    let margin_account = payer_mint0_account;
+    let target_token_account = context.users[0].token_accounts[0];
+    let make_flash_loan_tx = |solana, deposit_amount| async move {
+        let mut tx = ClientTransaction::new(solana);
+        let loans = vec![FlashLoanPart {
+            bank,
+            token_account: target_token_account,
+            withdraw_amount: 0,
+        }];
+        tx.add_instruction(FlashLoanBeginInstruction {
+            account,
+            owner,
+            loans: loans.clone(),
+        })
+        .await;
+        tx.add_instruction_direct(
+            spl_token::instruction::transfer(
+                &spl_token::ID,
+                &margin_account,
+                &target_token_account,
+                &payer.pubkey(),
+                &[&payer.pubkey()],
+                deposit_amount,
+            )
+            .unwrap(),
+        );
+        tx.add_signer(payer);
+        tx.add_instruction(FlashLoanEndInstruction {
+            account,
+            owner,
+            loans,
+            // the test only accesses a single token: not a swap
+            flash_loan_type: mango_v4::accounts_ix::FlashLoanType::Unknown,
+        })
+        .await;
+        tx
+    };
+
+    make_flash_loan_tx(solana, 901)
+        .await
+        .send_expect_error(MangoError::BankDepositLimit)
+        .await
+        .unwrap();
+
+    make_flash_loan_tx(solana, 899).await.send().await.unwrap();
+
+    Ok(())
+}

--- a/programs/mango-v4/tests/cases/test_serum.rs
+++ b/programs/mango-v4/tests/cases/test_serum.rs
@@ -1750,6 +1750,166 @@ async fn test_serum_bands() -> Result<(), TransportError> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_serum_deposit_limits() -> Result<(), TransportError> {
+    let mut test_builder = TestContextBuilder::new();
+    test_builder.test().set_compute_max_units(150_000); // Serum3PlaceOrder needs lots
+    let context = test_builder.start_default().await;
+    let solana = &context.solana.clone();
+
+    //
+    // SETUP: Create a group, accounts, market etc
+    //
+    let deposit_amount = 5000; // for 10k tokens over both order_placers
+    let CommonSetup {
+        group_with_tokens,
+        mut order_placer,
+        quote_token,
+        base_token,
+        ..
+    } = common_setup2(&context, deposit_amount, 0).await;
+
+    //
+    // SETUP: Set oracle price for market to 2
+    //
+    set_bank_stub_oracle_price(
+        solana,
+        group_with_tokens.group,
+        &base_token,
+        group_with_tokens.admin,
+        4.0,
+    )
+    .await;
+    set_bank_stub_oracle_price(
+        solana,
+        group_with_tokens.group,
+        &quote_token,
+        group_with_tokens.admin,
+        2.0,
+    )
+    .await;
+
+    //
+    // SETUP: Base token: add deposit limit
+    //
+    send_tx(
+        solana,
+        TokenEdit {
+            group: group_with_tokens.group,
+            admin: group_with_tokens.admin,
+            mint: base_token.mint.pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(13000),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    let solana2 = context.solana.clone();
+    let base_bank = base_token.bank;
+    let remaining_base = {
+        || async {
+            let b: Bank = solana2.get_account(base_bank).await;
+            b.remaining_deposits_until_limit().round().to_num::<u64>()
+        }
+    };
+
+    //
+    // TEST: even when placing all base tokens into an ask, they still count
+    //
+
+    order_placer.ask(2.0, 5000).await.unwrap();
+    assert_eq!(remaining_base().await, 3000);
+
+    //
+    // TEST: if we bid to buy more base, the limit reduces
+    //
+
+    order_placer.bid_maker(1.5, 1000).await.unwrap();
+    assert_eq!(remaining_base().await, 2000);
+
+    //
+    // TEST: if we bid too much for the limit, the order does not go through
+    //
+
+    let r = order_placer.try_bid(1.5, 2001, false).await;
+    assert_mango_error(&r, MangoError::BankDepositLimit.into(), "dep limit".into());
+    order_placer.try_bid(1.5, 1999, false).await.unwrap(); // not 2000 due to rounding
+
+    //
+    // SETUP: Switch deposit limit to quote token
+    //
+
+    send_tx(
+        solana,
+        TokenEdit {
+            group: group_with_tokens.group,
+            admin: group_with_tokens.admin,
+            mint: base_token.mint.pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(0),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+    send_tx(
+        solana,
+        TokenEdit {
+            group: group_with_tokens.group,
+            admin: group_with_tokens.admin,
+            mint: quote_token.mint.pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(13000),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    let solana2 = context.solana.clone();
+    let quote_bank = quote_token.bank;
+    let remaining_quote = {
+        || async {
+            let b: Bank = solana2.get_account(quote_bank).await;
+            b.remaining_deposits_until_limit().round().to_num::<u64>()
+        }
+    };
+
+    order_placer.cancel_all().await;
+
+    //
+    // TEST: even when placing all quote tokens into a bid, they still count
+    //
+
+    order_placer.bid_maker(2.0, 2500).await.unwrap();
+    assert_eq!(remaining_quote().await, 3000);
+
+    //
+    // TEST: if we ask to get more quote, the limit reduces
+    //
+
+    order_placer.ask(5.0, 200).await.unwrap();
+    assert_eq!(remaining_quote().await, 2000);
+
+    //
+    // TEST: if we bid too much for the limit, the order does not go through
+    //
+
+    let r = order_placer.try_ask(5.0, 401).await;
+    assert_mango_error(&r, MangoError::BankDepositLimit.into(), "dep limit".into());
+    order_placer.try_ask(5.0, 399).await.unwrap(); // not 400 due to rounding
+
+    Ok(())
+}
+
 struct CommonSetup {
     group_with_tokens: GroupWithTokens,
     serum_market_cookie: SpotMarketCookie,
@@ -1760,6 +1920,14 @@ struct CommonSetup {
 }
 
 async fn common_setup(context: &TestContext, deposit_amount: u64) -> CommonSetup {
+    common_setup2(context, deposit_amount, 10000000).await
+}
+
+async fn common_setup2(
+    context: &TestContext,
+    deposit_amount: u64,
+    vault_funding: u64,
+) -> CommonSetup {
     let admin = TestKeypair::new();
     let owner = context.users[0].key;
     let payer = context.users[1].key;
@@ -1834,17 +2002,19 @@ async fn common_setup(context: &TestContext, deposit_amount: u64) -> CommonSetup
     )
     .await;
     // to have enough funds in the vaults
-    create_funded_account(
-        &solana,
-        group,
-        owner,
-        3,
-        &context.users[1],
-        mints,
-        10000000,
-        0,
-    )
-    .await;
+    if vault_funding > 0 {
+        create_funded_account(
+            &solana,
+            group,
+            owner,
+            3,
+            &context.users[1],
+            mints,
+            10000000,
+            0,
+        )
+        .await;
+    }
 
     let open_orders = send_tx(
         solana,

--- a/programs/mango-v4/tests/cases/test_token_conditional_swap.rs
+++ b/programs/mango-v4/tests/cases/test_token_conditional_swap.rs
@@ -1016,3 +1016,146 @@ async fn test_token_conditional_swap_premium_auction() -> Result<(), TransportEr
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_token_conditional_swap_deposit_limit() -> Result<(), TransportError> {
+    pub use utils::assert_equal_f64_f64 as assert_equal_f_f;
+
+    let context = TestContext::new().await;
+    let solana = &context.solana.clone();
+
+    let admin = TestKeypair::new();
+    let owner = context.users[0].key;
+    let payer = context.users[1].key;
+    let mints = &context.mints[0..2];
+
+    //
+    // SETUP: Create a group, account, tokens
+    //
+
+    let mango_setup::GroupWithTokens { group, tokens, .. } = mango_setup::GroupWithTokensConfig {
+        admin,
+        payer,
+        mints: mints.to_vec(),
+        ..mango_setup::GroupWithTokensConfig::default()
+    }
+    .create(solana)
+    .await;
+    let quote_token = &tokens[0];
+    let base_token = &tokens[1];
+
+    // total deposits on quote and base is 2x this value
+    let deposit_amount = 1_000f64;
+    let account = create_funded_account(
+        &solana,
+        group,
+        owner,
+        0,
+        &context.users[1],
+        &mints[..1],
+        deposit_amount as u64,
+        0,
+    )
+    .await;
+    let liqor = create_funded_account(
+        &solana,
+        group,
+        owner,
+        1,
+        &context.users[1],
+        mints,
+        deposit_amount as u64,
+        0,
+    )
+    .await;
+    create_funded_account(
+        &solana,
+        group,
+        owner,
+        99,
+        &context.users[1],
+        &mints[1..],
+        deposit_amount as u64,
+        0,
+    )
+    .await;
+
+    //
+    // SETUP: A base deposit limit
+    //
+    send_tx(
+        solana,
+        TokenEdit {
+            group,
+            admin,
+            mint: base_token.mint.pubkey,
+            fallback_oracle: Pubkey::default(),
+            options: mango_v4::instruction::TokenEdit {
+                deposit_limit_opt: Some(2500),
+                ..token_edit_instruction_default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+
+    //
+    // SETUP: Sell base token from "account" creating borrows that are deposited into liqor,
+    // increasing the total deposits
+    //
+    send_tx(
+        solana,
+        TokenConditionalSwapCreateInstruction {
+            account,
+            owner,
+            buy_mint: quote_token.mint.pubkey,
+            sell_mint: base_token.mint.pubkey,
+            max_buy: 900,
+            max_sell: 900,
+            price_lower_limit: 0.0,
+            price_upper_limit: 10.0,
+            price_premium_rate: 0.01,
+            allow_creating_deposits: true,
+            allow_creating_borrows: true,
+        },
+    )
+    .await
+    .unwrap();
+
+    //
+    // TEST: Large execution fails, a bit smaller is ok
+    //
+
+    send_tx_expect_error!(
+        solana,
+        TokenConditionalSwapTriggerInstruction {
+            liqee: account,
+            liqor,
+            liqor_owner: owner,
+            index: 0,
+            max_buy_token_to_liqee: 100000,
+            max_sell_token_to_liqor: 501,
+            min_buy_token: 1,
+            min_taker_price: 0.0,
+        },
+        MangoError::BankDepositLimit,
+    );
+
+    send_tx(
+        solana,
+        TokenConditionalSwapTriggerInstruction {
+            liqee: account,
+            liqor,
+            liqor_owner: owner,
+            index: 0,
+            max_buy_token_to_liqee: 100000,
+            max_sell_token_to_liqor: 499,
+            min_buy_token: 1,
+            min_taker_price: 0.0,
+        },
+    )
+    .await
+    .unwrap();
+
+    Ok(())
+}

--- a/programs/mango-v4/tests/program_test/utils.rs
+++ b/programs/mango-v4/tests/program_test/utils.rs
@@ -87,15 +87,12 @@ pub fn assert_mango_error<T>(
 ) {
     match result {
         Ok(_) => assert!(false, "No error returned"),
-        Err(TransportError::TransactionError(tx_err)) => match tx_err {
-            TransactionError::InstructionError(_, err) => match err {
-                InstructionError::Custom(err_num) => {
-                    assert_eq!(*err_num, expected_error, "{}", comment);
-                }
-                _ => assert!(false, "Not a mango error"),
-            },
-            _ => assert!(false, "Not a mango error"),
-        },
+        Err(TransportError::TransactionError(TransactionError::InstructionError(
+            _,
+            InstructionError::Custom(err_num),
+        ))) => {
+            assert_eq!(*err_num, expected_error, "{}", comment);
+        }
         _ => assert!(false, "Not a mango error"),
     }
 }

--- a/ts/client/src/accounts/bank.ts
+++ b/ts/client/src/accounts/bank.ts
@@ -132,12 +132,13 @@ export class Bank implements BankForHealth {
       flashLoanSwapFeeRate: number;
       interestTargetUtilization: number;
       interestCurveScaling: number;
-      depositsInSerum: BN;
+      potentialSerumTokens: BN;
       maintWeightShiftStart: BN;
       maintWeightShiftEnd: BN;
       maintWeightShiftDurationInv: I80F48Dto;
       maintWeightShiftAssetTarget: I80F48Dto;
       maintWeightShiftLiabTarget: I80F48Dto;
+      depositLimit: BN;
     },
   ): Bank {
     return new Bank(
@@ -191,12 +192,13 @@ export class Bank implements BankForHealth {
       obj.flashLoanSwapFeeRate,
       obj.interestTargetUtilization,
       obj.interestCurveScaling,
-      obj.depositsInSerum,
+      obj.potentialSerumTokens,
       obj.maintWeightShiftStart,
       obj.maintWeightShiftEnd,
       obj.maintWeightShiftDurationInv,
       obj.maintWeightShiftAssetTarget,
       obj.maintWeightShiftLiabTarget,
+      obj.depositLimit,
     );
   }
 
@@ -251,12 +253,13 @@ export class Bank implements BankForHealth {
     public flashLoanSwapFeeRate: number,
     public interestTargetUtilization: number,
     public interestCurveScaling: number,
-    public depositsInSerum: BN,
+    public potentialSerumTokens: BN,
     public maintWeightShiftStart: BN,
     public maintWeightShiftEnd: BN,
     maintWeightShiftDurationInv: I80F48Dto,
     maintWeightShiftAssetTarget: I80F48Dto,
     maintWeightShiftLiabTarget: I80F48Dto,
+    public depositLimit: BN,
   ) {
     this.name = utf8.decode(new Uint8Array(name)).split('\x00')[0];
     this.oracleConfig = {

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -419,6 +419,7 @@ export class MangoClient {
         params.interestCurveScaling,
         params.interestTargetUtilization,
         params.groupInsuranceFund,
+        params.depositLimit,
       )
       .accounts({
         group: group.publicKey,
@@ -501,6 +502,7 @@ export class MangoClient {
         params.maintWeightShiftAssetTarget,
         params.maintWeightShiftLiabTarget,
         params.maintWeightShiftAbort ?? false,
+        params.depositLimit,
       )
       .accounts({
         group: group.publicKey,
@@ -1538,9 +1540,10 @@ export class MangoClient {
     quoteBank: Bank,
     marketIndex: number,
     name: string,
+    oraclePriceBand: number,
   ): Promise<MangoSignatureStatus> {
     const ix = await this.program.methods
-      .serum3RegisterMarket(marketIndex, name)
+      .serum3RegisterMarket(marketIndex, name, oraclePriceBand)
       .accounts({
         group: group.publicKey,
         admin: (this.program.provider as AnchorProvider).wallet.publicKey,
@@ -1582,11 +1585,12 @@ export class MangoClient {
     reduceOnly: boolean | null,
     forceClose: boolean | null,
     name: string | null,
+    oraclePriceBand: number | null,
   ): Promise<MangoSignatureStatus> {
     const serum3Market =
       group.serum3MarketsMapByMarketIndex.get(serum3MarketIndex);
     const ix = await this.program.methods
-      .serum3EditMarket(reduceOnly, forceClose, name)
+      .serum3EditMarket(reduceOnly, forceClose, name, oraclePriceBand)
       .accounts({
         group: group.publicKey,
         admin: (this.program.provider as AnchorProvider).wallet.publicKey,

--- a/ts/client/src/clientIxParamBuilder.ts
+++ b/ts/client/src/clientIxParamBuilder.ts
@@ -27,6 +27,7 @@ export interface TokenRegisterParams {
   flashLoanSwapFeeRate: number;
   interestCurveScaling: number;
   interestTargetUtilization: number;
+  depositLimit: BN;
 }
 
 export const DefaultTokenRegisterParams: TokenRegisterParams = {
@@ -64,6 +65,7 @@ export const DefaultTokenRegisterParams: TokenRegisterParams = {
   flashLoanSwapFeeRate: 0.0005,
   interestCurveScaling: 4.0,
   interestTargetUtilization: 0.5,
+  depositLimit: new BN(0),
 };
 
 export interface TokenEditParams {
@@ -101,6 +103,7 @@ export interface TokenEditParams {
   maintWeightShiftAssetTarget: number | null;
   maintWeightShiftLiabTarget: number | null;
   maintWeightShiftAbort: boolean | null;
+  depositLimit: BN | null;
 }
 
 export const NullTokenEditParams: TokenEditParams = {
@@ -138,6 +141,7 @@ export const NullTokenEditParams: TokenEditParams = {
   maintWeightShiftAssetTarget: null,
   maintWeightShiftLiabTarget: null,
   maintWeightShiftAbort: null,
+  depositLimit: null,
 };
 
 export interface PerpEditParams {

--- a/ts/client/src/mango_v4.ts
+++ b/ts/client/src/mango_v4.ts
@@ -614,6 +614,10 @@ export type MangoV4 = {
         {
           "name": "groupInsuranceFund",
           "type": "bool"
+        },
+        {
+          "name": "depositLimit",
+          "type": "u64"
         }
       ]
     },
@@ -988,6 +992,12 @@ export type MangoV4 = {
         {
           "name": "maintWeightShiftAbort",
           "type": "bool"
+        },
+        {
+          "name": "depositLimitOpt",
+          "type": {
+            "option": "u64"
+          }
         }
       ]
     },
@@ -2357,6 +2367,10 @@ export type MangoV4 = {
         {
           "name": "name",
           "type": "string"
+        },
+        {
+          "name": "oraclePriceBand",
+          "type": "f32"
         }
       ]
     },
@@ -2399,6 +2413,12 @@ export type MangoV4 = {
           "name": "nameOpt",
           "type": {
             "option": "string"
+          }
+        },
+        {
+          "name": "oraclePriceBandOpt",
+          "type": {
+            "option": "f32"
           }
         }
       ]
@@ -2742,6 +2762,9 @@ export type MangoV4 = {
     },
     {
       "name": "serum3PlaceOrderV2",
+      "docs": [
+        "requires the receiver_bank in the health account list to be writable"
+      ],
       "accounts": [
         {
           "name": "group",
@@ -7335,11 +7358,9 @@ export type MangoV4 = {
             "name": "potentialSerumTokens",
             "docs": [
               "Largest amount of tokens that might be added the the bank based on",
-              "serum open order execution.",
-              "",
-              "Can be negative with multiple banks, then it'd need to be balanced in the keeper."
+              "serum open order execution."
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "maintWeightShiftStart",
@@ -7368,11 +7389,18 @@ export type MangoV4 = {
             }
           },
           {
+            "name": "depositLimit",
+            "docs": [
+              "zero means none, in token native"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                2008
+                2000
               ]
             }
           }
@@ -8492,9 +8520,19 @@ export type MangoV4 = {
             "type": {
               "array": [
                 "u8",
-                5
+                1
               ]
             }
+          },
+          {
+            "name": "oraclePriceBand",
+            "docs": [
+              "Limit orders must be <= oracle * (1+band) and >= oracle / (1+band)",
+              "",
+              "Zero value is the default due to migration and disables the limit,",
+              "same as f32::MAX."
+            ],
+            "type": "f32"
           },
           {
             "name": "registrationTime",
@@ -13557,6 +13595,16 @@ export type MangoV4 = {
       "code": 6060,
       "name": "HealthAccountBankNotWritable",
       "msg": "a bank in the health account list should be writable but is not"
+    },
+    {
+      "code": 6061,
+      "name": "Serum3PriceBandExceeded",
+      "msg": "the market does not allow limit orders too far from the current oracle value"
+    },
+    {
+      "code": 6062,
+      "name": "BankDepositLimit",
+      "msg": "deposit crosses the token's deposit limit"
     }
   ]
 };
@@ -14177,6 +14225,10 @@ export const IDL: MangoV4 = {
         {
           "name": "groupInsuranceFund",
           "type": "bool"
+        },
+        {
+          "name": "depositLimit",
+          "type": "u64"
         }
       ]
     },
@@ -14551,6 +14603,12 @@ export const IDL: MangoV4 = {
         {
           "name": "maintWeightShiftAbort",
           "type": "bool"
+        },
+        {
+          "name": "depositLimitOpt",
+          "type": {
+            "option": "u64"
+          }
         }
       ]
     },
@@ -15920,6 +15978,10 @@ export const IDL: MangoV4 = {
         {
           "name": "name",
           "type": "string"
+        },
+        {
+          "name": "oraclePriceBand",
+          "type": "f32"
         }
       ]
     },
@@ -15962,6 +16024,12 @@ export const IDL: MangoV4 = {
           "name": "nameOpt",
           "type": {
             "option": "string"
+          }
+        },
+        {
+          "name": "oraclePriceBandOpt",
+          "type": {
+            "option": "f32"
           }
         }
       ]
@@ -16305,6 +16373,9 @@ export const IDL: MangoV4 = {
     },
     {
       "name": "serum3PlaceOrderV2",
+      "docs": [
+        "requires the receiver_bank in the health account list to be writable"
+      ],
       "accounts": [
         {
           "name": "group",
@@ -20829,11 +20900,9 @@ export const IDL: MangoV4 = {
             "name": "potentialSerumTokens",
             "docs": [
               "Largest amount of tokens that might be added the the bank based on",
-              "serum open order execution.",
-              "",
-              "Can be negative with multiple banks, then it'd need to be balanced in the keeper."
+              "serum open order execution."
             ],
-            "type": "i64"
+            "type": "u64"
           },
           {
             "name": "maintWeightShiftStart",
@@ -20862,11 +20931,18 @@ export const IDL: MangoV4 = {
             }
           },
           {
+            "name": "depositLimit",
+            "docs": [
+              "zero means none, in token native"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "reserved",
             "type": {
               "array": [
                 "u8",
-                2008
+                2000
               ]
             }
           }
@@ -21986,9 +22062,19 @@ export const IDL: MangoV4 = {
             "type": {
               "array": [
                 "u8",
-                5
+                1
               ]
             }
+          },
+          {
+            "name": "oraclePriceBand",
+            "docs": [
+              "Limit orders must be <= oracle * (1+band) and >= oracle / (1+band)",
+              "",
+              "Zero value is the default due to migration and disables the limit,",
+              "same as f32::MAX."
+            ],
+            "type": "f32"
           },
           {
             "name": "registrationTime",
@@ -27051,6 +27137,16 @@ export const IDL: MangoV4 = {
       "code": 6060,
       "name": "HealthAccountBankNotWritable",
       "msg": "a bank in the health account list should be writable but is not"
+    },
+    {
+      "code": 6061,
+      "name": "Serum3PriceBandExceeded",
+      "msg": "the market does not allow limit orders too far from the current oracle value"
+    },
+    {
+      "code": 6062,
+      "name": "BankDepositLimit",
+      "msg": "deposit crosses the token's deposit limit"
     }
   ]
 };


### PR DESCRIPTION
- limit deposits (via deposit, flash loan, tcs)
- limit potential deposits via openbook settle by restricting placable orders via potential_serum_tokens
- introduce Serum3PlaceOrderV2 for this purpose
- account for new limits in liquidator, max_swap