### PR TITLE
use fast clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "bs58": "^5.0.0",
     "cross-fetch": "^3.1.5",
     "dotenv": "^16.0.3",
+    "fast-copy": "^3.0.1",
     "lodash": "^4.17.21",
     "node-kraken-api": "^2.2.2"
   },

--- a/ts/client/scripts/archive/debug-user.ts
+++ b/ts/client/scripts/archive/debug-user.ts
@@ -1,6 +1,6 @@
 import { AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import { Cluster, Connection, Keypair, PublicKey } from '@solana/web3.js';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import { cpuUsage } from 'process';
 import { Group } from '../../src/accounts/group';
 import { HealthCache } from '../../src/accounts/healthCache';
@@ -244,7 +244,7 @@ async function debugUser(
         .getPerpMarketByMarketIndex(pp.marketIndex)
         .priceNativeToUi(lp.toNumber());
 
-      const gClone: Group = cloneDeep(group);
+      const gClone: Group = copy(group);
       gClone.getPerpMarketByMarketIndex(pm.perpMarketIndex)._price = lp;
 
       const simHealth = toUiDecimalsForQuote(

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -8,7 +8,7 @@ import {
   PublicKey,
 } from '@solana/web3.js';
 import BN from 'bn.js';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import merge from 'lodash/merge';
 import { MangoClient } from '../client';
 import { OPENBOOK_PROGRAM_ID } from '../constants';
@@ -203,7 +203,7 @@ export class Group {
       banks = await client.getBanksForGroup(this);
     }
 
-    const oldbanksMapByTokenIndex = cloneDeep(this.banksMapByTokenIndex);
+    const oldbanksMapByTokenIndex = copy(this.banksMapByTokenIndex);
     this.banksMapByName = new Map();
     this.banksMapByMint = new Map();
     this.banksMapByTokenIndex = new Map();
@@ -360,9 +360,7 @@ export class Group {
     }
 
     // ensure that freshly fetched perp markets have valid price until we fetch oracles again
-    const oldPerpMarketByMarketIndex = cloneDeep(
-      this.perpMarketsMapByMarketIndex,
-    );
+    const oldPerpMarketByMarketIndex = copy(this.perpMarketsMapByMarketIndex);
     for (const perpMarket of perpMarkets) {
       const oldPerpMarket = oldPerpMarketByMarketIndex.get(
         perpMarket.perpMarketIndex,

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -209,6 +209,7 @@ export class Group {
     }
 
     const oldbanksMapByTokenIndex = deepClone(this.banksMapByTokenIndex);
+
     this.banksMapByName = new Map();
     this.banksMapByMint = new Map();
     this.banksMapByTokenIndex = new Map();
@@ -368,10 +369,6 @@ export class Group {
     const oldPerpMarketByMarketIndex = deepClone(
       this.perpMarketsMapByMarketIndex,
     );
-    console.log({
-      original: this.perpMarketsMapByMarketIndex,
-      copy: oldPerpMarketByMarketIndex,
-    });
     for (const perpMarket of perpMarkets) {
       const oldPerpMarket = oldPerpMarketByMarketIndex.get(
         perpMarket.perpMarketIndex,

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -8,14 +8,19 @@ import {
   PublicKey,
 } from '@solana/web3.js';
 import BN from 'bn.js';
-import copy from 'fast-copy';
 import merge from 'lodash/merge';
 import { MangoClient } from '../client';
 import { OPENBOOK_PROGRAM_ID } from '../constants';
 import { Id } from '../ids';
 import { I80F48 } from '../numbers/I80F48';
 import { PriceImpact, computePriceImpactOnJup } from '../risk';
-import { buildFetch, toNative, toNativeI80F48, toUiDecimals } from '../utils';
+import {
+  buildFetch,
+  deepClone,
+  toNative,
+  toNativeI80F48,
+  toUiDecimals,
+} from '../utils';
 import { Bank, MintInfo, TokenIndex } from './bank';
 import {
   OracleProvider,
@@ -203,7 +208,7 @@ export class Group {
       banks = await client.getBanksForGroup(this);
     }
 
-    const oldbanksMapByTokenIndex = copy(this.banksMapByTokenIndex);
+    const oldbanksMapByTokenIndex = deepClone(this.banksMapByTokenIndex);
     this.banksMapByName = new Map();
     this.banksMapByMint = new Map();
     this.banksMapByTokenIndex = new Map();
@@ -360,7 +365,13 @@ export class Group {
     }
 
     // ensure that freshly fetched perp markets have valid price until we fetch oracles again
-    const oldPerpMarketByMarketIndex = copy(this.perpMarketsMapByMarketIndex);
+    const oldPerpMarketByMarketIndex = deepClone(
+      this.perpMarketsMapByMarketIndex,
+    );
+    console.log({
+      original: this.perpMarketsMapByMarketIndex,
+      copy: oldPerpMarketByMarketIndex,
+    });
     for (const perpMarket of perpMarkets) {
       const oldPerpMarket = oldPerpMarketByMarketIndex.get(
         perpMarket.perpMarketIndex,

--- a/ts/client/src/accounts/healthCache.spec.ts
+++ b/ts/client/src/accounts/healthCache.spec.ts
@@ -1,7 +1,6 @@
 import { BN } from '@coral-xyz/anchor';
 import { OpenOrders } from '@project-serum/serum';
 import { expect } from 'chai';
-import copy from 'fast-copy';
 import range from 'lodash/range';
 
 import { PublicKey } from '@solana/web3.js';
@@ -11,6 +10,7 @@ import { HealthCache, PerpInfo, Serum3Info, TokenInfo } from './healthCache';
 import { HealthType, PerpPosition, Serum3Orders } from './mangoAccount';
 import { PerpMarket, PerpOrderSide } from './perp';
 import { MarketIndex } from './serum3';
+import { deepClone } from '../utils';
 
 function mockBankAndOracle(
   tokenIndex: TokenIndex,
@@ -699,7 +699,7 @@ describe('Health Cache', () => {
       priceFactor: number,
       maxSwapFn: (HealthCache) => I80F48,
     ): number[] {
-      const clonedHc: HealthCache = copy(hc);
+      const clonedHc: HealthCache = deepClone<HealthCache>(hc);
 
       const sourcePrice = clonedHc.tokenInfos[source].prices;
       const targetPrice = clonedHc.tokenInfos[target].prices;
@@ -716,7 +716,7 @@ describe('Health Cache', () => {
 
       function valueForAmount(amount: I80F48): I80F48 {
         // adjust token balance
-        const clonedHcClone: HealthCache = copy(clonedHc);
+        const clonedHcClone: HealthCache = deepClone<HealthCache>(clonedHc);
         clonedHc.tokenInfos[source].balanceSpot.isub(amount);
         clonedHc.tokenInfos[target].balanceSpot.iadd(amount.mul(swapPrice));
         return maxSwapFn(clonedHcClone);
@@ -766,7 +766,7 @@ describe('Health Cache', () => {
       {
         console.log(' - test 0');
         // adjust by usdc
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         clonedHc.tokenInfos[1].balanceSpot.iadd(
           I80F48.fromNumber(100).div(clonedHc.tokenInfos[1].prices.oracle),
         );
@@ -815,7 +815,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 1');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-20).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -864,7 +864,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 2');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-50).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -886,7 +886,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 3');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-30).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -915,7 +915,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 4');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(100).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -961,7 +961,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 6');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
         clonedHc.serum3Infos = [
           new Serum3Info(
             I80F48.fromNumber(30 / 3),
@@ -1042,7 +1042,7 @@ describe('Health Cache', () => {
       {
         // check starting with negative health but swapping can make it positive
         console.log(' - test 7');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1070,7 +1070,7 @@ describe('Health Cache', () => {
       {
         // check starting with negative health but swapping can't make it positive
         console.log(' - test 8');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1098,7 +1098,7 @@ describe('Health Cache', () => {
       {
         // swap some assets into a zero-asset-weight token
         console.log(' - test 9');
-        const clonedHc: HealthCache = copy(hc);
+        const clonedHc: HealthCache = deepClone<HealthCache>(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1184,7 +1184,7 @@ describe('Health Cache', () => {
       let baseNative = I80F48.fromNumber(baseLots1).mul(
         I80F48.fromNumber(baseLotSize),
       );
-      let hcClone: HealthCache = copy(hc);
+      let hcClone: HealthCache = deepClone<HealthCache>(hc);
       hcClone.perpInfos[0].baseLots.iadd(new BN(baseLots1));
       hcClone.perpInfos[0].quote.isub(baseNative.mul(tradePrice));
       const actualRatio = hcClone.healthRatio(HealthType.init);
@@ -1192,7 +1192,7 @@ describe('Health Cache', () => {
       // the ratio for trading just one base lot extra
       const baseLots2 = direction * (baseLots0 + 1);
       baseNative = I80F48.fromNumber(baseLots2 * baseLotSize);
-      hcClone = copy(hc);
+      hcClone = deepClone<HealthCache>(hc);
       hcClone.perpInfos[0].baseLots.iadd(new BN(baseLots2));
       hcClone.perpInfos[0].quote.isub(baseNative.mul(tradePrice));
       const plusRatio = hcClone.healthRatio(HealthType.init);
@@ -1222,12 +1222,12 @@ describe('Health Cache', () => {
     // adjust token
     hc.tokenInfos[0].balanceSpot.iadd(I80F48.fromNumber(3000));
     for (const existingSettle of [-500, 0, 300]) {
-      const hcClone1: HealthCache = copy(hc);
+      const hcClone1: HealthCache = deepClone<HealthCache>(hc);
       hcClone1.tokenInfos[1].balanceSpot.iadd(
         I80F48.fromNumber(existingSettle),
       );
       for (const existing of [-5, 0, 3]) {
-        const hcClone2: HealthCache = copy(hcClone1);
+        const hcClone2: HealthCache = deepClone<HealthCache>(hcClone1);
         hcClone2.perpInfos[0].baseLots.iadd(new BN(existing));
         hcClone2.perpInfos[0].quote.isub(
           I80F48.fromNumber(existing * baseLotSize * 2),

--- a/ts/client/src/accounts/healthCache.spec.ts
+++ b/ts/client/src/accounts/healthCache.spec.ts
@@ -1,7 +1,7 @@
 import { BN } from '@coral-xyz/anchor';
 import { OpenOrders } from '@project-serum/serum';
 import { expect } from 'chai';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import range from 'lodash/range';
 
 import { PublicKey } from '@solana/web3.js';
@@ -699,7 +699,7 @@ describe('Health Cache', () => {
       priceFactor: number,
       maxSwapFn: (HealthCache) => I80F48,
     ): number[] {
-      const clonedHc: HealthCache = cloneDeep(hc);
+      const clonedHc: HealthCache = copy(hc);
 
       const sourcePrice = clonedHc.tokenInfos[source].prices;
       const targetPrice = clonedHc.tokenInfos[target].prices;
@@ -716,7 +716,7 @@ describe('Health Cache', () => {
 
       function valueForAmount(amount: I80F48): I80F48 {
         // adjust token balance
-        const clonedHcClone: HealthCache = cloneDeep(clonedHc);
+        const clonedHcClone: HealthCache = copy(clonedHc);
         clonedHc.tokenInfos[source].balanceSpot.isub(amount);
         clonedHc.tokenInfos[target].balanceSpot.iadd(amount.mul(swapPrice));
         return maxSwapFn(clonedHcClone);
@@ -766,7 +766,7 @@ describe('Health Cache', () => {
       {
         console.log(' - test 0');
         // adjust by usdc
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         clonedHc.tokenInfos[1].balanceSpot.iadd(
           I80F48.fromNumber(100).div(clonedHc.tokenInfos[1].prices.oracle),
         );
@@ -815,7 +815,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 1');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-20).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -864,7 +864,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 2');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-50).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -886,7 +886,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 3');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(-30).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -915,7 +915,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 4');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
           I80F48.fromNumber(100).div(clonedHc.tokenInfos[0].prices.oracle),
@@ -961,7 +961,7 @@ describe('Health Cache', () => {
 
       {
         console.log(' - test 6');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
         clonedHc.serum3Infos = [
           new Serum3Info(
             I80F48.fromNumber(30 / 3),
@@ -1042,7 +1042,7 @@ describe('Health Cache', () => {
       {
         // check starting with negative health but swapping can make it positive
         console.log(' - test 7');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1070,7 +1070,7 @@ describe('Health Cache', () => {
       {
         // check starting with negative health but swapping can't make it positive
         console.log(' - test 8');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1098,7 +1098,7 @@ describe('Health Cache', () => {
       {
         // swap some assets into a zero-asset-weight token
         console.log(' - test 9');
-        const clonedHc: HealthCache = cloneDeep(hc);
+        const clonedHc: HealthCache = copy(hc);
 
         // adjust by usdc
         clonedHc.tokenInfos[0].balanceSpot.iadd(
@@ -1184,7 +1184,7 @@ describe('Health Cache', () => {
       let baseNative = I80F48.fromNumber(baseLots1).mul(
         I80F48.fromNumber(baseLotSize),
       );
-      let hcClone: HealthCache = cloneDeep(hc);
+      let hcClone: HealthCache = copy(hc);
       hcClone.perpInfos[0].baseLots.iadd(new BN(baseLots1));
       hcClone.perpInfos[0].quote.isub(baseNative.mul(tradePrice));
       const actualRatio = hcClone.healthRatio(HealthType.init);
@@ -1192,7 +1192,7 @@ describe('Health Cache', () => {
       // the ratio for trading just one base lot extra
       const baseLots2 = direction * (baseLots0 + 1);
       baseNative = I80F48.fromNumber(baseLots2 * baseLotSize);
-      hcClone = cloneDeep(hc);
+      hcClone = copy(hc);
       hcClone.perpInfos[0].baseLots.iadd(new BN(baseLots2));
       hcClone.perpInfos[0].quote.isub(baseNative.mul(tradePrice));
       const plusRatio = hcClone.healthRatio(HealthType.init);
@@ -1222,12 +1222,12 @@ describe('Health Cache', () => {
     // adjust token
     hc.tokenInfos[0].balanceSpot.iadd(I80F48.fromNumber(3000));
     for (const existingSettle of [-500, 0, 300]) {
-      const hcClone1: HealthCache = cloneDeep(hc);
+      const hcClone1: HealthCache = copy(hc);
       hcClone1.tokenInfos[1].balanceSpot.iadd(
         I80F48.fromNumber(existingSettle),
       );
       for (const existing of [-5, 0, 3]) {
-        const hcClone2: HealthCache = cloneDeep(hcClone1);
+        const hcClone2: HealthCache = copy(hcClone1);
         hcClone2.perpInfos[0].baseLots.iadd(new BN(existing));
         hcClone2.perpInfos[0].quote.isub(
           I80F48.fromNumber(existing * baseLotSize * 2),

--- a/ts/client/src/accounts/healthCache.ts
+++ b/ts/client/src/accounts/healthCache.ts
@@ -1,7 +1,7 @@
 import { BN } from '@coral-xyz/anchor';
 import { OpenOrders } from '@project-serum/serum';
 import { PublicKey } from '@solana/web3.js';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import { I80F48, MAX_I80F48, ONE_I80F48, ZERO_I80F48 } from '../numbers/I80F48';
 import {
   toNativeI80F48ForQuote,
@@ -540,7 +540,7 @@ export class HealthCache {
     }[],
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = cloneDeep(this);
+    const adjustedCache: HealthCache = copy(this);
     // HealthCache.logHealthCache('beforeChange', adjustedCache);
     for (const change of nativeTokenChanges) {
       const bank: Bank = group.getFirstBankByMint(change.mintPk);
@@ -617,7 +617,7 @@ export class HealthCache {
     serum3Market: Serum3Market,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = cloneDeep(this);
+    const adjustedCache: HealthCache = copy(this);
     const quoteIndex = adjustedCache.getOrCreateTokenInfoIndex(quoteBank);
 
     // Move token balance to reserved funds in open orders,
@@ -646,7 +646,7 @@ export class HealthCache {
     serum3Market: Serum3Market,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = cloneDeep(this);
+    const adjustedCache: HealthCache = copy(this);
     const baseIndex = adjustedCache.getOrCreateTokenInfoIndex(baseBank);
 
     // Move token balance to reserved funds in open orders,
@@ -713,7 +713,7 @@ export class HealthCache {
     price: I80F48,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const clonedHealthCache: HealthCache = cloneDeep(this);
+    const clonedHealthCache: HealthCache = copy(this);
     const perpInfoIndex =
       clonedHealthCache.getOrCreatePerpInfoIndex(perpMarket);
     clonedHealthCache.adjustPerpInfo(perpInfoIndex, price, side, baseLots);
@@ -953,7 +953,7 @@ export class HealthCache {
     const initialRatio = this.healthRatio(HealthType.init);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
-    const healthCacheClone: HealthCache = cloneDeep(this);
+    const healthCacheClone: HealthCache = copy(this);
     const sourceIndex = healthCacheClone.getOrCreateTokenInfoIndex(sourceBank);
     const targetIndex = healthCacheClone.getOrCreateTokenInfoIndex(targetBank);
 
@@ -993,7 +993,7 @@ export class HealthCache {
     // The maximum will be at one of these points (ignoring serum3 effects).
 
     function cacheAfterSwap(amount: I80F48): HealthCache {
-      const adjustedCache: HealthCache = cloneDeep(healthCacheClone);
+      const adjustedCache: HealthCache = copy(healthCacheClone);
       // adjustedCache.logHealthCache('beforeSwap', adjustedCache);
       // TODO: make a copy of the bank, apply amount, recompute weights,
       // and set the new weights on the tokenInfos
@@ -1090,7 +1090,7 @@ export class HealthCache {
     side: Serum3Side,
     minRatio: I80F48,
   ): I80F48 {
-    const healthCacheClone: HealthCache = cloneDeep(this);
+    const healthCacheClone: HealthCache = copy(this);
 
     const baseIndex = healthCacheClone.getOrCreateTokenInfoIndex(baseBank);
     const quoteIndex = healthCacheClone.getOrCreateTokenInfoIndex(quoteBank);
@@ -1168,7 +1168,7 @@ export class HealthCache {
     // console.log(` - zeroAmountRatio ${zeroAmountRatio.toLocaleString()}`);
 
     function cacheAfterPlacingOrder(amount: I80F48): HealthCache {
-      const adjustedCache: HealthCache = cloneDeep(healthCacheClone);
+      const adjustedCache: HealthCache = copy(healthCacheClone);
       // adjustedCache.logHealthCache(` before placing order ${amount}`);
       // TODO: there should also be some issue with oracle vs stable price here;
       // probably better to pass in not the quote amount but the base or quote native amount
@@ -1219,7 +1219,7 @@ export class HealthCache {
     side: PerpOrderSide,
     minRatio: I80F48,
   ): I80F48 {
-    const healthCacheClone: HealthCache = cloneDeep(this);
+    const healthCacheClone: HealthCache = copy(this);
 
     const initialRatio = this.healthRatio(HealthType.init);
     if (initialRatio.lt(ZERO_I80F48())) {
@@ -1251,7 +1251,7 @@ export class HealthCache {
     finalHealthSlope.imul(settleInfo.liabWeightedPrice(HealthType.init));
 
     function cacheAfterTrade(baseLots: BN): HealthCache {
-      const adjustedCache: HealthCache = cloneDeep(healthCacheClone);
+      const adjustedCache: HealthCache = copy(healthCacheClone);
       // adjustedCache.logHealthCache(' -- before trade');
       adjustedCache.adjustPerpInfo(perpInfoIndex, price, side, baseLots);
       // adjustedCache.logHealthCache(' -- after trade');
@@ -1358,7 +1358,7 @@ export class HealthCache {
     perpPosition: PerpPosition,
   ): I80F48 | null {
     const hc = HealthCache.fromMangoAccount(group, mangoAccount);
-    const hcClone = cloneDeep(hc);
+    const hcClone = copy(hc);
     const perpMarket = group.getPerpMarketByMarketIndex(
       perpPosition.marketIndex,
     );

--- a/ts/client/src/accounts/healthCache.ts
+++ b/ts/client/src/accounts/healthCache.ts
@@ -1,9 +1,9 @@
 import { BN } from '@coral-xyz/anchor';
 import { OpenOrders } from '@project-serum/serum';
 import { PublicKey } from '@solana/web3.js';
-import copy from 'fast-copy';
 import { I80F48, MAX_I80F48, ONE_I80F48, ZERO_I80F48 } from '../numbers/I80F48';
 import {
+  deepClone,
   toNativeI80F48ForQuote,
   toUiDecimals,
   toUiDecimalsForQuote,
@@ -17,7 +17,7 @@ import {
   PerpPosition,
   Serum3Orders,
 } from './mangoAccount';
-import { PerpMarket, PerpMarketIndex, PerpOrderSide } from './perp';
+import { PerpMarket, PerpMarketIndex, PerpOrder, PerpOrderSide } from './perp';
 import { MarketIndex, Serum3Market, Serum3Side } from './serum3';
 
 //               ░░░░
@@ -540,7 +540,7 @@ export class HealthCache {
     }[],
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = copy(this);
+    const adjustedCache: HealthCache = deepClone<HealthCache>(this);
     // HealthCache.logHealthCache('beforeChange', adjustedCache);
     for (const change of nativeTokenChanges) {
       const bank: Bank = group.getFirstBankByMint(change.mintPk);
@@ -617,7 +617,7 @@ export class HealthCache {
     serum3Market: Serum3Market,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = copy(this);
+    const adjustedCache: HealthCache = deepClone<HealthCache>(this);
     const quoteIndex = adjustedCache.getOrCreateTokenInfoIndex(quoteBank);
 
     // Move token balance to reserved funds in open orders,
@@ -646,7 +646,7 @@ export class HealthCache {
     serum3Market: Serum3Market,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const adjustedCache: HealthCache = copy(this);
+    const adjustedCache: HealthCache = deepClone<HealthCache>(this);
     const baseIndex = adjustedCache.getOrCreateTokenInfoIndex(baseBank);
 
     // Move token balance to reserved funds in open orders,
@@ -713,7 +713,7 @@ export class HealthCache {
     price: I80F48,
     healthType: HealthType = HealthType.init,
   ): I80F48 {
-    const clonedHealthCache: HealthCache = copy(this);
+    const clonedHealthCache: HealthCache = deepClone<HealthCache>(this);
     const perpInfoIndex =
       clonedHealthCache.getOrCreatePerpInfoIndex(perpMarket);
     clonedHealthCache.adjustPerpInfo(perpInfoIndex, price, side, baseLots);
@@ -953,7 +953,7 @@ export class HealthCache {
     const initialRatio = this.healthRatio(HealthType.init);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
-    const healthCacheClone: HealthCache = copy(this);
+    const healthCacheClone: HealthCache = deepClone<HealthCache>(this);
     const sourceIndex = healthCacheClone.getOrCreateTokenInfoIndex(sourceBank);
     const targetIndex = healthCacheClone.getOrCreateTokenInfoIndex(targetBank);
 
@@ -993,7 +993,8 @@ export class HealthCache {
     // The maximum will be at one of these points (ignoring serum3 effects).
 
     function cacheAfterSwap(amount: I80F48): HealthCache {
-      const adjustedCache: HealthCache = copy(healthCacheClone);
+      const adjustedCache: HealthCache =
+        deepClone<HealthCache>(healthCacheClone);
       // adjustedCache.logHealthCache('beforeSwap', adjustedCache);
       // TODO: make a copy of the bank, apply amount, recompute weights,
       // and set the new weights on the tokenInfos
@@ -1090,7 +1091,7 @@ export class HealthCache {
     side: Serum3Side,
     minRatio: I80F48,
   ): I80F48 {
-    const healthCacheClone: HealthCache = copy(this);
+    const healthCacheClone: HealthCache = deepClone<HealthCache>(this);
 
     const baseIndex = healthCacheClone.getOrCreateTokenInfoIndex(baseBank);
     const quoteIndex = healthCacheClone.getOrCreateTokenInfoIndex(quoteBank);
@@ -1168,7 +1169,8 @@ export class HealthCache {
     // console.log(` - zeroAmountRatio ${zeroAmountRatio.toLocaleString()}`);
 
     function cacheAfterPlacingOrder(amount: I80F48): HealthCache {
-      const adjustedCache: HealthCache = copy(healthCacheClone);
+      const adjustedCache: HealthCache =
+        deepClone<HealthCache>(healthCacheClone);
       // adjustedCache.logHealthCache(` before placing order ${amount}`);
       // TODO: there should also be some issue with oracle vs stable price here;
       // probably better to pass in not the quote amount but the base or quote native amount
@@ -1219,7 +1221,7 @@ export class HealthCache {
     side: PerpOrderSide,
     minRatio: I80F48,
   ): I80F48 {
-    const healthCacheClone: HealthCache = copy(this);
+    const healthCacheClone: HealthCache = deepClone<HealthCache>(this);
 
     const initialRatio = this.healthRatio(HealthType.init);
     if (initialRatio.lt(ZERO_I80F48())) {
@@ -1251,7 +1253,8 @@ export class HealthCache {
     finalHealthSlope.imul(settleInfo.liabWeightedPrice(HealthType.init));
 
     function cacheAfterTrade(baseLots: BN): HealthCache {
-      const adjustedCache: HealthCache = copy(healthCacheClone);
+      const adjustedCache: HealthCache =
+        deepClone<HealthCache>(healthCacheClone);
       // adjustedCache.logHealthCache(' -- before trade');
       adjustedCache.adjustPerpInfo(perpInfoIndex, price, side, baseLots);
       // adjustedCache.logHealthCache(' -- after trade');
@@ -1358,7 +1361,7 @@ export class HealthCache {
     perpPosition: PerpPosition,
   ): I80F48 | null {
     const hc = HealthCache.fromMangoAccount(group, mangoAccount);
-    const hcClone = copy(hc);
+    const hcClone = deepClone<HealthCache>(hc);
     const perpMarket = group.getPerpMarketByMarketIndex(
       perpPosition.marketIndex,
     );

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -32,7 +32,7 @@ import {
 } from '@solana/web3.js';
 import bs58 from 'bs58';
 import chunk from 'lodash/chunk';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import groupBy from 'lodash/groupBy';
 import mapValues from 'lodash/mapValues';
 import maxBy from 'lodash/maxBy';
@@ -1219,7 +1219,7 @@ export class MangoClient {
     // Work on a deep cloned mango account, since we would deactivating positions
     // before deactivation reaches on-chain state in order to simplify building a fresh list
     // of healthRemainingAccounts to each subsequent ix
-    const clonedMangoAccount = cloneDeep(mangoAccount);
+    const clonedMangoAccount = copy(mangoAccount);
     const instructions: TransactionInstruction[] = [];
 
     for (const serum3Account of clonedMangoAccount.serum3Active()) {

--- a/ts/client/src/risk.ts
+++ b/ts/client/src/risk.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
-import cloneDeep from 'lodash/cloneDeep';
+import copy from 'fast-copy';
 import { TokenIndex } from './accounts/bank';
 import { Group } from './accounts/group';
 import { HealthType, MangoAccount } from './accounts/mangoAccount';
@@ -507,7 +507,7 @@ export async function getRiskStats(
 
   // Clone group, and simulate change % price drop for all assets except stables
   const drop = 1 - change;
-  const groupDrop: Group = cloneDeep(group);
+  const groupDrop: Group = copy(group);
   Array.from(groupDrop.banksMapByTokenIndex.values())
     .flat()
     .filter((b) => !b.name.includes('USD'))
@@ -523,7 +523,7 @@ export async function getRiskStats(
   });
 
   // Clone group, and simulate change % price drop for usdc
-  const groupUsdcDepeg: Group = cloneDeep(group);
+  const groupUsdcDepeg: Group = copy(group);
   Array.from(groupUsdcDepeg.banksMapByTokenIndex.values())
     .flat()
     .filter((b) => b.name.includes('USDC'))
@@ -534,7 +534,7 @@ export async function getRiskStats(
     });
 
   // Clone group, and simulate change % price drop for usdt
-  const groupUsdtDepeg: Group = cloneDeep(group);
+  const groupUsdtDepeg: Group = copy(group);
   Array.from(groupUsdtDepeg.banksMapByTokenIndex.values())
     .flat()
     .filter((b) => b.name.includes('USDT'))
@@ -546,7 +546,7 @@ export async function getRiskStats(
 
   // Clone group, and simulate change % price rally for all assets except stables
   const rally = 1 + change;
-  const groupRally: Group = cloneDeep(group);
+  const groupRally: Group = copy(group);
   Array.from(groupRally.banksMapByTokenIndex.values())
     .flat()
     .filter((b) => !b.name.includes('USD'))

--- a/ts/client/src/utils.ts
+++ b/ts/client/src/utils.ts
@@ -218,3 +218,36 @@ export declare abstract class As<Tag extends keyof never> {
   private static readonly $as$: unique symbol;
   private [As.$as$]: Record<Tag, true>;
 }
+
+export function deepClone<T>(obj: T, hash = new WeakMap()): T {
+  // Handle non-object types and functions
+  if (typeof obj !== 'object' || obj === null) return obj;
+
+  // Handle circular references
+  if (hash.has(obj)) return hash.get(obj) as T;
+
+  let result: any;
+
+  if (obj instanceof Map) {
+    result = new Map();
+    hash.set(obj, result);
+    obj.forEach((value, key) => {
+      result.set(deepClone(key, hash), deepClone(value, hash));
+    });
+  } else if (Array.isArray(obj)) {
+    result = [];
+    hash.set(obj, result);
+    obj.forEach((item, index) => {
+      result[index] = deepClone(item, hash);
+    });
+  } else {
+    const prototype = Object.getPrototypeOf(obj);
+    result = Object.create(prototype);
+    hash.set(obj, result);
+    for (const key of Object.keys(obj)) {
+      result[key] = deepClone((obj as any)[key], hash);
+    }
+  }
+
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,6 +1266,11 @@ eyes@^0.1.8:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
+fast-copy@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
+
 fast-csv@^4.3.6:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/fast-csv/-/fast-csv-4.3.6.tgz#70349bdd8fe4d66b1130d8c91820b64a21bc4a63"


### PR DESCRIPTION
This will drop render of some elements on ui from 1.5 sec to few ms  

- To copy something more complicated use fast-copy lib its faster then lodash implementation - e.g group copy
- for health obj its good to use own implementation because we don't need to loop over BN or I80F48 with functions from libs.

Own implementation still do deep copy without reference of given obj.
