### PR TITLE
fix decoding of broken oracle

### DIFF
--- a/ts/client/scripts/archive/mb-oracle-inspect.ts
+++ b/ts/client/scripts/archive/mb-oracle-inspect.ts
@@ -8,7 +8,7 @@ import {
 import { toNativeI80F48 } from '../../src/utils';
 const { MB_CLUSTER_URL } = process.env;
 
-async function decodePrice(conn, ai): Promise<void> {
+async function decodePrice(conn, ai, pk): Promise<void> {
   let uiPrice, price, lastUpdatedSlot, type;
   if (isPythOracle(ai!)) {
     const priceData = parsePriceData(ai!.data);
@@ -17,7 +17,7 @@ async function decodePrice(conn, ai): Promise<void> {
     lastUpdatedSlot = parseInt(priceData.lastSlot.toString());
     type = 'pyth';
   } else if (isSwitchboardOracle(ai!)) {
-    const priceData = await parseSwitchboardOracle(ai!, conn);
+    const priceData = await parseSwitchboardOracle(pk, ai!, conn);
     uiPrice = priceData.price;
     price = toNativeI80F48(uiPrice, 6 - 5);
     lastUpdatedSlot = priceData.lastUpdatedSlot;
@@ -31,16 +31,17 @@ async function decodePrice(conn, ai): Promise<void> {
 
 async function main(): Promise<void> {
   try {
+    const oraclePk1 = new PublicKey(
+      '4SZ1qb4MtSUrZcoeaeQ3BDzVCyqxw3VwSFpPiMTmn4GE',
+    );
     const conn = new Connection(MB_CLUSTER_URL!);
-    let ai = await conn.getAccountInfo(
-      new PublicKey('4SZ1qb4MtSUrZcoeaeQ3BDzVCyqxw3VwSFpPiMTmn4GE'),
+    let ai = await conn.getAccountInfo(oraclePk1);
+    decodePrice(conn, ai, oraclePk1);
+    const oraclePk2 = new PublicKey(
+      '8ihFLu5FimgTQ1Unh4dVyEHUGodJ5gJQCrQf4KUVB9bN',
     );
-    decodePrice(conn, ai);
-
-    ai = await conn.getAccountInfo(
-      new PublicKey('8ihFLu5FimgTQ1Unh4dVyEHUGodJ5gJQCrQf4KUVB9bN'),
-    );
-    decodePrice(conn, ai);
+    ai = await conn.getAccountInfo(oraclePk2);
+    decodePrice(conn, ai, oraclePk2);
   } catch (error) {
     console.log(error);
   }

--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -499,6 +499,7 @@ export class Group {
       provider = OracleProvider.Pyth;
     } else if (isSwitchboardOracle(ai)) {
       const priceData = await parseSwitchboardOracle(
+        oracle,
         ai,
         client.program.provider.connection,
       );

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -93,8 +93,10 @@ export function switchboardDecimalToBig(sbDecimal: {
 export function parseSwitchboardOracleV2(
   program: SwitchboardProgram,
   accountInfo: AccountInfo<Buffer>,
+  oracle: PublicKey,
 ): { price: number; lastUpdatedSlot: number; uiDeviation: number } {
   try {
+    //
     const price = program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
     const lastUpdatedSlot = program
       .decodeAggregator(accountInfo)
@@ -104,8 +106,9 @@ export function parseSwitchboardOracleV2(
     );
 
     return { price, lastUpdatedSlot, uiDeviation: stdDeviation.toNumber() };
+    //if oracle is badly configured or never published decodeLatestAggregate will throw.
   } catch (e) {
-    console.log('Unable to parse Switchboard Oracle V2', e);
+    console.log(`Unable to parse Switchboard Oracle V2: ${oracle}`, e);
     return { price: 0, lastUpdatedSlot: 0, uiDeviation: 0 };
   }
 }
@@ -116,6 +119,7 @@ export function parseSwitchboardOracleV2(
  * @returns ui price
  */
 export async function parseSwitchboardOracle(
+  oracle: PublicKey,
   accountInfo: AccountInfo<Buffer>,
   connection: Connection,
 ): Promise<{ price: number; lastUpdatedSlot: number; uiDeviation: number }> {
@@ -123,14 +127,14 @@ export async function parseSwitchboardOracle(
     if (!sbv2DevnetProgram) {
       sbv2DevnetProgram = await SwitchboardProgram.loadDevnet(connection);
     }
-    return parseSwitchboardOracleV2(sbv2DevnetProgram, accountInfo);
+    return parseSwitchboardOracleV2(sbv2DevnetProgram, accountInfo, oracle);
   }
 
   if (accountInfo.owner.equals(SwitchboardProgram.mainnetPid)) {
     if (!sbv2MainnetProgram) {
       sbv2MainnetProgram = await SwitchboardProgram.loadMainnet(connection);
     }
-    return parseSwitchboardOracleV2(sbv2MainnetProgram, accountInfo);
+    return parseSwitchboardOracleV2(sbv2MainnetProgram, accountInfo, oracle);
   }
 
   if (

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -105,6 +105,7 @@ export function parseSwitchboardOracleV2(
 
     return { price, lastUpdatedSlot, uiDeviation: stdDeviation.toNumber() };
   } catch (e) {
+    console.log('Unable to parse Switchboard Oracle V2', e);
     return { price: 0, lastUpdatedSlot: 0, uiDeviation: 0 };
   }
 }

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -106,7 +106,8 @@ export function parseSwitchboardOracleV2(
     );
 
     return { price, lastUpdatedSlot, uiDeviation: stdDeviation.toNumber() };
-    //if oracle is badly configured or never published decodeLatestAggregate will throw.
+    //if oracle is badly configured or didn't publish price at least once
+    //decodeLatestAggregatorValue can throw (0 switchboard rounds).
   } catch (e) {
     console.log(`Unable to parse Switchboard Oracle V2: ${oracle}`, e);
     return { price: 0, lastUpdatedSlot: 0, uiDeviation: 0 };

--- a/ts/client/src/accounts/oracle.ts
+++ b/ts/client/src/accounts/oracle.ts
@@ -94,17 +94,19 @@ export function parseSwitchboardOracleV2(
   program: SwitchboardProgram,
   accountInfo: AccountInfo<Buffer>,
 ): { price: number; lastUpdatedSlot: number; uiDeviation: number } {
-  const price = program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
-  const lastUpdatedSlot = program
-    .decodeAggregator(accountInfo)
-    .latestConfirmedRound!.roundOpenSlot!.toNumber();
-  const stdDeviation = switchboardDecimalToBig(
-    program.decodeAggregator(accountInfo).latestConfirmedRound.stdDeviation,
-  );
+  try {
+    const price = program.decodeLatestAggregatorValue(accountInfo)!.toNumber();
+    const lastUpdatedSlot = program
+      .decodeAggregator(accountInfo)
+      .latestConfirmedRound!.roundOpenSlot!.toNumber();
+    const stdDeviation = switchboardDecimalToBig(
+      program.decodeAggregator(accountInfo).latestConfirmedRound.stdDeviation,
+    );
 
-  if (!price || !lastUpdatedSlot)
-    throw new Error('Unable to parse Switchboard Oracle V2');
-  return { price, lastUpdatedSlot, uiDeviation: stdDeviation.toNumber() };
+    return { price, lastUpdatedSlot, uiDeviation: stdDeviation.toNumber() };
+  } catch (e) {
+    return { price: 0, lastUpdatedSlot: 0, uiDeviation: 0 };
+  }
 }
 
 /**


### PR DESCRIPTION
currently if oracle never reported the price or something with the switchboard oracle is broken, client is starting to break bots and ui. 

Imo it should be catched inside ui or bot that the price is 0 and handled there depending on case, now one broken token breaks use of other tokens as well.