### PR TITLE
oracle: don't force logging in OracleState functions

### DIFF
--- a/bin/service-mango-orderbook/src/orderbook_filter.rs
+++ b/bin/service-mango-orderbook/src/orderbook_filter.rs
@@ -373,7 +373,6 @@ pub async fn init(
                             {
                                 if unchecked_oracle_state
                                     .check_confidence_and_maybe_staleness(
-                                        &mkt.1.name,
                                         &oracle_config.to_oracle_config(),
                                         None, // force this to always return a price no matter how stale
                                     )

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -212,9 +212,14 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         // net borrow check.
         let slot_opt = Some(Clock::get()?.slot);
         unsafe_oracle_state
-            .check_confidence_and_maybe_staleness(&bank.name(), &bank.oracle_config, slot_opt)
+            .check_confidence_and_maybe_staleness(&bank.oracle_config, slot_opt)
             .with_context(|| {
-                oracle_log_context(&unsafe_oracle_state, &bank.oracle_config, slot_opt)
+                oracle_log_context(
+                    bank.name(),
+                    &unsafe_oracle_state,
+                    &bank.oracle_config,
+                    slot_opt,
+                )
             })?;
         bank.check_net_borrows(unsafe_oracle_state.price)?;
     }

--- a/programs/mango-v4/src/state/perp_market.rs
+++ b/programs/mango-v4/src/state/perp_market.rs
@@ -277,8 +277,10 @@ impl PerpMarket {
         require_keys_eq!(self.oracle, *oracle_acc.key());
         let state = oracle::oracle_state_unchecked(oracle_acc, self.base_decimals)?;
         state
-            .check_confidence_and_maybe_staleness(&self.name(), &self.oracle_config, staleness_slot)
-            .with_context(|| oracle_log_context(&state, &self.oracle_config, staleness_slot))?;
+            .check_confidence_and_maybe_staleness(&self.oracle_config, staleness_slot)
+            .with_context(|| {
+                oracle_log_context(self.name(), &state, &self.oracle_config, staleness_slot)
+            })?;
         Ok(state)
     }
 


### PR DESCRIPTION
The msg!() caused writes to stdout in the liquidator etc in codepaths that just wanted to check if the oracle was usable.