### PR TITLE
Upgrade mango-feeds-connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ dependencies = [
  "futures 0.3.30",
  "regex",
  "serde",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
  "thiserror",
  "tokio",
  "url 2.5.0",
@@ -369,7 +369,7 @@ dependencies = [
  "borsh 0.10.3",
  "bytemuck",
  "getrandom 0.2.12",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -394,7 +394,7 @@ dependencies = [
  "borsh 0.10.3",
  "bytemuck",
  "getrandom 0.2.12",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -405,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
  "anchor-lang 0.28.0",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
@@ -419,7 +419,7 @@ checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
 dependencies = [
  "anchor-lang 0.29.0",
  "mpl-token-metadata 3.2.3",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
@@ -3545,10 +3545,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
  "tokio",
  "warp",
  "yellowstone-grpc-client",
@@ -3576,9 +3576,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-sdk",
  "tonic-build 0.6.2",
 ]
 
@@ -3609,11 +3609,11 @@ dependencies = [
  "regex",
  "serde",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-address-lookup-table-program",
+ "solana-logger",
+ "solana-program",
  "solana-program-test",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "solana-security-txt",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
@@ -3642,8 +3642,8 @@ dependencies = [
  "pyth-sdk-solana",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-sdk",
  "tokio",
  "tracing",
 ]
@@ -3676,11 +3676,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-address-lookup-table-program",
+ "solana-client",
  "solana-rpc",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "spl-associated-token-account 1.1.3",
  "thiserror",
  "tokio",
@@ -3708,8 +3708,8 @@ dependencies = [
  "prometheus",
  "pyth-sdk-solana",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-sdk",
  "tokio",
  "tracing",
  "warp",
@@ -3750,11 +3750,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-logger",
  "solana-rpc",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.16.1",
@@ -3797,11 +3797,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-client",
+ "solana-logger",
  "solana-rpc",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.16.1",
@@ -4029,7 +4029,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "shank",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
@@ -4048,7 +4048,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "shank",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
  "thiserror",
@@ -4063,7 +4063,7 @@ dependencies = [
  "borsh 0.10.3",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -4094,7 +4094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
 dependencies = [
  "arrayref",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-token-2022 0.6.1",
 ]
 
@@ -4471,7 +4471,7 @@ dependencies = [
  "num_enum 0.5.11",
  "pyth-sdk-solana",
  "raydium-amm-v3",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-security-txt",
  "static_assertions",
  "switchboard-program",
@@ -5240,7 +5240,7 @@ dependencies = [
  "num-traits",
  "pyth-sdk",
  "serde",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -5526,7 +5526,7 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "mpl-token-metadata 1.13.2",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-memo 4.0.0",
  "uint",
 ]
@@ -6198,7 +6198,7 @@ dependencies = [
  "num_enum 0.5.11",
  "safe-transmute",
  "serde",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-security-txt",
  "spl-token 3.5.0",
  "static_assertions",
@@ -6224,7 +6224,7 @@ dependencies = [
  "num_enum 0.5.11",
  "safe-transmute",
  "serde",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-security-txt",
  "spl-token 3.5.0",
  "static_assertions",
@@ -6255,9 +6255,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
  "tokio",
  "tokio-tungstenite 0.17.2",
  "toml",
@@ -6297,9 +6297,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -6332,9 +6332,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/grooviegermanikus/program.git?branch=groovie/v0.5.10-updates-expose-things)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
  "tokio",
  "tokio-tungstenite 0.17.2",
  "toml",
@@ -6359,9 +6359,9 @@ dependencies = [
  "mango-v4-client",
  "serde",
  "serde_derive",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-logger",
+ "solana-sdk",
  "tokio",
  "toml",
 ]
@@ -6647,31 +6647,6 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121e55656c2094950f374247e1303dd09517f1ed49c91bf60bf114760b286eb4"
-dependencies = [
- "Inflector",
- "base64 0.21.7",
- "bincode",
- "bs58 0.4.0",
- "bv",
- "lazy_static",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-config-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token 4.0.0",
- "spl-token-2022 0.9.0",
- "spl-token-metadata-interface",
- "thiserror",
- "zstd",
-]
-
-[[package]]
-name = "solana-account-decoder"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "Inflector",
@@ -6683,35 +6658,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-address-lookup-table-program",
+ "solana-config-program",
+ "solana-sdk",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
  "spl-token-metadata-interface",
  "thiserror",
  "zstd",
-]
-
-[[package]]
-name = "solana-address-lookup-table-program"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccb31f7f14d5876acd9ec38f5bf6097bfb4b350141d81c7ff2bf684db3ca815"
-dependencies = [
- "bincode",
- "bytemuck",
- "log 0.4.20",
- "num-derive 0.3.3",
- "num-traits",
- "rustc_version 0.4.0",
- "serde",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
 ]
 
 [[package]]
@@ -6726,11 +6680,11 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-program",
+ "solana-program-runtime",
+ "solana-sdk",
  "thiserror",
 ]
 
@@ -6742,8 +6696,8 @@ dependencies = [
  "borsh 0.10.3",
  "futures 0.3.30",
  "solana-banks-interface",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program",
+ "solana-sdk",
  "tarpc",
  "thiserror",
  "tokio",
@@ -6756,7 +6710,7 @@ version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "serde",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "tarpc",
 ]
 
@@ -6769,9 +6723,9 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.30",
  "solana-banks-interface",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -6791,9 +6745,9 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -6806,9 +6760,9 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.20",
  "rand 0.7.3",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-program-runtime",
+ "solana-sdk",
  "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana_rbpf",
  "thiserror",
@@ -6825,27 +6779,9 @@ dependencies = [
  "modular-bitfield",
  "num_enum 0.6.1",
  "rand 0.7.3",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-sdk",
  "tempfile",
-]
-
-[[package]]
-name = "solana-clap-utils"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a8150d4ff694d9587496a5976d33e6ebdb16cc61c6338bdfe3b2fc2c7c4986"
-dependencies = [
- "chrono",
- "clap 2.34.0",
- "rpassword",
- "solana-perf 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-remote-wallet 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tiny-bip39",
- "uriparse",
- "url 2.5.0",
 ]
 
 [[package]]
@@ -6856,9 +6792,9 @@ dependencies = [
  "chrono",
  "clap 2.34.0",
  "rpassword",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-remote-wallet 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf",
+ "solana-remote-wallet",
+ "solana-sdk",
  "thiserror",
  "tiny-bip39",
  "uriparse",
@@ -6875,42 +6811,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-clap-utils",
+ "solana-sdk",
  "url 2.5.0",
-]
-
-[[package]]
-name = "solana-client"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35d7582847ab4d60652ff640ca574647789461c1630e8c7580ff770738c3d7f4"
-dependencies = [
- "async-trait",
- "bincode",
- "futures 0.3.30",
- "futures-util",
- "indexmap 1.9.3",
- "indicatif",
- "log 0.4.20",
- "quinn",
- "rand 0.7.3",
- "rayon",
- "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-pubsub-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-quic-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-nonce-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-thin-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-tpu-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-udp-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -6928,19 +6831,19 @@ dependencies = [
  "quinn",
  "rand 0.7.3",
  "rayon",
- "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-pubsub-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-quic-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-nonce-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-thin-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-udp-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-connection-cache",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubsub-client",
+ "solana-quic-client",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-rpc-client-nonce-utils",
+ "solana-sdk",
+ "solana-streamer",
+ "solana-thin-client",
+ "solana-tpu-client",
+ "solana-udp-client",
  "thiserror",
  "tokio",
 ]
@@ -6950,22 +6853,8 @@ name = "solana-compute-budget-program"
 version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-config-program"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dc0f4463daf1c6155f20eac948ea4ced705e5f5520546aef4e11e746a6d95d"
-dependencies = [
- "bincode",
- "chrono",
- "serde",
- "serde_derive",
- "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -6977,29 +6866,8 @@ dependencies = [
  "chrono",
  "serde",
  "serde_derive",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-connection-cache"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758587d44e05a4abdf82b9514d1c8b7d35637ad65f7af7c3e3e02417aaae3c9e"
-dependencies = [
- "async-trait",
- "bincode",
- "futures-util",
- "indexmap 1.9.3",
- "log 0.4.20",
- "rand 0.7.3",
- "rayon",
- "rcgen",
- "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
+ "solana-program-runtime",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -7015,9 +6883,9 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "rcgen",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-metrics",
+ "solana-sdk",
  "thiserror",
  "tokio",
 ]
@@ -7036,12 +6904,12 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
  "solana-merkle-tree",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics",
+ "solana-perf",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -7056,48 +6924,15 @@ dependencies = [
  "log 0.4.20",
  "serde",
  "serde_derive",
- "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-clap-utils",
  "solana-cli-config",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger",
+ "solana-metrics",
+ "solana-sdk",
+ "solana-version",
  "spl-memo 4.0.0",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "solana-frozen-abi"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266bf0311bb403d31206aa2904b8741f57c7f5e27580b6810ad5e22fc7c3282"
-dependencies = [
- "ahash 0.8.7",
- "blake3",
- "block-buffer 0.10.4",
- "bs58 0.4.0",
- "bv",
- "byteorder",
- "cc",
- "either",
- "generic-array 0.14.7",
- "getrandom 0.1.16",
- "im",
- "lazy_static",
- "log 0.4.20",
- "memmap2",
- "once_cell",
- "rand_core 0.6.4",
- "rustc_version 0.4.0",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle",
- "thiserror",
 ]
 
 [[package]]
@@ -7127,21 +6962,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.10.8",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro",
  "subtle",
  "thiserror",
-]
-
-[[package]]
-name = "solana-frozen-abi-macro"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfe18c5155015dcb494c6de84a03b725fcf90ec2006a047769018b94c2cf0de"
-dependencies = [
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "rustc_version 0.4.0",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -7179,25 +7002,25 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-bloom",
- "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-clap-utils",
+ "solana-client",
  "solana-entry",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-ledger",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-perf",
+ "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-thin-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
+ "solana-streamer",
+ "solana-thin-client",
+ "solana-tpu-client",
+ "solana-version",
+ "solana-vote-program",
  "static_assertions",
  "thiserror",
 ]
@@ -7235,23 +7058,23 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.8",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-measure",
+ "solana-metrics",
+ "solana-perf",
+ "solana-program-runtime",
+ "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
  "static_assertions",
@@ -7269,26 +7092,15 @@ source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.
 dependencies = [
  "log 0.4.20",
  "rand 0.7.3",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-program-runtime",
+ "solana-sdk",
  "solana_rbpf",
 ]
 
 [[package]]
 name = "solana-logger"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f76fe25c2d06dcf621befd1e8d5655143e8a059c7e20fcb71736bc80ed779d6"
-dependencies = [
- "env_logger",
- "lazy_static",
- "log 0.4.20",
-]
-
-[[package]]
-name = "solana-logger"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "env_logger",
@@ -7299,20 +7111,10 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db165b8a7f5d840abef011c78a18ffe63cad9192d676b07d94f469b6b5dc6cf6"
-dependencies = [
- "log 0.4.20",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "solana-measure"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "log 0.4.20",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -7322,21 +7124,7 @@ source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.
 dependencies = [
  "fast-math",
  "matches",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-metrics"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa01731bb3952904962d49a1ea1205db54e93f3a56f4006d32e02a7c85d60546"
-dependencies = [
- "crossbeam-channel",
- "gethostname",
- "lazy_static",
- "log 0.4.20",
- "reqwest",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
 ]
 
 [[package]]
@@ -7349,29 +7137,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.20",
  "reqwest",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-net-utils"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7ab67329dcebe4a40673fd0da27373282b1359ec7945e0fb81a9c594bcd057"
-dependencies = [
- "bincode",
- "clap 3.2.25",
- "crossbeam-channel",
- "log 0.4.20",
- "nix",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "socket2 0.4.10",
- "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio",
- "url 2.5.0",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -7388,38 +7154,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "socket2 0.4.10",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger",
+ "solana-sdk",
+ "solana-version",
  "tokio",
  "url 2.5.0",
-]
-
-[[package]]
-name = "solana-perf"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f900c1015844087cd4f10ba9d2d26a9859f2f5ca07427865cc74942595abc0a7"
-dependencies = [
- "ahash 0.8.7",
- "bincode",
- "bv",
- "caps",
- "curve25519-dalek",
- "dlopen",
- "dlopen_derive",
- "fnv",
- "lazy_static",
- "libc",
- "log 0.4.20",
- "nix",
- "rand 0.7.3",
- "rayon",
- "serde",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rayon-threadlimit 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-vote-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7442,10 +7181,10 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
+ "solana-vote-program",
 ]
 
 [[package]]
@@ -7458,66 +7197,11 @@ dependencies = [
  "log 0.4.20",
  "solana-entry",
  "solana-ledger",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "thiserror",
-]
-
-[[package]]
-name = "solana-program"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb16998986492de307eef503ce47e84503d35baa92dc60832b22476948b1c16"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "array-bytes",
- "base64 0.21.7",
- "bincode",
- "bitflags 1.3.2",
- "blake3",
- "borsh 0.10.3",
- "borsh 0.9.3",
- "bs58 0.4.0",
- "bv",
- "bytemuck",
- "cc",
- "console_error_panic_hook",
- "console_log",
- "curve25519-dalek",
- "getrandom 0.2.12",
- "itertools 0.10.5",
- "js-sys",
- "lazy_static",
- "libc",
- "libsecp256k1",
- "log 0.4.20",
- "memoffset 0.9.0",
- "num-bigint 0.4.4",
- "num-derive 0.3.3",
- "num-traits",
- "parking_lot 0.12.1",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rustc_version 0.4.0",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tiny-bip39",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -7565,41 +7249,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-sdk-macro",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "solana-program-runtime"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036d6ecf67a3a7c6dc74d4f7fa6ab321e7ce8feccb7c9dff8384a41d0a12345b"
-dependencies = [
- "base64 0.21.7",
- "bincode",
- "eager",
- "enum-iterator",
- "itertools 0.10.5",
- "libc",
- "log 0.4.20",
- "num-derive 0.3.3",
- "num-traits",
- "percentage",
- "rand 0.7.3",
- "rustc_version 0.4.0",
- "serde",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana_rbpf",
- "thiserror",
 ]
 
 [[package]]
@@ -7620,11 +7276,11 @@ dependencies = [
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-measure",
+ "solana-metrics",
+ "solana-sdk",
  "solana_rbpf",
  "thiserror",
 ]
@@ -7646,38 +7302,13 @@ dependencies = [
  "solana-banks-interface",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger",
+ "solana-program-runtime",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
+ "solana-vote-program",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "solana-pubsub-client"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e318f46bedb39374e98f299266a155b2c81c9d920f3c90f761261267c275c1"
-dependencies = [
- "crossbeam-channel",
- "futures-util",
- "log 0.4.20",
- "reqwest",
- "semver 1.0.21",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite 0.17.2",
- "tungstenite 0.17.3",
- "url 2.5.0",
 ]
 
 [[package]]
@@ -7693,43 +7324,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-rpc-client-api",
+ "solana-sdk",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.17.2",
  "tungstenite 0.17.3",
  "url 2.5.0",
-]
-
-[[package]]
-name = "solana-quic-client"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61db18a804642f8eb37369e903774a85d7949a55bd204ec090ebe0742fd2fe32"
-dependencies = [
- "async-mutex",
- "async-trait",
- "futures 0.3.30",
- "itertools 0.10.5",
- "lazy_static",
- "log 0.4.20",
- "quinn",
- "quinn-proto",
- "quinn-udp",
- "rcgen",
- "rustls 0.20.9",
- "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-net-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -7748,13 +7351,13 @@ dependencies = [
  "quinn-udp",
  "rcgen",
  "rustls 0.20.9",
- "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-connection-cache",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-rpc-client-api",
+ "solana-sdk",
+ "solana-streamer",
  "thiserror",
  "tokio",
 ]
@@ -7762,39 +7365,10 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805377478f2d413f6cfcba6924c81ac4988ac0f96cdb045a8a9d81c430e6622a"
-dependencies = [
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
-name = "solana-rayon-threadlimit"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "solana-remote-wallet"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1148dcd76f76ad0399c1d9abf05cb32a0e545c5bee47ebe6d3b3e800c7fa7c"
-dependencies = [
- "console",
- "dialoguer",
- "log 0.4.20",
- "num-derive 0.3.3",
- "num-traits",
- "parking_lot 0.12.1",
- "qstring",
- "semver 1.0.21",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "uriparse",
 ]
 
 [[package]]
@@ -7810,7 +7384,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "qstring",
  "semver 1.0.21",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "thiserror",
  "uriparse",
 ]
@@ -7839,28 +7413,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "soketto",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-client",
  "solana-entry",
  "solana-faucet",
  "solana-gossip",
  "solana-ledger",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-metrics",
+ "solana-perf",
  "solana-poh",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit",
+ "solana-rpc-client-api",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
- "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-streamer",
+ "solana-tpu-client",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version",
+ "solana-vote-program",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
  "stream-cancel",
@@ -7872,32 +7446,6 @@ dependencies = [
 [[package]]
 name = "solana-rpc-client"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc51a85c6ff03bb4a3e1fde1e36dcb553b990f2b3e66aed941a31a6a7c20fa33"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "bincode",
- "bs58 0.4.0",
- "indicatif",
- "log 0.4.20",
- "reqwest",
- "semver 1.0.21",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-vote-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio",
-]
-
-[[package]]
-name = "solana-rpc-client"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "async-trait",
@@ -7911,35 +7459,13 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-rpc-client-api",
+ "solana-sdk",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version",
+ "solana-vote-program",
  "tokio",
-]
-
-[[package]]
-name = "solana-rpc-client-api"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6756a1f89f509154644a958869c7cc6c70cc622f44faddf9b94612d8d2d8eed5"
-dependencies = [
- "base64 0.21.7",
- "bs58 0.4.0",
- "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest",
- "semver 1.0.21",
- "serde",
- "serde_derive",
- "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "spl-token-2022 0.9.0",
- "thiserror",
 ]
 
 [[package]]
@@ -7955,24 +7481,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-sdk",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version",
  "spl-token-2022 0.9.0",
- "thiserror",
-]
-
-[[package]]
-name = "solana-rpc-client-nonce-utils"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850e8db607525a36d330f073703e78e908a54ac66aa323a44cfc12c14c16699"
-dependencies = [
- "clap 2.34.0",
- "solana-clap-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -7982,9 +7495,9 @@ version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "clap 2.34.0",
- "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-clap-utils",
+ "solana-rpc-client",
+ "solana-sdk",
  "thiserror",
 ]
 
@@ -8027,23 +7540,23 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-compute-budget-program",
- "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-config-program",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
  "solana-loader-v4-program",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure",
+ "solana-metrics",
+ "solana-perf",
+ "solana-program-runtime",
+ "solana-rayon-threadlimit",
+ "solana-sdk",
  "solana-stake-program",
  "solana-system-program",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "static_assertions",
@@ -8054,59 +7567,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "zstd",
-]
-
-[[package]]
-name = "solana-sdk"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4106cda3d10833ba957dbd25fb841b50aeca7480ccf8f54859294716f54bcd4b"
-dependencies = [
- "assert_matches",
- "base64 0.21.7",
- "bincode",
- "bitflags 1.3.2",
- "borsh 0.10.3",
- "bs58 0.4.0",
- "bytemuck",
- "byteorder",
- "chrono",
- "derivation-path",
- "digest 0.10.7",
- "ed25519-dalek",
- "ed25519-dalek-bip32",
- "generic-array 0.14.7",
- "hmac 0.12.1",
- "itertools 0.10.5",
- "js-sys",
- "lazy_static",
- "libsecp256k1",
- "log 0.4.20",
- "memmap2",
- "num-derive 0.3.3",
- "num-traits",
- "num_enum 0.6.1",
- "pbkdf2 0.11.0",
- "qstring",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
- "rustc_version 0.4.0",
- "rustversion",
- "serde",
- "serde_bytes",
- "serde_derive",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "uriparse",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -8151,27 +7611,14 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-logger",
+ "solana-program",
+ "solana-sdk-macro",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-sdk-macro"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e560806a3859717eb2220b26e2cd68bb757b63affa3e79c3f1d8d853b5ee78f"
-dependencies = [
- "bs58 0.4.0",
- "proc-macro2 1.0.76",
- "quote 1.0.35",
- "rustversion",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -8199,12 +7646,12 @@ source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.
 dependencies = [
  "crossbeam-channel",
  "log 0.4.20",
- "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client",
+ "solana-measure",
+ "solana-metrics",
  "solana-runtime",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk",
+ "solana-tpu-client",
 ]
 
 [[package]]
@@ -8215,10 +7662,10 @@ dependencies = [
  "bincode",
  "log 0.4.20",
  "rustc_version 0.4.0",
- "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-config-program",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-vote-program",
 ]
 
 [[package]]
@@ -8244,8 +7691,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "smpl_jwt",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics",
+ "solana-sdk",
  "solana-storage-proto",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
@@ -8264,43 +7711,10 @@ dependencies = [
  "prost 0.11.9",
  "protobuf-src",
  "serde",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-sdk",
  "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tonic-build 0.8.4",
-]
-
-[[package]]
-name = "solana-streamer"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f142cbb497d257e70253c158a4c34037e310d24a055fae7dbc5c396b7611aa"
-dependencies = [
- "async-channel",
- "bytes 1.5.0",
- "crossbeam-channel",
- "futures-util",
- "histogram",
- "indexmap 1.9.3",
- "itertools 0.10.5",
- "libc",
- "log 0.4.20",
- "nix",
- "pem",
- "percentage",
- "pkcs8",
- "quinn",
- "quinn-proto",
- "quinn-udp",
- "rand 0.7.3",
- "rcgen",
- "rustls 0.20.9",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-perf 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
- "x509-parser",
 ]
 
 [[package]]
@@ -8327,9 +7741,9 @@ dependencies = [
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.9",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics",
+ "solana-perf",
+ "solana-sdk",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -8344,23 +7758,8 @@ dependencies = [
  "log 0.4.20",
  "serde",
  "serde_derive",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-thin-client"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e41ce715b34749d2c0d3181dd910d2b99fa2142a0aaf3cd44926cb02edd60d"
-dependencies = [
- "bincode",
- "log 0.4.20",
- "rayon",
- "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -8371,35 +7770,10 @@ dependencies = [
  "bincode",
  "log 0.4.20",
  "rayon",
- "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-tpu-client"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ec99361a39e17a2bffe2a59b97b3d20ddef323f9166929783ce49f340c200d"
-dependencies = [
- "async-trait",
- "bincode",
- "futures-util",
- "indexmap 1.9.3",
- "indicatif",
- "log 0.4.20",
- "rand 0.7.3",
- "rayon",
- "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-pubsub-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
+ "solana-connection-cache",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -8415,13 +7789,13 @@ dependencies = [
  "log 0.4.20",
  "rand 0.7.3",
  "rayon",
- "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-pubsub-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-connection-cache",
+ "solana-measure",
+ "solana-metrics",
+ "solana-pubsub-client",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
  "thiserror",
  "tokio",
 ]
@@ -8442,9 +7816,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-address-lookup-table-program",
+ "solana-sdk",
  "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
@@ -8467,9 +7841,9 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-account-decoder",
+ "solana-address-lookup-table-program",
+ "solana-sdk",
  "spl-associated-token-account 2.2.0",
  "spl-memo 4.0.0",
  "spl-token 4.0.0",
@@ -8480,46 +7854,15 @@ dependencies = [
 [[package]]
 name = "solana-udp-client"
 version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b438036719e5c1201aba2336a5dc1caa8c8eefafd7110b7a3818ae199b54da"
-dependencies = [
- "async-trait",
- "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-net-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "solana-udp-client"
-version = "1.16.17"
 source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "async-trait",
- "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-connection-cache",
+ "solana-net-utils",
+ "solana-sdk",
+ "solana-streamer",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "solana-version"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62847d7ef409e3b410f65e726bf7816d8f8d0330918e78537e940bdf1ca061ae"
-dependencies = [
- "log 0.4.20",
- "rustc_version 0.4.0",
- "semver 1.0.21",
- "serde",
- "serde_derive",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -8532,31 +7875,9 @@ dependencies = [
  "semver 1.0.21",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
-]
-
-[[package]]
-name = "solana-vote-program"
-version = "1.16.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0c3e5ee7bd03b249c6b80eead5620af62bc7ef1af8ea4f499b8054b00e9c7d"
-dependencies = [
- "bincode",
- "log 0.4.20",
- "num-derive 0.3.3",
- "num-traits",
- "rustc_version 0.4.0",
- "serde",
- "serde_derive",
- "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -8571,12 +7892,12 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-metrics",
+ "solana-program",
+ "solana-program-runtime",
+ "solana-sdk",
  "thiserror",
 ]
 
@@ -8589,8 +7910,8 @@ dependencies = [
  "getrandom 0.1.16",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime",
+ "solana-sdk",
  "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
@@ -8616,8 +7937,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
+ "solana-sdk",
  "subtle",
  "thiserror",
  "zeroize",
@@ -8644,8 +7965,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
- "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program",
+ "solana-sdk",
  "subtle",
  "thiserror",
  "zeroize",
@@ -8702,7 +8023,7 @@ dependencies = [
  "borsh 0.9.3",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
  "thiserror",
@@ -8718,7 +8039,7 @@ dependencies = [
  "borsh 0.10.3",
  "num-derive 0.4.1",
  "num-traits",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-token 4.0.0",
  "spl-token-2022 0.9.0",
  "thiserror",
@@ -8731,7 +8052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
 dependencies = [
  "bytemuck",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-discriminator-derive",
 ]
 
@@ -8765,7 +8086,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
 ]
 
 [[package]]
@@ -8774,7 +8095,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
 dependencies = [
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
 ]
 
 [[package]]
@@ -8785,7 +8106,7 @@ checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error",
 ]
@@ -8798,7 +8119,7 @@ checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
 dependencies = [
  "num-derive 0.4.1",
  "num-traits",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-program-error-derive",
  "thiserror",
 ]
@@ -8822,7 +8143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
 dependencies = [
  "bytemuck",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -8840,7 +8161,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -8855,7 +8176,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "thiserror",
 ]
 
@@ -8870,7 +8191,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
@@ -8888,7 +8209,7 @@ dependencies = [
  "num-derive 0.4.1",
  "num-traits",
  "num_enum 0.7.2",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 4.0.0",
  "spl-pod",
@@ -8906,7 +8227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
 dependencies = [
  "borsh 0.10.3",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -8921,7 +8242,7 @@ checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -8936,7 +8257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
 dependencies = [
  "bytemuck",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -9125,7 +8446,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "quick-protobuf",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "switchboard-protos",
  "switchboard-utils",
 ]
@@ -9166,10 +8487,10 @@ dependencies = [
  "serde_json",
  "sgx-quote",
  "sha2 0.10.8",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-address-lookup-table-program",
+ "solana-client",
+ "solana-program",
  "superslice",
  "switchboard-common",
  "tokio",
@@ -9189,7 +8510,7 @@ dependencies = [
  "quick-protobuf",
  "rust_decimal",
  "rust_decimal_macros",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "switchboard-protos",
 ]
 
@@ -9203,7 +8524,7 @@ dependencies = [
  "anchor-spl 0.28.0",
  "bytemuck",
  "rust_decimal",
- "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program",
  "superslice",
 ]
 
@@ -10964,8 +10285,8 @@ dependencies = [
  "bincode",
  "prost 0.12.3",
  "protobuf-src",
- "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-account-decoder",
+ "solana-sdk",
  "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.10.2",
  "tonic-build 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,32 +65,33 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check 0.9.4",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.10",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check 0.9.4",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -119,11 +129,23 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faa5be5b72abea167f87c868379ba3c2be356bfca9e6f474fd055fa0f7eeb4f2"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "regex",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-access-control"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f619f1d04f53621925ba8a2e633ba5a6081f2ae14758cbb67f38fd823e0a3e"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -133,12 +155,25 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f468970344c7c9f9d03b4da854fd7c54f21305059f53789d0045c1dd803f0018"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0",
  "anyhow",
  "bs58 0.5.0",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-account"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f2a3e1df4685f18d12a943a9f2a7456305401af21a07c9fe076ef9ecd6e400"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "bs58 0.5.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -148,8 +183,19 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59948e7f9ef8144c2aefb3f32a40c5fce2798baeec765ba038389e82301017ef"
 dependencies = [
- "anchor-syn",
- "proc-macro2 1.0.67",
+ "anchor-syn 0.28.0",
+ "proc-macro2 1.0.76",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-constant"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9423945cb55627f0b30903288e78baf6f62c6c8ab28fb344b6b25f1ffee3dca7"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -159,9 +205,20 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc753c9d1c7981cb8948cf7e162fb0f64558999c0413058e2d43df1df5448086"
 dependencies = [
- "anchor-syn",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "anchor-syn 0.28.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ed12720033cc3c3bf3cfa293349c2275cd5ab99936e33dd4bf283aaad3e241"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -171,10 +228,22 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38b4e172ba1b52078f53fdc9f11e3dc0668ad27997838a0aad2d148afac8c97"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-event"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef4dc0371eba2d8c8b54794b0b0eb786a234a559b77593d6f80825b6d2c77a2"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -184,10 +253,21 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eebd21543606ab61e2d83d9da37d24d3886a49f390f9c43a1964735e8c0f0d5"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-attribute-program"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18c4f191331e078d4a6a080954d1576241c29c56638783322a18d308ab27e4f"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -197,17 +277,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8434a6bf33efba0c93157f7fa2fafac658cb26ab75396886dcedd87c2a8ad445"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
- "futures 0.3.28",
+ "futures 0.3.30",
  "regex",
  "serde",
- "solana-account-decoder",
- "solana-client",
- "solana-sdk",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
- "url 2.4.1",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -216,10 +296,34 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4720d899b3686396cced9508f23dab420f1308344456ec78ef76f98fda42af"
 dependencies = [
- "anchor-syn",
+ "anchor-syn 0.28.0",
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-accounts"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de10d6e9620d3bcea56c56151cad83c5992f50d5960b3a9bebc4a50390ddc3c"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-serde"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e2e5be518ec6053d90a2a7f26843dbee607583c779e6c8395951b9739bdfbe"
+dependencies = [
+ "anchor-syn 0.29.0",
+ "borsh-derive-internal 0.10.3",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -229,8 +333,19 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f495e85480bd96ddeb77b71d499247c7d4e8b501e75ecb234e9ef7ae7bd6552a"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "anchor-derive-space"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecc31d19fa54840e74b7a979d44bcea49d70459de846088a1d71e87ba53c419"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -240,21 +355,46 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d2d4b20100f1310a774aba3471ef268e5c4ba4d5c28c0bbe663c2658acbc414"
 dependencies = [
- "anchor-attribute-access-control",
- "anchor-attribute-account",
- "anchor-attribute-constant",
- "anchor-attribute-error",
- "anchor-attribute-event",
- "anchor-attribute-program",
- "anchor-derive-accounts",
- "anchor-derive-space",
+ "anchor-attribute-access-control 0.28.0",
+ "anchor-attribute-account 0.28.0",
+ "anchor-attribute-constant 0.28.0",
+ "anchor-attribute-error 0.28.0",
+ "anchor-attribute-event 0.28.0",
+ "anchor-attribute-program 0.28.0",
+ "anchor-derive-accounts 0.28.0",
+ "anchor-derive-space 0.28.0",
  "arrayref",
  "base64 0.13.1",
  "bincode",
  "borsh 0.10.3",
  "bytemuck",
- "getrandom 0.2.10",
- "solana-program",
+ "getrandom 0.2.12",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35da4785497388af0553586d55ebdc08054a8b1724720ef2749d313494f2b8ad"
+dependencies = [
+ "anchor-attribute-access-control 0.29.0",
+ "anchor-attribute-account 0.29.0",
+ "anchor-attribute-constant 0.29.0",
+ "anchor-attribute-error 0.29.0",
+ "anchor-attribute-event 0.29.0",
+ "anchor-attribute-program 0.29.0",
+ "anchor-derive-accounts 0.29.0",
+ "anchor-derive-serde",
+ "anchor-derive-space 0.29.0",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "borsh 0.10.3",
+ "bytemuck",
+ "getrandom 0.2.12",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -264,11 +404,25 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f860599da1c2354e7234c768783049eb42e2f54509ecfc942d2e0076a2da7b"
 dependencies = [
- "anchor-lang",
- "solana-program",
+ "anchor-lang 0.28.0",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
+]
+
+[[package]]
+name = "anchor-spl"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4fd6e43b2ca6220d2ef1641539e678bfc31b6cc393cf892b373b5997b6a39a"
+dependencies = [
+ "anchor-lang 0.29.0",
+ "mpl-token-metadata 3.2.3",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 2.2.0",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
 ]
 
 [[package]]
@@ -280,11 +434,29 @@ dependencies = [
  "anyhow",
  "bs58 0.5.0",
  "heck 0.3.3",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "serde",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
+name = "anchor-syn"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9101b84702fed2ea57bd22992f75065da5648017135b844283a2f6d74f27825"
+dependencies = [
+ "anyhow",
+ "bs58 0.5.0",
+ "heck 0.3.3",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -315,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "arc-swap"
@@ -348,7 +520,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -365,7 +537,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint 0.4.4",
  "num-traits",
  "paste",
@@ -379,7 +551,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -391,8 +563,8 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -427,8 +599,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -491,7 +663,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.31",
 ]
 
 [[package]]
@@ -500,8 +672,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -512,8 +684,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -536,12 +708,12 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.15"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
  "brotli",
- "flate2 1.0.27",
+ "flate2 1.0.28",
  "futures-core",
  "memchr",
  "pin-project-lite",
@@ -590,8 +762,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -601,20 +773,20 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -665,12 +837,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
  "mime 0.3.17",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -710,11 +882,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.10",
+ "getrandom 0.2.12",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -750,9 +937,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -762,9 +949,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
 dependencies = [
  "serde",
 ]
@@ -799,13 +986,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.15",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "prettyplease 0.2.16",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -816,9 +1003,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitmaps"
@@ -918,7 +1105,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -931,7 +1118,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -941,8 +1128,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -952,8 +1139,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -963,8 +1150,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -974,16 +1161,16 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -992,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1023,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
  "serde",
@@ -1068,16 +1255,16 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1162,8 +1349,8 @@ name = "checked_math"
 version = "0.1.0"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
  "trybuild",
 ]
@@ -1203,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -1252,8 +1439,8 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1290,24 +1477,24 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.19",
 ]
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1350,9 +1537,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1360,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core_affinity"
@@ -1378,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -1407,36 +1594,30 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.19",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.19",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg 1.1.0",
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.16",
- "memoffset 0.9.0",
- "scopeguard",
+ "crossbeam-utils 0.8.19",
 ]
 
 [[package]]
@@ -1452,12 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -1536,8 +1714,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1550,10 +1728,10 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "strsim 0.10.0",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1563,7 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1574,8 +1752,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
- "quote 1.0.33",
- "syn 2.0.37",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1590,10 +1768,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.4.0"
+name = "dashmap"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.14.3",
+ "lock_api 0.4.11",
+ "once_cell",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "default-env"
@@ -1631,9 +1822,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derivation-path"
@@ -1647,8 +1841,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1668,8 +1862,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling 0.14.4",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1690,8 +1884,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
@@ -1739,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "dir-diff"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2860407d7d7e2e004bb2128510ad9e8d669e76fa005ccf567977b5d71b8b4a0b"
+checksum = "a7ad16bf5f84253b50d6557681c58c3ab67c47c77d39fed9aeb56e947290bd10"
 dependencies = [
  "walkdir",
 ]
@@ -1793,9 +1987,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1829,9 +2023,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "eager"
@@ -1871,7 +2065,7 @@ dependencies = [
  "derivation-path",
  "ed25519-dalek",
  "hmac 0.12.1",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1881,8 +2075,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1909,35 +2103,35 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
+checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
+checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "3.1.13"
+version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f76552f53cefc9a7f64987c3701b99d982f7690606fd67de1d09712fbf52f1"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
  "num-bigint 0.4.4",
  "num-traits",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1955,8 +2149,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "946ee94e3dbf58fdd324f9ce245c7b238d46a66f00e86a020b71996349e46cce"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1989,24 +2183,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "errno"
-version = "0.3.3"
+name = "erased-serde"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "55d05712b2d8d88102bc9868020c9e5c7a1f5527c452b9b97450a1d006140ba7"
 dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
+ "serde",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "errno"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "cc",
  "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2038,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "feature-probe"
@@ -2060,14 +2252,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2083,19 +2275,6 @@ source = "git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-
 dependencies = [
  "az",
  "borsh 0.10.3",
- "bytemuck",
- "half",
- "serde",
- "typenum",
-]
-
-[[package]]
-name = "fixed"
-version = "1.11.0"
-source = "git+https://github.com/openbook-dex/openbook-v2.git#deb70f66c3294f4f8942f12f46ef40730f5d23c6"
-dependencies = [
- "az",
- "borsh 0.9.3",
  "bytemuck",
  "half",
  "serde",
@@ -2120,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2151,11 +2330,11 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -2194,9 +2373,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2209,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2219,15 +2398,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2237,38 +2416,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -2328,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2340,6 +2519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,15 +2532,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
- "fnv",
  "log 0.4.20",
- "regex",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2365,7 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8af59a261bcf42f45d1b261232847b9b850ba0a1419d6100698246fb66e9240"
 dependencies = [
  "arc-swap",
- "futures 0.3.28",
+ "futures 0.3.30",
  "log 0.4.20",
  "reqwest",
  "serde",
@@ -2373,7 +2558,7 @@ dependencies = [
  "serde_json",
  "simpl",
  "smpl_jwt",
- "time 0.3.29",
+ "time 0.3.31",
  "tokio",
 ]
 
@@ -2390,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2400,10 +2585,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.10",
  "tracing",
 ]
 
@@ -2428,7 +2613,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -2437,7 +2622,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -2446,14 +2631,14 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "headers"
@@ -2461,7 +2646,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "bytes 1.5.0",
  "headers-core",
  "http",
@@ -2556,18 +2741,18 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes 1.5.0",
  "fnv",
@@ -2576,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes 1.5.0",
  "http",
@@ -2624,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
@@ -2639,7 +2824,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2653,10 +2838,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
 dependencies = [
  "bytes 1.5.0",
- "futures 0.3.28",
+ "futures 0.3.30",
  "headers",
  "http",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-tls",
  "native-tls",
  "tokio",
@@ -2666,15 +2851,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http",
- "hyper 0.14.27",
- "rustls 0.20.9",
+ "hyper 0.14.28",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2683,7 +2869,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2696,7 +2882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.5.0",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2704,16 +2890,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -2744,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2776,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "index_list"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9d968042a4902e08810946fc7cd5851eb75e80301342305af755ca06cb82ce"
+checksum = "70891286cb8e844fdfcf1178b47569699f9e20b5ecc4b45a6240a64771444638"
 
 [[package]]
 name = "indexmap"
@@ -2793,12 +2979,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2834,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itertools"
@@ -2848,10 +3034,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.9"
+name = "itertools"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jemalloc-sys"
@@ -2876,18 +3071,18 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2899,8 +3094,8 @@ source = "git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip#3
 dependencies = [
  "derive_more",
  "flate2 0.2.20",
- "futures 0.3.28",
- "hyper 0.14.27",
+ "futures 0.3.30",
+ "hyper 0.14.28",
  "hyper-tls",
  "jsonrpc-core 18.0.0 (git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip)",
  "jsonrpc-pubsub 18.0.0 (git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip)",
@@ -2917,7 +3112,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "futures-executor",
  "futures-util",
  "log 0.4.20",
@@ -2931,7 +3126,7 @@ name = "jsonrpc-core"
 version = "18.0.0"
 source = "git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip#3e83f454313b218a75be25d3d4cfc2c4e76bb8bd"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "futures-executor",
  "futures-util",
  "log 0.4.20",
@@ -2945,7 +3140,7 @@ name = "jsonrpc-core-client"
 version = "18.0.0"
 source = "git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip#3e83f454313b218a75be25d3d4cfc2c4e76bb8bd"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "jsonrpc-client-transports",
 ]
 
@@ -2956,8 +3151,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -2967,8 +3162,8 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.28",
- "hyper 0.14.27",
+ "futures 0.3.30",
+ "hyper 0.14.28",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-server-utils",
  "log 0.4.20",
@@ -2983,7 +3178,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log 0.4.20",
@@ -2997,7 +3192,7 @@ name = "jsonrpc-pubsub"
 version = "18.0.0"
 source = "git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip#3e83f454313b218a75be25d3d4cfc2c4e76bb8bd"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "jsonrpc-core 18.0.0 (git+https://github.com/ckamm/jsonrpc.git?branch=ckamm/http-with-gzip)",
  "lazy_static",
  "log 0.4.20",
@@ -3013,7 +3208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes 1.5.0",
- "futures 0.3.28",
+ "futures 0.3.30",
  "globset",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
@@ -3048,7 +3243,7 @@ dependencies = [
  "beef",
  "futures-channel",
  "futures-util",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -3070,12 +3265,12 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "globset",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "lazy_static",
  "serde_json",
- "socket2",
+ "socket2 0.4.10",
  "tokio",
  "tracing",
  "unicase 2.7.0",
@@ -3097,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -3112,6 +3307,15 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log 0.4.20",
 ]
 
 [[package]]
@@ -3147,25 +3351,36 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if 1.0.0",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -3232,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "295c17e837573c8c821dbaeb3cceb3d745ad082f7572191409e69cbc1b3fd050"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3243,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -3258,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -3280,6 +3495,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -3313,25 +3531,24 @@ dependencies = [
 [[package]]
 name = "mango-feeds-connector"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcd440ee3dd5090a6f36bf8d9392ce7f9cc705828fdacf88b6022ddb7aeb895"
+source = "git+https://github.com/blockworks-foundation/mango-feeds.git?rev=5def8c9468c29a7e3b50bbc51946456de6dab52d#5def8c9468c29a7e3b50bbc51946456de6dab52d"
 dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
- "futures 0.3.28",
- "itertools",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client",
  "log 0.4.20",
  "rustls 0.20.9",
  "serde",
  "serde_derive",
- "solana-account-decoder",
- "solana-client",
- "solana-logger",
- "solana-rpc",
- "solana-sdk",
+ "serde_json",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "warp",
  "yellowstone-grpc-client",
@@ -3345,23 +3562,23 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-trait",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bs58 0.5.0",
  "bytemuck",
  "bytes 1.5.0",
  "chrono",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
+ "fixed",
+ "futures 0.3.30",
  "futures-core",
- "itertools",
+ "itertools 0.10.5",
  "log 0.4.20",
  "rand 0.7.3",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-client",
- "solana-sdk",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-build 0.6.2",
 ]
 
@@ -3369,8 +3586,8 @@ dependencies = [
 name = "mango-v4"
 version = "0.22.0"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "arrayref",
  "async-trait",
  "base64 0.13.1",
@@ -3380,8 +3597,8 @@ dependencies = [
  "default-env",
  "derivative",
  "env_logger",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "itertools",
+ "fixed",
+ "itertools 0.10.5",
  "lazy_static",
  "log 0.4.20",
  "num 0.4.1",
@@ -3392,11 +3609,11 @@ dependencies = [
  "regex",
  "serde",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-address-lookup-table-program",
- "solana-logger",
- "solana-program",
+ "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-program-test",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-security-txt",
  "spl-associated-token-account 1.1.3",
  "spl-token 3.5.0",
@@ -3410,23 +3627,23 @@ name = "mango-v4-cli"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "anyhow",
  "async-channel",
- "base64 0.21.4",
+ "base64 0.21.7",
  "clap 3.2.25",
  "dotenv",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
- "itertools",
+ "fixed",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "mango-v4",
  "mango-v4-client",
  "pyth-sdk-solana",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tracing",
 ]
@@ -3436,8 +3653,8 @@ name = "mango-v4-client"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "anyhow",
  "async-channel",
  "async-once-cell",
@@ -3446,9 +3663,9 @@ dependencies = [
  "base64 0.13.1",
  "bincode",
  "derive_builder",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
- "itertools",
+ "fixed",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client",
  "mango-feeds-connector",
@@ -3459,11 +3676,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder",
- "solana-address-lookup-table-program",
- "solana-client",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-rpc",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "spl-associated-token-account 1.1.3",
  "thiserror",
  "tokio",
@@ -3477,22 +3694,22 @@ name = "mango-v4-keeper"
 version = "0.3.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "anyhow",
  "clap 3.2.25",
  "dotenv",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
- "itertools",
+ "fixed",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "lazy_static",
  "mango-v4",
  "mango-v4-client",
  "prometheus",
  "pyth-sdk-solana",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tracing",
  "warp",
@@ -3503,7 +3720,7 @@ name = "mango-v4-liquidator"
 version = "0.0.1"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "arrayref",
  "async-channel",
@@ -3515,11 +3732,11 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "dotenv",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
+ "fixed",
+ "futures 0.3.30",
  "futures-core",
  "futures-util",
- "itertools",
+ "itertools 0.10.5",
  "jemallocator",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client",
@@ -3533,11 +3750,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder",
- "solana-client",
- "solana-logger",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-rpc",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.16.1",
@@ -3549,7 +3766,7 @@ name = "mango-v4-settler"
 version = "0.0.1"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "arrayref",
  "async-channel",
@@ -3561,11 +3778,11 @@ dependencies = [
  "bytes 1.5.0",
  "clap 3.2.25",
  "dotenv",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
- "futures 0.3.28",
+ "fixed",
+ "futures 0.3.30",
  "futures-core",
  "futures-util",
- "itertools",
+ "itertools 0.10.5",
  "jemallocator",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client",
@@ -3580,11 +3797,11 @@ dependencies = [
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
  "shellexpand",
- "solana-account-decoder",
- "solana-client",
- "solana-logger",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-rpc",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.16.1",
@@ -3630,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -3736,7 +3953,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log 0.4.20",
- "miow 0.2.2",
+ "miow",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -3744,15 +3961,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
- "log 0.4.20",
- "miow 0.3.7",
- "ntapi",
- "winapi 0.3.9",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3780,15 +3995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "modular-bitfield"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,8 +4010,8 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -3823,8 +4029,8 @@ dependencies = [
  "rmp-serde",
  "serde",
  "shank",
- "solana-program",
- "solana-zk-token-sdk",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -3842,9 +4048,22 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "shank",
- "solana-program",
- "spl-associated-token-account 2.1.0",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 2.2.0",
  "spl-token 4.0.0",
+ "thiserror",
+]
+
+[[package]]
+name = "mpl-token-metadata"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
+dependencies = [
+ "borsh 0.10.3",
+ "num-derive 0.3.3",
+ "num-traits",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -3854,7 +4073,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12989bc45715b0ee91944855130131479f9c772e198a910c3eb0ea327d5bffc3"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -3864,7 +4083,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a739019e11d93661a64ef5fe108ab17c79b35961e944442ff6efdd460ad01a"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -3875,7 +4094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f2e4f92aec317d5853c0cc4c03c55f5178511c45bb3dbb441aea63117bf3dc9"
 dependencies = [
  "arrayref",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-2022 0.6.1",
 ]
 
@@ -3967,15 +4186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4060,20 +4270,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "num-derive"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
+checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4123,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -4160,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.0",
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -4174,8 +4384,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -4186,21 +4396,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro-crate 3.0.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4208,6 +4418,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "oid-registry"
@@ -4220,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -4239,19 +4458,21 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "openbook-v2"
 version = "0.1.0"
-source = "git+https://github.com/openbook-dex/openbook-v2.git#deb70f66c3294f4f8942f12f46ef40730f5d23c6"
+source = "git+https://github.com/openbook-dex/openbook-v2.git#fa8b1cfaac44933009e42b55678a38c4a15cb615"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "arrayref",
  "bytemuck",
+ "default-env",
  "derivative",
- "fixed 1.11.0 (git+https://github.com/openbook-dex/openbook-v2.git)",
- "itertools",
+ "fixed",
+ "itertools 0.10.5",
  "num_enum 0.5.11",
  "pyth-sdk-solana",
  "raydium-amm-v3",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-security-txt",
  "static_assertions",
  "switchboard-program",
  "switchboard-v2",
@@ -4259,11 +4480,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4278,9 +4499,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4291,18 +4512,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.5+3.1.3"
+version = "300.2.1+3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
+checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
 dependencies = [
  "cc",
  "libc",
@@ -4324,7 +4545,7 @@ dependencies = [
  "futures-util",
  "js-sys",
  "lazy_static",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project",
  "rand 0.8.5",
  "thiserror",
@@ -4332,9 +4553,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.1"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "ouroboros"
@@ -4354,8 +4575,8 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -4383,7 +4604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.10",
+ "lock_api 0.4.11",
  "parking_lot_core 0.8.6",
 ]
 
@@ -4393,8 +4614,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.10",
- "parking_lot_core 0.9.8",
+ "lock_api 0.4.11",
+ "parking_lot_core 0.9.9",
 ]
 
 [[package]]
@@ -4422,20 +4643,20 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec 1.11.1",
+ "smallvec 1.12.0",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.3.5",
- "smallvec 1.11.1",
+ "redox_syscall 0.4.1",
+ "smallvec 1.12.0",
  "windows-targets 0.48.5",
 ]
 
@@ -4486,9 +4707,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "percentage"
@@ -4506,7 +4727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -4542,9 +4763,9 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4572,9 +4793,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plain"
@@ -4596,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postgres-derive"
@@ -4607,9 +4828,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4618,7 +4839,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d442770e2b1e244bb5eb03b31c79b65bb2568f413b899eaba850fa945a65954"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.30",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -4631,7 +4852,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "byteorder",
  "bytes 1.5.0",
  "fallible-iterator",
@@ -4639,7 +4860,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.8.5",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "stringprep",
 ]
 
@@ -4663,7 +4884,7 @@ version = "0.3.3"
 source = "git+https://github.com/nolanderc/rust-postgres-query?rev=b4422051c8a31fbba4a35f88004c1cefb1878dd5#b4422051c8a31fbba4a35f88004c1cefb1878dd5"
 dependencies = [
  "async-trait",
- "futures 0.3.28",
+ "futures 0.3.30",
  "postgres-types",
  "postgres_query_macro",
  "proc-macro-hack",
@@ -4678,10 +4899,16 @@ version = "0.3.3"
 source = "git+https://github.com/nolanderc/rust-postgres-query?rev=b4422051c8a31fbba4a35f88004c1cefb1878dd5#b4422051c8a31fbba4a35f88004c1cefb1878dd5"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4695,18 +4922,18 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
- "proc-macro2 1.0.67",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4735,7 +4962,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+dependencies = [
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -4745,8 +4981,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
  "version_check 0.9.4",
 ]
@@ -4757,8 +4993,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "version_check 0.9.4",
 ]
 
@@ -4779,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -4822,6 +5058,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes 1.5.0",
+ "prost-derive 0.12.3",
+]
+
+[[package]]
 name = "prost-build"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4829,7 +5075,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes 1.5.0",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log 0.4.20",
  "multimap",
@@ -4849,7 +5095,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes 1.5.0",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log 0.4.20",
  "multimap",
@@ -4864,15 +5110,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+dependencies = [
+ "bytes 1.5.0",
+ "heck 0.4.1",
+ "itertools 0.11.0",
+ "log 0.4.20",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.16",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "regex",
+ "syn 2.0.48",
+ "tempfile",
+ "which",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "itertools 0.10.5",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -4883,10 +5151,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "itertools 0.10.5",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4906,6 +5187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -4931,7 +5221,7 @@ checksum = "1e7aeef4d5f0a9c98ff5af2ddd84a8b89919c512188305b497a9eb9afa97a949"
 dependencies = [
  "borsh 0.10.3",
  "borsh-derive 0.10.3",
- "getrandom 0.2.10",
+ "getrandom 0.2.12",
  "hex",
  "schemars",
  "serde",
@@ -4950,7 +5240,7 @@ dependencies = [
  "num-traits",
  "pyth-sdk",
  "serde",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -4960,7 +5250,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -4992,13 +5282,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956be1b23f4261676aed05a0046e204e8a6836e50203902683a718af0797989"
+checksum = "94b0b33c13a79f669c85defaf4c275dc86a0c0372807d0ca3d78e0bb87274863"
 dependencies = [
  "bytes 1.5.0",
  "rand 0.8.5",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -5017,7 +5307,7 @@ checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
  "libc",
  "quinn-proto",
- "socket2",
+ "socket2 0.4.10",
  "tracing",
  "windows-sys 0.42.0",
 ]
@@ -5033,11 +5323,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
 ]
 
 [[package]]
@@ -5143,7 +5433,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -5229,14 +5519,15 @@ dependencies = [
 [[package]]
 name = "raydium-amm-v3"
 version = "0.1.0"
-source = "git+https://github.com/raydium-io/raydium-clmm.git#6e4639f7133a8852068d2d473c263f907b69cd4a"
+source = "git+https://github.com/raydium-io/raydium-clmm.git#e6dd1d5673995d5c0de32862438f36b9af935e7c"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.29.0",
+ "anchor-spl 0.29.0",
  "arrayref",
  "bytemuck",
- "mpl-token-metadata",
- "solana-program",
+ "mpl-token-metadata 1.13.2",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-memo 4.0.0",
  "uint",
 ]
 
@@ -5257,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
- "crossbeam-utils 0.8.16",
+ "crossbeam-utils 0.8.19",
 ]
 
 [[package]]
@@ -5267,8 +5558,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
- "ring",
- "time 0.3.29",
+ "ring 0.16.20",
+ "time 0.3.31",
  "yasna",
 ]
 
@@ -5298,21 +5589,21 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
+ "getrandom 0.2.12",
+ "libredox",
  "thiserror",
 ]
 
@@ -5327,20 +5618,20 @@ dependencies = [
  "libm",
  "lru",
  "parking_lot 0.11.2",
- "smallvec 1.11.1",
+ "smallvec 1.12.0",
  "spin 0.9.8",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5354,13 +5645,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -5371,18 +5662,18 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "async-compression",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bytes 1.5.0",
  "encoding_rs",
  "futures-core",
@@ -5390,7 +5681,7 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -5399,23 +5690,24 @@ dependencies = [
  "mime 0.3.17",
  "native-tls",
  "once_cell",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
- "rustls 0.20.9",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
- "tokio-util 0.7.2",
+ "tokio-rustls 0.24.1",
+ "tokio-util 0.7.10",
  "tower-service",
- "url 2.4.1",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -5429,9 +5721,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom 0.2.12",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5468,23 +5774,23 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.2.0"
+version = "7.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678cf63ab3491898c0d021b493c94c9b221d91295294a2a5746eacbe5928322"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
 dependencies = [
  "libc",
  "rtoolbox",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034e22c514f5c0cb8a10ff341b9b048b5ceb21591f31c8f44c43b960f9b3524a"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5504,7 +5810,7 @@ version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4903d8db81d2321699ca8318035d6ff805c548868df435813968795a802171b2"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "rust_decimal",
 ]
 
@@ -5535,7 +5841,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.19",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -5549,15 +5855,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5567,19 +5873,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log 0.4.20",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log 0.4.20",
- "ring",
+ "ring 0.17.7",
  "rustls-webpki",
  "sct",
 ]
@@ -5598,21 +5904,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5623,9 +5929,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "safe-transmute"
@@ -5650,18 +5956,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "schemars"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -5671,12 +5977,12 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "serde_derive_internals",
  "syn 1.0.109",
 ]
@@ -5708,19 +6014,19 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5757,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "semver-parser"
@@ -5769,31 +6075,31 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5802,16 +6108,25 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.107"
+name = "serde_fmt"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -5847,18 +6162,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling 0.20.3",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.25"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
+checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -5870,7 +6185,7 @@ name = "serum_dex"
 version = "0.5.10"
 source = "git+https://github.com/grooviegermanikus/program.git?branch=groovie/v0.5.10-updates-expose-things#03f1b242db2a709af2601b4df445b2ea33a8d97d"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.29.0",
  "arrayref",
  "bincode",
  "bytemuck",
@@ -5878,12 +6193,12 @@ dependencies = [
  "default-env",
  "enumflags2",
  "field-offset",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "num_enum 0.5.11",
  "safe-transmute",
  "serde",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-security-txt",
  "spl-token 3.5.0",
  "static_assertions",
@@ -5896,7 +6211,7 @@ name = "serum_dex"
 version = "0.5.10"
 source = "git+https://github.com/openbook-dex/program.git#c85e56deeaead43abbc33b7301058838b9c5136d"
 dependencies = [
- "anchor-lang",
+ "anchor-lang 0.29.0",
  "arrayref",
  "bincode",
  "bytemuck",
@@ -5904,12 +6219,12 @@ dependencies = [
  "default-env",
  "enumflags2",
  "field-offset",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "num_enum 0.5.11",
  "safe-transmute",
  "serde",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-security-txt",
  "spl-token 3.5.0",
  "static_assertions",
@@ -5922,7 +6237,7 @@ name = "service-mango-crank"
 version = "0.1.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "async-channel",
  "async-trait",
@@ -5930,7 +6245,7 @@ dependencies = [
  "bytemuck",
  "futures-channel",
  "futures-util",
- "itertools",
+ "itertools 0.10.5",
  "log 0.4.20",
  "mango-feeds-connector",
  "mango-feeds-lib",
@@ -5940,9 +6255,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client",
- "solana-logger",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tokio-tungstenite 0.17.2",
  "toml",
@@ -5954,19 +6269,19 @@ name = "service-mango-fills"
 version = "0.1.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "async-channel",
  "async-trait",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bs58 0.3.1",
  "bytemuck",
  "chrono",
- "futures 0.3.28",
+ "futures 0.3.30",
  "futures-channel",
  "futures-core",
  "futures-util",
- "itertools",
+ "itertools 0.10.5",
  "jemallocator",
  "log 0.4.20",
  "mango-feeds-connector",
@@ -5982,9 +6297,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/openbook-dex/program.git)",
- "solana-client",
- "solana-logger",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -5998,16 +6313,16 @@ name = "service-mango-orderbook"
 version = "0.1.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "async-channel",
  "async-trait",
  "bs58 0.3.1",
  "bytemuck",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
+ "fixed",
  "futures-channel",
  "futures-util",
- "itertools",
+ "itertools 0.10.5",
  "log 0.4.20",
  "mango-feeds-connector",
  "mango-feeds-lib",
@@ -6017,9 +6332,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serum_dex 0.5.10 (git+https://github.com/grooviegermanikus/program.git?branch=groovie/v0.5.10-updates-expose-things)",
- "solana-client",
- "solana-logger",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "tokio-tungstenite 0.17.2",
  "toml",
@@ -6031,12 +6346,12 @@ name = "service-mango-pnl"
 version = "0.1.0"
 dependencies = [
  "anchor-client",
- "anchor-lang",
+ "anchor-lang 0.28.0",
  "anyhow",
  "async-channel",
  "async-trait",
  "bs58 0.3.1",
- "fixed 1.11.0 (git+https://github.com/blockworks-foundation/fixed.git?branch=v1.11.0-borsh0_10-mango)",
+ "fixed",
  "jsonrpsee",
  "log 0.4.20",
  "mango-feeds-connector",
@@ -6044,9 +6359,9 @@ dependencies = [
  "mango-v4-client",
  "serde",
  "serde_derive",
- "solana-client",
- "solana-logger",
- "solana-sdk",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
  "toml",
 ]
@@ -6122,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -6168,8 +6483,8 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "shank_macro_impl",
  "syn 1.0.109",
 ]
@@ -6181,17 +6496,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "serde",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -6274,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
 
 [[package]]
 name = "smpl_jwt"
@@ -6291,17 +6606,27 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "simpl",
- "time 0.3.29",
+ "time 0.3.31",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6312,7 +6637,7 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.5.0",
- "futures 0.3.28",
+ "futures 0.3.30",
  "httparse",
  "log 0.4.20",
  "rand 0.8.5",
@@ -6321,12 +6646,12 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ada16ccd5ca6884ae28b716211c4f09d22225a9ebde14eccd4f605cc321e42"
+checksum = "121e55656c2094950f374247e1303dd09517f1ed49c91bf60bf114760b286eb4"
 dependencies = [
  "Inflector",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bs58 0.4.0",
  "bv",
@@ -6334,20 +6659,45 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-address-lookup-table-program",
- "solana-config-program",
- "solana-sdk",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
+ "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
+ "spl-token-metadata-interface",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "solana-account-decoder"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "Inflector",
+ "base64 0.21.7",
+ "bincode",
+ "bs58 0.4.0",
+ "bv",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
+ "spl-token-metadata-interface",
  "thiserror",
  "zstd",
 ]
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248b435722d18100b70bb8f09fd38b8a8c46031a0de86f6b31768f64cf4092c5"
+checksum = "3ccb31f7f14d5876acd9ec38f5bf6097bfb4b350141d81c7ff2bf684db3ca815"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6356,25 +6706,44 @@ dependencies = [
  "num-traits",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-program",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-address-lookup-table-program"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "log 0.4.20",
+ "num-derive 0.3.3",
+ "num-traits",
+ "rustc_version 0.4.0",
+ "serde",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-banks-client"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5c444528608701d09fab7926244e10294f5eec816f20bc4a82e103227bc0c6"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "borsh 0.10.3",
- "futures 0.3.28",
+ "futures 0.3.30",
  "solana-banks-interface",
- "solana-program",
- "solana-sdk",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tarpc",
  "thiserror",
  "tokio",
@@ -6383,28 +6752,26 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b298b4d6355ed958cca28db551222e4e2a5fbe05a787b00aef2212e77b110b08"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "serde",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309d16b0056e599f5e83c296d126dba64c6d47366ef07d38796cbbae41c2b6bf"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "crossbeam-channel",
- "futures 0.3.28",
+ "futures 0.3.30",
  "solana-banks-interface",
- "solana-client",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-send-transaction-service",
  "tarpc",
  "tokio",
@@ -6413,9 +6780,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc9d0e0da1647bc42b4ad5be07f88e410dac2cefeb3a8c890316a15db8285c0"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bv",
  "fnv",
@@ -6425,35 +6791,33 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b84a554f12f89c72f3c2dea973a5105740814aeebfb04998cc0afd9e2e6a2e"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "byteorder",
  "libsecp256k1",
  "log 0.4.20",
  "rand 0.7.3",
- "solana-measure",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90e94b36eb9cdbe78a4d37c0ce1f96794c7fbae16baa0f6e51811ffbb25819b"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bv",
  "log 0.4.20",
@@ -6461,54 +6825,70 @@ dependencies = [
  "modular-bitfield",
  "num_enum 0.6.1",
  "rand 0.7.3",
- "solana-measure",
- "solana-sdk",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tempfile",
 ]
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2782dc1178498135d438ea51998e5a28be05f2ed5b9ff97e224d8ca1f6b16fe5"
+checksum = "47a8150d4ff694d9587496a5976d33e6ebdb16cc61c6338bdfe3b2fc2c7c4986"
 dependencies = [
  "chrono",
  "clap 2.34.0",
  "rpassword",
- "solana-perf",
- "solana-remote-wallet",
- "solana-sdk",
+ "solana-perf 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-remote-wallet 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tiny-bip39",
  "uriparse",
- "url 2.4.1",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "solana-clap-utils"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "chrono",
+ "clap 2.34.0",
+ "rpassword",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-remote-wallet 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "thiserror",
+ "tiny-bip39",
+ "uriparse",
+ "url 2.5.0",
 ]
 
 [[package]]
 name = "solana-cli-config"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538e8c1de6e6a948930a11f7debdbb21ff5492d09b67fb0d37a03c5208c233c7"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "dirs-next",
  "lazy_static",
  "serde",
  "serde_derive",
  "serde_yaml",
- "solana-clap-utils",
- "solana-sdk",
- "url 2.4.1",
+ "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "url 2.5.0",
 ]
 
 [[package]]
 name = "solana-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969294bec354ba003bb4dc2e95e94beee4202d3244d6011434c282337601cc1f"
+checksum = "35d7582847ab4d60652ff640ca574647789461c1630e8c7580ff770738c3d7f4"
 dependencies = [
  "async-trait",
  "bincode",
- "futures 0.3.28",
+ "futures 0.3.30",
  "futures-util",
  "indexmap 1.9.3",
  "indicatif",
@@ -6516,52 +6896,96 @@ dependencies = [
  "quinn",
  "rand 0.7.3",
  "rayon",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-pubsub-client",
- "solana-quic-client",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-rpc-client-nonce-utils",
- "solana-sdk",
- "solana-streamer",
- "solana-thin-client",
- "solana-tpu-client",
- "solana-udp-client",
+ "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-pubsub-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-quic-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-nonce-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-thin-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-tpu-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-udp-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "futures 0.3.30",
+ "futures-util",
+ "indexmap 1.9.3",
+ "indicatif",
+ "log 0.4.20",
+ "quinn",
+ "rand 0.7.3",
+ "rayon",
+ "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-pubsub-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-quic-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-nonce-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-thin-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-udp-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f864bd6ba7d6dfeb88b774edc31af0abd27df96763d4e8a3f91e34f4f0995"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
- "solana-program-runtime",
- "solana-sdk",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0622d8798d060c84883572483f214b0d5c1640450e4322483cfe2e72823a6d7"
+checksum = "94dc0f4463daf1c6155f20eac948ea4ced705e5f5520546aef4e11e746a6d95d"
 dependencies = [
  "bincode",
  "chrono",
  "serde",
  "serde_derive",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-config-program"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bincode",
+ "chrono",
+ "serde",
+ "serde_derive",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1439d38886d31690d8e2573e656e6767d3ae790229050dfe71ade309d5664cb"
+checksum = "758587d44e05a4abdf82b9514d1c8b7d35637ad65f7af7c3e3e02417aaae3c9e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6571,18 +6995,37 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "rcgen",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
+ "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-connection-cache"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "futures-util",
+ "indexmap 1.9.3",
+ "log 0.4.20",
+ "rand 0.7.3",
+ "rayon",
+ "rcgen",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-entry"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32fa8cf5f71c4bd9b08db79469811f1c47d3c577643da8d5544ef6ddd685683"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6593,19 +7036,18 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-measure",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-merkle-tree",
- "solana-metrics",
- "solana-perf",
- "solana-rayon-threadlimit",
- "solana-sdk",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-faucet"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec77384c3c93e9f755ef0352c0c90ec98017e9db9908a9e7878dad60ea3244b"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "byteorder",
@@ -6614,24 +7056,24 @@ dependencies = [
  "log 0.4.20",
  "serde",
  "serde_derive",
- "solana-clap-utils",
+ "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-cli-config",
- "solana-logger",
- "solana-metrics",
- "solana-sdk",
- "solana-version",
- "spl-memo 3.0.1",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-memo 4.0.0",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e74d294241df12a73a229e38a819e810d54234da494c3d43f8a1a828631047d"
+checksum = "d266bf0311bb403d31206aa2904b8741f57c7f5e27580b6810ad5e22fc7c3282"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
  "blake3",
  "block-buffer 0.10.4",
  "bs58 0.4.0",
@@ -6652,37 +7094,79 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
- "solana-frozen-abi-macro",
+ "sha2 0.10.8",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-frozen-abi"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "ahash 0.8.7",
+ "blake3",
+ "block-buffer 0.10.4",
+ "bs58 0.4.0",
+ "bv",
+ "byteorder",
+ "cc",
+ "either",
+ "generic-array 0.14.7",
+ "getrandom 0.1.16",
+ "im",
+ "lazy_static",
+ "log 0.4.20",
+ "memmap2",
+ "once_cell",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.0",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "subtle",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dabde7fbd88a68eb083ae9d6d5f6855b7ba1bfc45d200c786b1b448ac49da5f"
+checksum = "6dfe18c5155015dcb494c6de84a03b725fcf90ec2006a047769018b94c2cf0de"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "rustc_version 0.4.0",
- "syn 2.0.37",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "solana-frozen-abi-macro"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "rustc_version 0.4.0",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "solana-gossip"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d681e00c69a3533a67bebf8ac25efecc93347537c60b941d4d2fe36030499c"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "bv",
  "clap 2.34.0",
  "crossbeam-channel",
- "flate2 1.0.27",
+ "flate2 1.0.28",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "log 0.4.20",
  "lru",
  "matches",
@@ -6695,34 +7179,33 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-bloom",
- "solana-clap-utils",
- "solana-client",
+ "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-entry",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-ledger",
- "solana-logger",
- "solana-measure",
- "solana-metrics",
- "solana-net-utils",
- "solana-perf",
- "solana-rayon-threadlimit",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
- "solana-streamer",
- "solana-thin-client",
- "solana-tpu-client",
- "solana-version",
- "solana-vote-program",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-thin-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "static_assertions",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-ledger"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b139341b34e1dd43eb60a71d296688d0cf6101d4c21b21b2e8a62a912aecce"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6731,10 +7214,10 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 4.0.2",
  "fs_extra",
- "futures 0.3.28",
- "itertools",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "lazy_static",
  "libc",
  "log 0.4.20",
@@ -6751,26 +7234,26 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_bytes",
- "sha2 0.10.7",
- "solana-account-decoder",
+ "sha2 0.10.8",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-bpf-loader-program",
  "solana-entry",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-program-runtime",
- "solana-rayon-threadlimit",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-stake-program",
  "solana-storage-bigtable",
  "solana-storage-proto",
- "solana-transaction-status",
- "solana-vote-program",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
  "static_assertions",
  "tempfile",
  "thiserror",
@@ -6781,23 +7264,32 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de634a9a00c745e42c3278458c0c85d0aa088db2cf872f06af8210991bf51574"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "log 0.4.20",
  "rand 0.7.3",
- "solana-measure",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana_rbpf",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24dc0037a389d782c8de3c6f509b74efa1d60523ef9e5561cefe41f1a354fee0"
+checksum = "4f76fe25c2d06dcf621befd1e8d5655143e8a059c7e20fcb71736bc80ed779d6"
+dependencies = [
+ "env_logger",
+ "lazy_static",
+ "log 0.4.20",
+]
+
+[[package]]
+name = "solana-logger"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6806,44 +7298,65 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19563c27f12801e0e65b42d0f216db1d910dfeaad88d8f1335dd6369697eda60"
+checksum = "db165b8a7f5d840abef011c78a18ffe63cad9192d676b07d94f469b6b5dc6cf6"
 dependencies = [
  "log 0.4.20",
- "solana-sdk",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-measure"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "log 0.4.20",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10945018bc2fa7b773cbf519dfed76c6e8946daa1548abf2eb34591186915cb4"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "fast-math",
  "matches",
- "solana-program",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f74c557e821c7ff48c9b4ef4ab3a296918d7fb745e3f2e820ebdb38e8e3555b"
+checksum = "aa01731bb3952904962d49a1ea1205db54e93f3a56f4006d32e02a7c85d60546"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
  "lazy_static",
  "log 0.4.20",
  "reqwest",
- "solana-sdk",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-metrics"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "crossbeam-channel",
+ "gethostname",
+ "lazy_static",
+ "log 0.4.20",
+ "reqwest",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-net-utils"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d5599760f8a287c59d96a5c52752028c1c72c815fe74e0d7990bb90684cbfc"
+checksum = "fd7ab67329dcebe4a40673fd0da27373282b1359ec7945e0fb81a9c594bcd057"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -6853,21 +7366,42 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_derive",
- "socket2",
- "solana-logger",
- "solana-sdk",
- "solana-version",
+ "socket2 0.4.10",
+ "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
- "url 2.4.1",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "solana-net-utils"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bincode",
+ "clap 3.2.25",
+ "crossbeam-channel",
+ "log 0.4.20",
+ "nix",
+ "rand 0.7.3",
+ "serde",
+ "serde_derive",
+ "socket2 0.4.10",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "tokio",
+ "url 2.5.0",
 ]
 
 [[package]]
 name = "solana-perf"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b2adb00aa09d92cd3b4f614ddd4f81366524a0d8ae9dd63b64418f696171c6"
+checksum = "f900c1015844087cd4f10ba9d2d26a9859f2f5ca07427865cc74942595abc0a7"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.7",
  "bincode",
  "bv",
  "caps",
@@ -6882,42 +7416,67 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "serde",
- "solana-metrics",
- "solana-rayon-threadlimit",
- "solana-sdk",
- "solana-vote-program",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rayon-threadlimit 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-perf"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "ahash 0.8.7",
+ "bincode",
+ "bv",
+ "caps",
+ "curve25519-dalek",
+ "dlopen",
+ "dlopen_derive",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "log 0.4.20",
+ "nix",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-poh"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8735489e784625b6a81168415ce0bb02c057fa3a90513a764b6324f3fe7cb4db"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
  "log 0.4.20",
  "solana-entry",
  "solana-ledger",
- "solana-measure",
- "solana-metrics",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2faeb9c89b354b547a229e3b39fa8fd6d11c78362ba8580f0c4721739725b6"
+checksum = "1bb16998986492de307eef503ce47e84503d35baa92dc60832b22476948b1c16"
 dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
  "ark-serialize",
  "array-bytes",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bitflags 1.3.2",
  "blake3",
@@ -6930,8 +7489,8 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.2.10",
- "itertools",
+ "getrandom 0.2.12",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "libc",
@@ -6950,11 +7509,65 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3 0.10.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk-macro",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tiny-bip39",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-program"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "array-bytes",
+ "base64 0.21.7",
+ "bincode",
+ "bitflags 1.3.2",
+ "blake3",
+ "borsh 0.10.3",
+ "borsh 0.9.3",
+ "bs58 0.4.0",
+ "bv",
+ "bytemuck",
+ "cc",
+ "console_error_panic_hook",
+ "console_log",
+ "curve25519-dalek",
+ "getrandom 0.2.12",
+ "itertools 0.10.5",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "libsecp256k1",
+ "log 0.4.20",
+ "memoffset 0.9.0",
+ "num-bigint 0.4.4",
+ "num-derive 0.3.3",
+ "num-traits",
+ "parking_lot 0.12.1",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -6963,15 +7576,15 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f65907a405764cda63be89335ffd2138ade18f065e5cae09d20adab7fb09502"
+checksum = "036d6ecf67a3a7c6dc74d4f7fa6ab321e7ce8feccb7c9dff8384a41d0a12345b"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "eager",
  "enum-iterator",
- "itertools",
+ "itertools 0.10.5",
  "libc",
  "log 0.4.20",
  "num-derive 0.3.3",
@@ -6980,24 +7593,50 @@ dependencies = [
  "rand 0.7.3",
  "rustc_version 0.4.0",
  "serde",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-measure",
- "solana-metrics",
- "solana-sdk",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-program-runtime"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "base64 0.21.7",
+ "bincode",
+ "eager",
+ "enum-iterator",
+ "itertools 0.10.5",
+ "libc",
+ "log 0.4.20",
+ "num-derive 0.3.3",
+ "num-traits",
+ "percentage",
+ "rand 0.7.3",
+ "rustc_version 0.4.0",
+ "serde",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana_rbpf",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-program-test"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48eaefd61e16f94f3fb7c4ad9a3cbb18666d28f631ea1420d985203ea8b87861"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "assert_matches",
  "async-trait",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "chrono-humanize",
  "crossbeam-channel",
@@ -7007,50 +7646,74 @@ dependencies = [
  "solana-banks-interface",
  "solana-banks-server",
  "solana-bpf-loader-program",
- "solana-logger",
- "solana-program-runtime",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
- "solana-vote-program",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367e70572ebc81de7d8ca742342f7cf19b6b47d182dd9aa8932c7cfa71bb6dc4"
+checksum = "70e318f46bedb39374e98f299266a155b2c81c9d920f3c90f761261267c275c1"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
  "log 0.4.20",
  "reqwest",
- "semver 1.0.19",
+ "semver 1.0.21",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.17.2",
  "tungstenite 0.17.3",
- "url 2.4.1",
+ "url 2.5.0",
+]
+
+[[package]]
+name = "solana-pubsub-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "crossbeam-channel",
+ "futures-util",
+ "log 0.4.20",
+ "reqwest",
+ "semver 1.0.21",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.17.2",
+ "tungstenite 0.17.3",
+ "url 2.5.0",
 ]
 
 [[package]]
 name = "solana-quic-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87daa01ce0ecd6667425c7f19f10388cbce63a62f8f69767ea37b69293e814cf"
+checksum = "61db18a804642f8eb37369e903774a85d7949a55bd204ec090ebe0742fd2fe32"
 dependencies = [
  "async-mutex",
  "async-trait",
- "futures 0.3.28",
- "itertools",
+ "futures 0.3.30",
+ "itertools 0.10.5",
  "lazy_static",
  "log 0.4.20",
  "quinn",
@@ -7058,22 +7721,58 @@ dependencies = [
  "quinn-udp",
  "rcgen",
  "rustls 0.20.9",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-net-utils",
- "solana-rpc-client-api",
- "solana-sdk",
- "solana-streamer",
+ "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-net-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-quic-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-mutex",
+ "async-trait",
+ "futures 0.3.30",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log 0.4.20",
+ "quinn",
+ "quinn-proto",
+ "quinn-udp",
+ "rcgen",
+ "rustls 0.20.9",
+ "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6593da84631b9b523dac91b04f4e2a366205f61112d677e8cbe2bfda57a176"
+checksum = "805377478f2d413f6cfcba6924c81ac4988ac0f96cdb045a8a9d81c430e6622a"
+dependencies = [
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "solana-rayon-threadlimit"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -7081,9 +7780,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a431bdda7679de1381722f6eef63dfc301f07cbd51a930a28e61ee42167448a5"
+checksum = "7a1148dcd76f76ad0399c1d9abf05cb32a0e545c5bee47ebe6d3b3e800c7fa7c"
 dependencies = [
  "console",
  "dialoguer",
@@ -7092,24 +7791,41 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.1",
  "qstring",
- "semver 1.0.19",
- "solana-sdk",
+ "semver 1.0.21",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "uriparse",
+]
+
+[[package]]
+name = "solana-remote-wallet"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "console",
+ "dialoguer",
+ "log 0.4.20",
+ "num-derive 0.3.3",
+ "num-traits",
+ "parking_lot 0.12.1",
+ "qstring",
+ "semver 1.0.21",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "uriparse",
 ]
 
 [[package]]
 name = "solana-rpc"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afe5477133fd83e423a9ac2339a1c3e209920c328cd024b3066431362d7c43f"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bs58 0.4.0",
  "crossbeam-channel",
- "dashmap",
- "itertools",
+ "dashmap 4.0.2",
+ "itertools 0.10.5",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -7123,30 +7839,30 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "soketto",
- "solana-account-decoder",
- "solana-client",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-entry",
  "solana-faucet",
  "solana-gossip",
  "solana-ledger",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-poh",
- "solana-rayon-threadlimit",
- "solana-rpc-client-api",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-send-transaction-service",
  "solana-stake-program",
  "solana-storage-bigtable",
- "solana-streamer",
- "solana-tpu-client",
- "solana-transaction-status",
- "solana-version",
- "solana-vote-program",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
+ "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
  "stream-cancel",
  "thiserror",
  "tokio",
@@ -7155,70 +7871,127 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2771ac12cdbde1aa6b55a129947f1428bb44d14314059c1e69674e1d58aaf9e1"
+checksum = "dc51a85c6ff03bb4a3e1fde1e36dcb553b990f2b3e66aed941a31a6a7c20fa33"
 dependencies = [
  "async-trait",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bs58 0.4.0",
  "indicatif",
  "log 0.4.20",
  "reqwest",
- "semver 1.0.19",
+ "semver 1.0.21",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-rpc-client-api",
- "solana-sdk",
- "solana-transaction-status",
- "solana-version",
- "solana-vote-program",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-vote-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+]
+
+[[package]]
+name = "solana-rpc-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "bincode",
+ "bs58 0.4.0",
+ "indicatif",
+ "log 0.4.20",
+ "reqwest",
+ "semver 1.0.21",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tokio",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f401e2ae586fd60c1c8c0f406be521bfe4889c6c2854fbb76bd20e8bc2d57284"
+checksum = "6756a1f89f509154644a958869c7cc6c70cc622f44faddf9b94612d8d2d8eed5"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.7",
  "bs58 0.4.0",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest",
- "semver 1.0.19",
+ "semver 1.0.21",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-sdk",
- "solana-transaction-status",
- "solana-version",
- "spl-token-2022 0.6.1",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-version 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-2022 0.9.0",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-rpc-client-api"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "base64 0.21.7",
+ "bs58 0.4.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest",
+ "semver 1.0.21",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-version 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46df2d20521eab49fadb9afe93808e9764767e193bd701c7d380a56d0dc7f8ad"
+checksum = "4850e8db607525a36d330f073703e78e908a54ac66aa323a44cfc12c14c16699"
 dependencies = [
  "clap 2.34.0",
- "solana-clap-utils",
- "solana-rpc-client",
- "solana-sdk",
+ "solana-clap-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-rpc-client-nonce-utils"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "clap 2.34.0",
+ "solana-clap-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-runtime"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd836895d54bcda07566caab7825649f33dda7f900bf7660e5547468909989c"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "arrayref",
  "bincode",
@@ -7228,13 +8001,13 @@ dependencies = [
  "byteorder",
  "bzip2",
  "crossbeam-channel",
- "dashmap",
+ "dashmap 4.0.2",
  "dir-diff",
- "flate2 1.0.27",
+ "flate2 1.0.28",
  "fnv",
  "im",
  "index_list",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log 0.4.20",
  "lru",
@@ -7254,25 +8027,25 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-address-lookup-table-program",
+ "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-bpf-loader-program",
  "solana-bucket-map",
  "solana-compute-budget-program",
- "solana-config-program",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
+ "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-loader-v4-program",
- "solana-measure",
- "solana-metrics",
- "solana-perf",
- "solana-program-runtime",
- "solana-rayon-threadlimit",
- "solana-sdk",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rayon-threadlimit 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-stake-program",
  "solana-system-program",
- "solana-vote-program",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-zk-token-proof-program",
- "solana-zk-token-sdk",
+ "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "static_assertions",
  "strum",
  "strum_macros",
@@ -7285,12 +8058,12 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f4046d0d487e3d79be809ff29c63c1484793956e6ccbc5d3307b0aafbf989d"
+checksum = "4106cda3d10833ba957dbd25fb841b50aeca7480ccf8f54859294716f54bcd4b"
 dependencies = [
  "assert_matches",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bitflags 1.3.2",
  "borsh 0.10.3",
@@ -7304,7 +8077,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "generic-array 0.14.7",
  "hmac 0.12.1",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "libsecp256k1",
@@ -7324,13 +8097,65 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3 0.10.8",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-logger",
- "solana-program",
- "solana-sdk-macro",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "uriparse",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "assert_matches",
+ "base64 0.21.7",
+ "bincode",
+ "bitflags 1.3.2",
+ "borsh 0.10.3",
+ "bs58 0.4.0",
+ "bytemuck",
+ "byteorder",
+ "chrono",
+ "derivation-path",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "generic-array 0.14.7",
+ "hmac 0.12.1",
+ "itertools 0.10.5",
+ "js-sys",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.20",
+ "memmap2",
+ "num-derive 0.3.3",
+ "num-traits",
+ "num_enum 0.6.1",
+ "pbkdf2 0.11.0",
+ "qstring",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-logger 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "uriparse",
  "wasm-bindgen",
@@ -7338,15 +8163,27 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760fdfd4b7edb02fd9173a6dcec899ffae06ac21b66b65f8c7c5f3d17b12fa64"
+checksum = "1e560806a3859717eb2220b26e2cd68bb757b63affa3e79c3f1d8d853b5ee78f"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "rustversion",
- "syn 2.0.37",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bs58 0.4.0",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "rustversion",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -7357,51 +8194,48 @@ checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9accbdf367a02ceb44fb2c74de00a66362f5340706f62d7d0340491a3fd628fc"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "crossbeam-channel",
  "log 0.4.20",
- "solana-client",
- "solana-measure",
- "solana-metrics",
+ "solana-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-runtime",
- "solana-sdk",
- "solana-tpu-client",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-tpu-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2be095a8ec22b7856b182b9de2067e2ab91570f0cafbca46d39bebe119e791"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "log 0.4.20",
  "rustc_version 0.4.0",
- "solana-config-program",
- "solana-program-runtime",
- "solana-sdk",
- "solana-vote-program",
+ "solana-config-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-vote-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3729c426b3b7702b4d56c0f19a4056f324dd703de1a6d445e950967711fd720"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "backoff",
  "bincode",
  "bytes 1.5.0",
  "bzip2",
  "enum-iterator",
- "flate2 1.0.27",
- "futures 0.3.28",
+ "flate2 1.0.28",
+ "futures 0.3.30",
  "goauth",
  "http",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-proxy",
  "log 0.4.20",
  "openssl",
@@ -7410,10 +8244,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "smpl_jwt",
- "solana-metrics",
- "solana-sdk",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "solana-storage-proto",
- "solana-transaction-status",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
  "tonic 0.8.3",
@@ -7422,26 +8256,25 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0124784702a3ad8d1cba35ec8868cda27b0cfe8d6bca744322b65e4ec0b0d76"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
  "prost 0.11.9",
  "protobuf-src",
  "serde",
- "solana-account-decoder",
- "solana-sdk",
- "solana-transaction-status",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-transaction-status 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "tonic-build 0.8.4",
 ]
 
 [[package]]
 name = "solana-streamer"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0125d00ca7e8e67d12f7f192a18d1dff2801a9c3e3239033af40b3e72ad92d76"
+checksum = "78f142cbb497d257e70253c158a4c34037e310d24a055fae7dbc5c396b7611aa"
 dependencies = [
  "async-channel",
  "bytes 1.5.0",
@@ -7449,7 +8282,7 @@ dependencies = [
  "futures-util",
  "histogram",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.10.5",
  "libc",
  "log 0.4.20",
  "nix",
@@ -7462,9 +8295,41 @@ dependencies = [
  "rand 0.7.3",
  "rcgen",
  "rustls 0.20.9",
- "solana-metrics",
- "solana-perf",
- "solana-sdk",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-perf 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+ "x509-parser",
+]
+
+[[package]]
+name = "solana-streamer"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-channel",
+ "bytes 1.5.0",
+ "crossbeam-channel",
+ "futures-util",
+ "histogram",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "libc",
+ "log 0.4.20",
+ "nix",
+ "pem",
+ "percentage",
+ "pkcs8",
+ "quinn",
+ "quinn-proto",
+ "quinn-udp",
+ "rand 0.7.3",
+ "rcgen",
+ "rustls 0.20.9",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-perf 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -7472,38 +8337,51 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d4305ec995efdf6c01ba055833e0f225461ed73c66fd715bb1d566b983bc1c"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bincode",
  "log 0.4.20",
  "serde",
  "serde_derive",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-thin-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b6137bb86d37323482474d841dd5baba41d5e3cb8827e4f0f5e37e9ff09153"
+checksum = "e0e41ce715b34749d2c0d3181dd910d2b99fa2142a0aaf3cd44926cb02edd60d"
 dependencies = [
  "bincode",
  "log 0.4.20",
  "rayon",
- "solana-connection-cache",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
+ "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-thin-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bincode",
+ "log 0.4.20",
+ "rayon",
+ "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe350f0f2e6a098c118e9a5820280bb3c512f27560ad848f793825f2cd76fa5"
+checksum = "84ec99361a39e17a2bffe2a59b97b3d20ddef323f9166929783ce49f340c200d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -7513,79 +8391,157 @@ dependencies = [
  "log 0.4.20",
  "rand 0.7.3",
  "rayon",
- "solana-connection-cache",
- "solana-measure",
- "solana-metrics",
- "solana-pubsub-client",
- "solana-rpc-client",
- "solana-rpc-client-api",
- "solana-sdk",
+ "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-measure 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-pubsub-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-rpc-client-api 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-tpu-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "futures-util",
+ "indexmap 1.9.3",
+ "indicatif",
+ "log 0.4.20",
+ "rand 0.7.3",
+ "rayon",
+ "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-measure 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-pubsub-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-rpc-client-api 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdf7379a72c051d7879f1c36cfdab5fed0653a2a613718bc5d343e44e603401"
+checksum = "236dd4e43b8a7402bce250228e04c0c68d9493a3e19c71b377ccc7c4390fd969"
 dependencies = [
  "Inflector",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bs58 0.4.0",
  "lazy_static",
  "log 0.4.20",
  "serde",
  "serde_derive",
  "serde_json",
- "solana-account-decoder",
- "solana-address-lookup-table-program",
- "solana-sdk",
- "spl-associated-token-account 1.1.3",
- "spl-memo 3.0.1",
- "spl-token 3.5.0",
- "spl-token-2022 0.6.1",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-associated-token-account 2.2.0",
+ "spl-memo 4.0.0",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-transaction-status"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "Inflector",
+ "base64 0.21.7",
+ "bincode",
+ "borsh 0.10.3",
+ "bs58 0.4.0",
+ "lazy_static",
+ "log 0.4.20",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-address-lookup-table-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "spl-associated-token-account 2.2.0",
+ "spl-memo 4.0.0",
+ "spl-token 4.0.0",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-udp-client"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c5d62db9c69e8eced8eb8fdb1f8317dbcb3ad37cb5cc0d495aec85b5a46f7f"
+checksum = "16b438036719e5c1201aba2336a5dc1caa8c8eefafd7110b7a3818ae199b54da"
 dependencies = [
  "async-trait",
- "solana-connection-cache",
- "solana-net-utils",
- "solana-sdk",
- "solana-streamer",
+ "solana-connection-cache 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-net-utils 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-streamer 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "solana-udp-client"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "async-trait",
+ "solana-connection-cache 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-net-utils 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-streamer 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
  "tokio",
 ]
 
 [[package]]
 name = "solana-version"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d62712e119d6c616d1dea0fa5c1464f7316abe446e0b1eb4796cc9c77324c69"
+checksum = "62847d7ef409e3b410f65e726bf7816d8f8d0330918e78537e940bdf1ca061ae"
 dependencies = [
  "log 0.4.20",
  "rustc_version 0.4.0",
- "semver 1.0.19",
+ "semver 1.0.21",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-sdk",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-version"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "log 0.4.20",
+ "rustc_version 0.4.0",
+ "semver 1.0.21",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde11af84827c25b484baf1743b5d0db068af32cf2e4f533148a2d2a31c2263"
+checksum = "fb0c3e5ee7bd03b249c6b80eead5620af62bc7ef1af8ea4f499b8054b00e9c7d"
 dependencies = [
  "bincode",
  "log 0.4.20",
@@ -7594,44 +8550,64 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
- "solana-frozen-abi",
- "solana-frozen-abi-macro",
- "solana-metrics",
- "solana-program",
- "solana-program-runtime",
- "solana-sdk",
+ "solana-frozen-abi 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-frozen-abi-macro 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-metrics 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program-runtime 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "solana-vote-program"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "bincode",
+ "log 0.4.20",
+ "num-derive 0.3.3",
+ "num-traits",
+ "rustc_version 0.4.0",
+ "serde",
+ "serde_derive",
+ "solana-frozen-abi 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-frozen-abi-macro 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-metrics 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.16.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2633ae5b15fd52b3c1c625d17b62284b328d67ee0b801c2bacb7e7429874e5bd"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program-runtime",
- "solana-sdk",
- "solana-zk-token-sdk",
+ "solana-program-runtime 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-zk-token-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
 ]
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.14"
+version = "1.16.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdec366a15133a70a8dfc4f027b5d0f508bd7cb46af11971076c9ebaf9ede2d"
+checksum = "278c08e13bc04b6940997602909052524a375154b00cf0bfa934359a3bb7e6f0"
 dependencies = [
  "aes-gcm-siv",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bincode",
  "bytemuck",
  "byteorder",
  "curve25519-dalek",
  "getrandom 0.1.16",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "merlin",
  "num-derive 0.3.3",
@@ -7640,8 +8616,36 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "solana-program",
- "solana-sdk",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-zk-token-sdk"
+version = "1.16.17"
+source = "git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio#0b395f463097112fc028522fa0081a4374dd2168"
+dependencies = [
+ "aes-gcm-siv",
+ "base64 0.21.7",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "curve25519-dalek",
+ "getrandom 0.1.16",
+ "itertools 0.10.5",
+ "lazy_static",
+ "merlin",
+ "num-derive 0.3.3",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "sha3 0.9.1",
+ "solana-program 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
+ "solana-sdk 1.16.17 (git+https://github.com/blockworks-foundation/solana.git?branch=pan/v1.16.17-upgrade-tokio)",
  "subtle",
  "thiserror",
  "zeroize",
@@ -7698,7 +8702,7 @@ dependencies = [
  "borsh 0.9.3",
  "num-derive 0.3.3",
  "num-traits",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 3.5.0",
  "spl-token-2022 0.6.1",
  "thiserror",
@@ -7706,17 +8710,17 @@ dependencies = [
 
 [[package]]
 name = "spl-associated-token-account"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477696277857a7b2c17a6f7f3095e835850ad1c0f11637b5bd2693ca777d8546"
+checksum = "385e31c29981488f2820b2022d8e731aae3b02e6e18e2fd854e4c9a94dc44fc3"
 dependencies = [
  "assert_matches",
  "borsh 0.10.3",
- "num-derive 0.4.0",
+ "num-derive 0.4.1",
  "num-traits",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token 4.0.0",
- "spl-token-2022 0.8.0",
+ "spl-token-2022 0.9.0",
  "thiserror",
 ]
 
@@ -7727,31 +8731,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cce5d563b58ef1bb2cdbbfe0dfb9ffdc24903b10ae6a4df2d8f425ece375033f"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-discriminator-derive",
 ]
 
 [[package]]
 name = "spl-discriminator-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fa8f409b5c5e0ac571df17c981ae1424b204743daa4428430627d38717caf5"
+checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "spl-discriminator-syn",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "spl-discriminator-syn"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21968d7da2f0a624c509f24580c3fee70b364a6886d90709e679e64f572eca2f"
+checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "solana-program",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "sha2 0.10.8",
+ "syn 2.0.48",
  "thiserror",
 ]
 
@@ -7761,7 +8765,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
 dependencies = [
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7770,7 +8774,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f180b03318c3dbab3ef4e1e4d46d5211ae3c780940dd0a28695aba4b59a75a"
 dependencies = [
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7781,8 +8785,8 @@ checksum = "2881dddfca792737c0706fa0175345ab282b1b0879c7d877bad129645737c079"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
- "solana-program",
- "solana-zk-token-sdk",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error",
 ]
 
@@ -7792,33 +8796,33 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "249e0318493b6bcf27ae9902600566c689b7dfba9f1bdff5893e92253374e78c"
 dependencies = [
- "num-derive 0.4.0",
+ "num-derive 0.4.1",
  "num-traits",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-program-error-derive",
  "thiserror",
 ]
 
 [[package]]
 name = "spl-program-error-derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6709c5f41fefb730f2bd8464da741079cf0efd1d0f522e041224b98d431b9b3"
+checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "solana-program",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "sha2 0.10.8",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7960b1e1a41e4238807fca0865e72a341b668137a3f2ddcd770d04fd1b374c96"
+checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -7836,7 +8840,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -7851,7 +8855,7 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.6.1",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -7866,8 +8870,8 @@ dependencies = [
  "num-derive 0.3.3",
  "num-traits",
  "num_enum 0.5.11",
- "solana-program",
- "solana-zk-token-sdk",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 3.0.1",
  "spl-token 3.5.0",
  "thiserror",
@@ -7875,17 +8879,17 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fc0c7a763c3f53fa12581d07ed324548a771bb648a1217e4f330b1d0a59331"
+checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
 dependencies = [
  "arrayref",
  "bytemuck",
- "num-derive 0.4.0",
+ "num-derive 0.4.1",
  "num-traits",
- "num_enum 0.7.0",
- "solana-program",
- "solana-zk-token-sdk",
+ "num_enum 0.7.2",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-zk-token-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo 4.0.0",
  "spl-pod",
  "spl-token 4.0.0",
@@ -7902,7 +8906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c16ce3ba6979645fb7627aa1e435576172dd63088dc7848cb09aa331fa1fe4f"
 dependencies = [
  "borsh 0.10.3",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -7911,13 +8915,13 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7489940049417ae5ce909314bead0670e2a5ea5c82d43ab96dc15c8fcbbccba"
+checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
 dependencies = [
  "arrayref",
  "bytemuck",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -7932,7 +8936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a468e6f6371f9c69aae760186ea9f1a01c2908351b06a5e0026d21cfc4d7ecac"
 dependencies = [
  "bytemuck",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
@@ -7946,9 +8950,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stream-cancel"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
+checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -7994,8 +8998,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -8013,18 +9017,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
-name = "switchboard-common"
-version = "0.9.0"
+name = "sval"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736f68ec1e444e96c99f0161e5b80d977e1ab5e4c1a30a31c6cf1f53dfd9769c"
+checksum = "1604e9ab506f4805bc62d2868c6d20f23fa6ced4c7cfe695a1d20589ba5c63d0"
+
+[[package]]
+name = "sval_buffer"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2831b6451148d344f612016d4277348f7721b78a0869a145fd34ef8b06b3fa2e"
 dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238ac5832a23099a413ffd22e66f7e6248b9af4581b64c758ca591074be059fc"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8474862431bac5ac7aee8a12597798e944df33f489c340e17e886767bda0c4e"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f348030cc3d2a11eb534145600601f080cf16bf9ec0783efecd2883f14c21e"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6659c3f6be1e5e99dc7c518877f48a8a39088ace2504b046db789bd78ce5969d"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829ad319bd82d0da77be6f3d547623686c453502f8eebdeb466cfa987972bd28"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9da6c3efaedf8b8c0861ec5343e8e8c51d838f326478623328bd8728b79bca"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_nested",
+]
+
+[[package]]
+name = "switchboard-common"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d897dad47d39bd61d444793d75ed8c69d7ee9e62218ea8a2d7f9c4ecc79f1fe"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
  "envy",
- "getrandom 0.2.10",
+ "futures 0.3.30",
+ "getrandom 0.2.12",
  "hex",
+ "log 0.4.20",
  "serde",
  "serde_json",
  "sgx-quote",
- "sha2 0.10.7",
+ "sha2 0.10.8",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -8038,7 +9125,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "quick-protobuf",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "switchboard-protos",
  "switchboard-utils",
 ]
@@ -8057,27 +9144,36 @@ dependencies = [
 
 [[package]]
 name = "switchboard-solana"
-version = "0.28.27"
+version = "0.28.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625e34dba0d9bcf6b1f5db5ccf1c0aa8db8329ff89c4d51715bbe4514140127a"
+checksum = "b38cdd8f4bfbef390a14b4443fb5aa3e9d6ea83cc097ed4874e753f3cb5527ca"
 dependencies = [
  "anchor-client",
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
+ "base64 0.21.7",
  "bincode",
  "bytemuck",
  "chrono",
  "cron",
+ "dashmap 5.5.3",
+ "futures 0.3.30",
  "hex",
+ "kv-log-macro",
+ "log 0.4.20",
  "rust_decimal",
+ "serde",
+ "serde_json",
  "sgx-quote",
- "solana-address-lookup-table-program",
- "solana-client",
- "solana-program",
+ "sha2 0.10.8",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-address-lookup-table-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "superslice",
  "switchboard-common",
  "tokio",
- "url 2.4.1",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -8093,7 +9189,7 @@ dependencies = [
  "quick-protobuf",
  "rust_decimal",
  "rust_decimal_macros",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "switchboard-protos",
 ]
 
@@ -8103,11 +9199,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b81886169f446e22edc18ead7addd9ebd141c39bf2286cb37943c92cd3af724"
 dependencies = [
- "anchor-lang",
- "anchor-spl",
+ "anchor-lang 0.28.0",
+ "anchor-spl 0.28.0",
  "bytemuck",
  "rust_decimal",
- "solana-program",
+ "solana-program 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "superslice",
 ]
 
@@ -8134,19 +9230,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
@@ -8162,10 +9258,31 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -8187,7 +9304,7 @@ checksum = "1c38a012bed6fb9681d3bf71ffaa4f88f3b4b9ed3198cda6e4c8462d24d4bb80"
 dependencies = [
  "anyhow",
  "fnv",
- "futures 0.3.28",
+ "futures 0.3.30",
  "humantime",
  "opentelemetry",
  "pin-project",
@@ -8209,29 +9326,29 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -8253,22 +9370,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8294,12 +9411,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -8313,9 +9431,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -8356,22 +9474,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.14.1"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d0183f6f6001549ab68f8c7585093bb732beefbcf6d23a10b9b95c73a1dd49"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg 1.1.0",
+ "backtrace",
  "bytes 1.5.0",
  "libc",
- "memchr",
- "mio 0.7.14",
+ "mio 0.8.10",
  "num_cpus",
- "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.5.5",
  "tokio-macros",
- "winapi 0.3.9",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8418,13 +9535,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 1.0.109",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -8439,9 +9556,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.7"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a12c1b3e0704ae7dfc25562629798b29c72e6b1d0a681b6f29ab4ae5e7f7bf"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8451,14 +9568,16 @@ dependencies = [
  "futures-util",
  "log 0.4.20",
  "parking_lot 0.12.1",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "rand 0.8.5",
+ "socket2 0.5.5",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.10",
+ "whoami",
 ]
 
 [[package]]
@@ -8467,8 +9586,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "606f2b73660439474394432239c82249c0d45eb5f23d91f401be1e33590444a7"
 dependencies = [
- "futures 0.3.28",
- "ring",
+ "futures 0.3.30",
+ "ring 0.16.20",
  "rustls 0.20.9",
  "tokio",
  "tokio-postgres",
@@ -8511,7 +9630,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.7",
+ "rustls 0.21.10",
  "tokio",
 ]
 
@@ -8533,9 +9652,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8602,19 +9721,19 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite 0.17.3",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log 0.4.20",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -8635,9 +9754,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes 1.5.0",
  "futures-core",
@@ -8658,9 +9777,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
@@ -8668,7 +9787,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -8689,9 +9819,9 @@ dependencies = [
  "h2",
  "http",
  "http-body",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-timeout",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project",
  "prost 0.11.9",
  "prost-derive 0.11.9",
@@ -8699,7 +9829,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.10",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8709,26 +9839,25 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream 0.3.5",
  "async-trait",
  "axum",
- "base64 0.21.4",
+ "base64 0.21.7",
  "bytes 1.5.0",
- "flate2 1.0.27",
- "futures-core",
- "futures-util",
+ "flate2 1.0.28",
  "h2",
  "http",
  "http-body",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "hyper-timeout",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project",
- "prost 0.11.9",
+ "prost 0.12.3",
+ "rustls 0.21.10",
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
@@ -8746,9 +9875,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
  "prost-build 0.9.0",
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -8759,36 +9888,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease 0.1.25",
- "proc-macro2 1.0.67",
+ "proc-macro2 1.0.76",
  "prost-build 0.11.9",
- "quote 1.0.33",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
- "prettyplease 0.1.25",
- "proc-macro2 1.0.67",
- "prost-build 0.11.9",
- "quote 1.0.33",
- "syn 1.0.109",
+ "prettyplease 0.2.16",
+ "proc-macro2 1.0.76",
+ "prost-build 0.12.3",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080964d45894b90273d2b1dd755fdd114560db8636bb41cea615213c45043c4d"
+checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
 dependencies = [
  "async-stream 0.3.5",
- "prost 0.11.9",
+ "prost 0.12.3",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -8805,7 +9934,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.10",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8825,11 +9954,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
  "log 0.4.20",
  "pin-project-lite",
  "tracing-attributes",
@@ -8838,20 +9966,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -8869,12 +9997,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log 0.4.20",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -8893,16 +10021,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.11.1",
+ "smallvec 1.12.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -8923,15 +10051,15 @@ checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.85"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196a58260a906cedb9bf6d8034b6379d0c11f552416960452f267402ceeddff1"
+checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
 dependencies = [
  "basic-toml",
  "glob",
@@ -8957,7 +10085,7 @@ dependencies = [
  "rand 0.8.5",
  "sha-1 0.9.8",
  "thiserror",
- "url 2.4.1",
+ "url 2.5.0",
  "utf-8",
 ]
 
@@ -8977,28 +10105,28 @@ dependencies = [
  "rustls 0.20.9",
  "sha-1 0.10.1",
  "thiserror",
- "url 2.4.1",
+ "url 2.5.0",
  "utf-8",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes 1.5.0",
+ "data-encoding",
  "http",
  "httparse",
  "log 0.4.20",
  "rand 0.8.5",
  "sha1",
  "thiserror",
- "url 2.4.1",
+ "url 2.5.0",
  "utf-8",
 ]
 
@@ -9046,9 +10174,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -9110,9 +10238,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "unsize"
@@ -9128,6 +10256,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uriparse"
@@ -9152,13 +10286,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -9172,6 +10306,42 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdbaf5e132e593e9fc1de6a15bbec912395b11fb9719e061cf64f804524c503"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cad98b1b18d06b6f38b3cd04347a9d7a3a0111441a061f71377fb6740437e4"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc7271d6b3bf58dd2e610a601c0e159f271ffdb7fbb21517c40b52138d64f8e"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -9224,21 +10394,21 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "bytes 1.5.0",
  "futures-channel",
  "futures-util",
  "headers",
  "http",
- "hyper 0.14.27",
+ "hyper 0.14.28",
  "log 0.4.20",
  "mime 0.3.17",
  "mime_guess",
  "multer",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
@@ -9247,8 +10417,8 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.18.0",
- "tokio-util 0.7.2",
+ "tokio-tungstenite 0.20.1",
+ "tokio-util 0.7.10",
  "tower-service",
  "tracing",
 ]
@@ -9273,9 +10443,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -9283,24 +10453,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log 0.4.20",
  "once_cell",
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -9310,38 +10480,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
- "quote 1.0.33",
+ "quote 1.0.35",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9349,12 +10519,12 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9365,6 +10535,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "websocket"
@@ -9420,6 +10596,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9463,12 +10649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -9488,15 +10674,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9505,18 +10682,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.42.2"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -9535,6 +10706,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9545,6 +10731,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9559,6 +10751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9569,6 +10767,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9583,6 +10787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9593,6 +10803,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9607,6 +10823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9619,21 +10841,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.15"
+name = "windows_x86_64_msvc"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi 0.3.9",
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9661,7 +10890,7 @@ dependencies = [
  "rand 0.7.3",
  "sha-1 0.8.2",
  "slab",
- "url 2.4.1",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -9689,16 +10918,18 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.29",
+ "time 0.3.31",
 ]
 
 [[package]]
 name = "xattr"
-version = "1.0.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]
@@ -9707,35 +10938,57 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.29",
+ "time 0.3.31",
 ]
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "1.9.0+solana.1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638fc820f10c6d836732d43f7c8f93a85301a7d90705a0db38b3bc11fc6657f6"
+version = "1.12.0+solana.1.16.17"
+source = "git+https://github.com/rpcpool/yellowstone-grpc.git?tag=v1.11.0+solana.1.16.17#365140d759585c83e5b56f43a3089a1330638651"
 dependencies = [
  "bytes 1.5.0",
- "futures 0.3.28",
+ "futures 0.3.30",
  "http",
  "thiserror",
- "tonic 0.9.2",
+ "tonic 0.10.2",
  "tonic-health",
  "yellowstone-grpc-proto",
 ]
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "1.9.0+solana.1.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b29533f1a9486a84b2ffc1fc53d19607af3b71e0554dbde38a841b72026be6"
+version = "1.11.0+solana.1.16.17"
+source = "git+https://github.com/rpcpool/yellowstone-grpc.git?tag=v1.11.0+solana.1.16.17#365140d759585c83e5b56f43a3089a1330638651"
 dependencies = [
  "anyhow",
- "prost 0.11.9",
+ "bincode",
+ "prost 0.12.3",
  "protobuf-src",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "solana-account-decoder 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-transaction-status 1.16.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.10.2",
+ "tonic-build 0.10.2",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -9753,9 +11006,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.67",
- "quote 1.0.33",
- "syn 2.0.37",
+ "proc-macro2 1.0.76",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -9779,11 +11032,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ serum_dex = { git = "https://github.com/openbook-dex/program.git", default-featu
 mango-feeds-connector = { git = "https://github.com/blockworks-foundation/mango-feeds.git", rev="5def8c9468c29a7e3b50bbc51946456de6dab52d"}
 
 # 1.16.7+ is required due to this: https://github.com/blockworks-foundation/mango-v4/issues/712
-solana-address-lookup-table-program = "~1.16.17"
-solana-account-decoder = "~1.16.17"
-solana-client = "~1.16.17"
-solana-logger = "~1.16.17"
-solana-program = "~1.16.17"
-solana-program-test = "~1.16.17"
-solana-rpc = "~1.16.17"
-solana-sdk = { version = "~1.16.17", default-features = false }
+solana-address-lookup-table-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-account-decoder = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-client = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-logger = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-program-test = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-rpc = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-sdk = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio", default-features = false }
 
 [profile.release]
 overflow-checks = true
@@ -31,4 +31,3 @@ overflow-checks = true
 [patch.crates-io]
 # for gzip encoded responses
 jsonrpc-core-client = { git = "https://github.com/ckamm/jsonrpc.git", branch = "ckamm/http-with-gzip" }
-tokio = { git = "https://github.com/tokio-rs/tokio.git", tag = "tokio-1.29.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ fixed = { git = "https://github.com/blockworks-foundation/fixed.git", branch = "
 pyth-sdk-solana = "0.8.0"
 # commit c85e56d (0.5.10 plus dependency updates)
 serum_dex = { git = "https://github.com/openbook-dex/program.git", default-features=false }
-mango-feeds-connector = "0.2.1"
+mango-feeds-connector = { git = "https://github.com/blockworks-foundation/mango-feeds.git", rev="5def8c9468c29a7e3b50bbc51946456de6dab52d"}
 
 # 1.16.7+ is required due to this: https://github.com/blockworks-foundation/mango-v4/issues/712
-solana-address-lookup-table-program = "~1.16.7"
-solana-account-decoder = "~1.16.7"
-solana-client = "~1.16.7"
-solana-logger = "~1.16.7"
-solana-program = "~1.16.7"
-solana-program-test = "~1.16.7"
-solana-rpc = "~1.16.7"
-solana-sdk = { version = "~1.16.7", default-features = false }
+solana-address-lookup-table-program = "~1.16.17"
+solana-account-decoder = "~1.16.17"
+solana-client = "~1.16.17"
+solana-logger = "~1.16.17"
+solana-program = "~1.16.17"
+solana-program-test = "~1.16.17"
+solana-rpc = "~1.16.17"
+solana-sdk = { version = "~1.16.17", default-features = false }
 
 [profile.release]
 overflow-checks = true
@@ -31,3 +31,4 @@ overflow-checks = true
 [patch.crates-io]
 # for gzip encoded responses
 jsonrpc-core-client = { git = "https://github.com/ckamm/jsonrpc.git", branch = "ckamm/http-with-gzip" }
+tokio = { git = "https://github.com/tokio-rs/tokio.git", tag = "tokio-1.29.1"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ serum_dex = { git = "https://github.com/openbook-dex/program.git", default-featu
 mango-feeds-connector = { git = "https://github.com/blockworks-foundation/mango-feeds.git", rev="5def8c9468c29a7e3b50bbc51946456de6dab52d"}
 
 # 1.16.7+ is required due to this: https://github.com/blockworks-foundation/mango-v4/issues/712
-solana-address-lookup-table-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-account-decoder = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-client = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-logger = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-program-test = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-rpc = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
-solana-sdk = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio", default-features = false }
+solana-address-lookup-table-program = "~1.16.17"
+solana-account-decoder = "~1.16.17"
+solana-client = "~1.16.17"
+solana-logger = "~1.16.17"
+solana-program = "~1.16.17"
+solana-program-test = "~1.16.17"
+solana-rpc = "~1.16.17"
+solana-sdk = { version = "~1.16.17", default-features = false }
 
 [profile.release]
 overflow-checks = true
@@ -31,3 +31,11 @@ overflow-checks = true
 [patch.crates-io]
 # for gzip encoded responses
 jsonrpc-core-client = { git = "https://github.com/ckamm/jsonrpc.git", branch = "ckamm/http-with-gzip" }
+solana-address-lookup-table-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-account-decoder = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-client = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-logger = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-program = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-program-test = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-rpc = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }
+solana-sdk = { git = "https://github.com/blockworks-foundation/solana.git", branch = "pan/v1.16.17-upgrade-tokio" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 # Base image containing all binaries, deployed to ghcr.io/blockworks-foundation/mango-v4:latest
-FROM rust:1.69.0-bullseye as base
+FROM rust:1.70.0-bullseye as base
 RUN cargo install cargo-chef --locked
 RUN rustup component add rustfmt
 RUN apt-get update && apt-get -y install clang cmake

--- a/bin/service-mango-crank/src/main.rs
+++ b/bin/service-mango-crank/src/main.rs
@@ -26,7 +26,7 @@ use std::{
 use mango_feeds_connector::EntityFilter::FilterByAccountIds;
 use mango_feeds_connector::FilterConfig;
 use mango_feeds_connector::{
-    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig,
+    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate
 };
 use serde::Deserialize;
 
@@ -137,6 +137,9 @@ async fn main() -> anyhow::Result<()> {
         Keypair::from_bytes(&config.keypair).expect("valid keyair in config"),
     );
 
+    let (transaction_queue_sender, _transaction_queue_receiver) =
+        async_channel::unbounded::<TransactionUpdate>();
+
     info!(
         "connect: {}",
         config
@@ -162,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
             &filter_config,
             account_write_queue_sender,
             slot_queue_sender,
+            transaction_queue_sender,
             metrics_tx.clone(),
             exit.clone(),
         )

--- a/bin/service-mango-crank/src/main.rs
+++ b/bin/service-mango-crank/src/main.rs
@@ -26,7 +26,7 @@ use std::{
 use mango_feeds_connector::EntityFilter::FilterByAccountIds;
 use mango_feeds_connector::FilterConfig;
 use mango_feeds_connector::{
-    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate
+    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate,
 };
 use serde::Deserialize;
 

--- a/bin/service-mango-fills/src/main.rs
+++ b/bin/service-mango-fills/src/main.rs
@@ -404,7 +404,7 @@ async fn main() -> anyhow::Result<()> {
             )
         })
         .collect();
-    info!("pmcs {:?}", perp_market_configs.clone());
+
     let spot_market_configs: Vec<(Pubkey, MarketConfig)> = group_context
         .serum3_markets
         .values()
@@ -456,7 +456,7 @@ async fn main() -> anyhow::Result<()> {
         .map(|context| (context.address.to_string(), context.name.clone()))
         .collect();
     let market_pubkey_strings: HashMap<String, String> = [b].concat().into_iter().collect();
-    //info!("a {:?} b {:?}", _a.clone(), b.clone());
+
     let postgres_update_sender = match config.postgres {
         Some(postgres_config) => Some(
             fill_event_postgres_target::init(&postgres_config, metrics_tx.clone(), exit.clone())
@@ -612,7 +612,7 @@ async fn main() -> anyhow::Result<()> {
     let use_geyser = true;
     let all_queue_pks = [perp_queue_pks.clone()].concat();
     let relevant_pubkeys = all_queue_pks.iter().map(|m| m.1).collect();
-    info!("{:?}", relevant_pubkeys);
+    info!("{} event queue pubkeys", relevant_pubkeys.len());
     let filter_config = FilterConfig {
         entity_filter: EntityFilter::FilterByAccountIds(relevant_pubkeys),
     };

--- a/bin/service-mango-fills/src/main.rs
+++ b/bin/service-mango-fills/src/main.rs
@@ -9,6 +9,7 @@ use futures_util::{
     future::{self, Ready},
     pin_mut, SinkExt, StreamExt, TryStreamExt,
 };
+use itertools::Itertools;
 use log::*;
 use mango_feeds_connector::{
     grpc_plugin_source, metrics,
@@ -611,7 +612,7 @@ async fn main() -> anyhow::Result<()> {
     );
     let use_geyser = true;
     let all_queue_pks = [perp_queue_pks.clone()].concat();
-    let relevant_pubkeys = all_queue_pks.iter().map(|m| m.1).collect();
+    let relevant_pubkeys = all_queue_pks.iter().map(|m| m.1).collect_vec();
     info!("{} event queue pubkeys", relevant_pubkeys.len());
     let filter_config = FilterConfig {
         entity_filter: EntityFilter::FilterByAccountIds(relevant_pubkeys),

--- a/bin/service-mango-fills/src/main.rs
+++ b/bin/service-mango-fills/src/main.rs
@@ -13,7 +13,7 @@ use log::*;
 use mango_feeds_connector::{
     grpc_plugin_source, metrics,
     metrics::{MetricType, MetricU64},
-    websocket_source, EntityFilter, FilterConfig, MetricsConfig, SourceConfig, TransactionUpdate
+    websocket_source, EntityFilter, FilterConfig, MetricsConfig, SourceConfig, TransactionUpdate,
 };
 use mango_feeds_lib::MarketConfig;
 use mango_feeds_lib::StatusResponse;

--- a/bin/service-mango-orderbook/src/main.rs
+++ b/bin/service-mango-orderbook/src/main.rs
@@ -33,7 +33,7 @@ use tokio_tungstenite::tungstenite::{protocol::Message, Error};
 
 use mango_feeds_connector::EntityFilter::FilterByAccountIds;
 use mango_feeds_connector::{
-    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate
+    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate,
 };
 use mango_feeds_connector::{
     metrics::{MetricType, MetricU64},
@@ -601,9 +601,7 @@ async fn main() -> anyhow::Result<()> {
         .unique()
         .collect_vec();
     info!("{} oracle pubkeys", oracle_pubkeys.len());
-    let relevant_pubkeys = [orderbook_pubkeys, oracle_pubkeys]
-        .concat()
-        .to_vec();
+    let relevant_pubkeys = [orderbook_pubkeys, oracle_pubkeys].concat().to_vec();
     let filter_config = FilterConfig {
         entity_filter: FilterByAccountIds(relevant_pubkeys),
     };

--- a/bin/service-mango-orderbook/src/main.rs
+++ b/bin/service-mango-orderbook/src/main.rs
@@ -588,23 +588,24 @@ async fn main() -> anyhow::Result<()> {
             .collect::<String>()
     );
 
-    let relevant_pubkeys = [market_configs.clone(), serum_market_configs.clone()]
+    let orderbook_pubkeys = [market_configs.clone(), serum_market_configs.clone()]
         .concat()
         .iter()
         .flat_map(|m| [m.1.bids, m.1.asks])
+        .unique()
         .collect_vec();
+    info!("{} orderbook pubkeys", orderbook_pubkeys.len());
+    let oracle_pubkeys = market_configs
+        .iter()
+        .map(|(_, mkt)| mkt.oracle)
+        .unique()
+        .collect_vec();
+    info!("{} oracle pubkeys", oracle_pubkeys.len());
+    let relevant_pubkeys = [orderbook_pubkeys, oracle_pubkeys]
+        .concat()
+        .to_vec();
     let filter_config = FilterConfig {
-        entity_filter: FilterByAccountIds(
-            [
-                relevant_pubkeys,
-                market_configs
-                    .iter()
-                    .map(|(_, mkt)| mkt.oracle)
-                    .collect_vec(),
-            ]
-            .concat()
-            .to_vec(),
-        ),
+        entity_filter: FilterByAccountIds(relevant_pubkeys),
     };
     let use_geyser = true;
     if use_geyser {

--- a/bin/service-mango-orderbook/src/main.rs
+++ b/bin/service-mango-orderbook/src/main.rs
@@ -33,7 +33,7 @@ use tokio_tungstenite::tungstenite::{protocol::Message, Error};
 
 use mango_feeds_connector::EntityFilter::FilterByAccountIds;
 use mango_feeds_connector::{
-    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig,
+    grpc_plugin_source, metrics, websocket_source, MetricsConfig, SourceConfig, TransactionUpdate
 };
 use mango_feeds_connector::{
     metrics::{MetricType, MetricU64},
@@ -436,6 +436,9 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
+    let (transaction_queue_sender, _transaction_queue_receiver) =
+        async_channel::unbounded::<TransactionUpdate>();
+
     let level_checkpoints = LevelCheckpointMap::new(Mutex::new(HashMap::new()));
     let book_checkpoints = BookCheckpointMap::new(Mutex::new(HashMap::new()));
     let peers = PeerMap::new(Mutex::new(HashMap::new()));
@@ -610,6 +613,7 @@ async fn main() -> anyhow::Result<()> {
             &filter_config,
             account_write_queue_sender,
             slot_queue_sender,
+            transaction_queue_sender,
             metrics_tx.clone(),
             exit.clone(),
         )

--- a/bin/service-mango-pnl/src/main.rs
+++ b/bin/service-mango-pnl/src/main.rs
@@ -19,6 +19,7 @@ use anchor_client::Cluster;
 use anchor_lang::Discriminator;
 use fixed::types::I80F48;
 use mango_feeds_connector::metrics::*;
+use mango_feeds_connector::TransactionUpdate;
 use mango_v4::state::{MangoAccount, MangoAccountValue, PerpMarketIndex};
 use mango_v4_client::{
     chain_data, health_cache, AccountFetcher, Client, MangoGroupContext, TransactionBuilderConfig,
@@ -307,6 +308,8 @@ async fn main() -> anyhow::Result<()> {
 
     // start filling chain_data from the grpc plugin source
     let (account_write_queue_sender, slot_queue_sender) = memory_target::init(chain_data).await?;
+    let (transaction_queue_sender, _transaction_queue_receiver) =
+        async_channel::unbounded::<TransactionUpdate>();
     let filter_config = FilterConfig {
         entity_filter: EntityFilter::filter_by_program_id(
             "4MangoMjqJ2firMokCjjGgoK8d4MXcrgL7XJaL3w6fVg",
@@ -317,6 +320,7 @@ async fn main() -> anyhow::Result<()> {
         &filter_config,
         account_write_queue_sender,
         slot_queue_sender,
+        transaction_queue_sender,
         metrics_tx.clone(),
         exit.clone(),
     )

--- a/cd/fills.toml
+++ b/cd/fills.toml
@@ -8,16 +8,6 @@ kill_timeout = 30
 [experimental]
   cmd = ["service-mango-fills", "fills-config.toml"]
 
-[[services]]
-  internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-
-  [services.concurrency]
-    hard_limit = 1024
-    soft_limit = 1024
-    type = "connections"
-
 [metrics]
   path = "/metrics"
   port = 9091

--- a/cd/orderbook.toml
+++ b/cd/orderbook.toml
@@ -8,16 +8,6 @@ kill_timeout = 5
 [experimental]
   cmd = ["service-mango-orderbook", "orderbook-config.toml"]
 
-[[services]]
-  internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-
-  [services.concurrency]
-    hard_limit = 1024
-    soft_limit = 1024
-    type = "connections"
-
 [metrics]
   path = "/metrics"
   port = 9091

--- a/cd/pnl.toml
+++ b/cd/pnl.toml
@@ -8,16 +8,6 @@ kill_timeout = 5
 [experimental]
   cmd = ["service-mango-pnl", "pnl-config.toml"]
 
-[[services]]
-  internal_port = 8081
-  processes = ["app"]
-  protocol = "tcp"
-
-  [services.concurrency]
-    hard_limit = 1024
-    soft_limit = 1024
-    type = "connections"
-
 [metrics]
   path = "/metrics"
   port = 9091

--- a/lib/mango-feeds-lib/Cargo.toml
+++ b/lib/mango-feeds-lib/Cargo.toml
@@ -10,9 +10,9 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 
-solana-client = "~1.16.7"
-solana-account-decoder = "~1.16.7"
-solana-sdk = "~1.16.7"
+solana-client = "~1.16.17"
+solana-account-decoder = "~1.16.17"
+solana-sdk = "~1.16.17"
 
 
 fixed = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.69"
+channel = "1.70"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
* Upgrade mango-feeds-connector in order to upgrade the underlying yellowstone-grpc libraries
* Use a patched solana v1.16.17 to upgrade and unpin tokio (1.14.1 -> 1.32.0)
* Add some logging to feeds and clean up deployment configs