### PR TITLE
rust client: Perp - Auto close account when needed

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Parser, Subcommand};
+use mango_v4::state::{PlaceOrderType, SelfTradeBehavior, Side};
 use mango_v4_client::{
     keypair_from_cli, pubkey_from_cli, Client, MangoClient, TransactionBuilderConfig,
 };
@@ -6,7 +7,6 @@ use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use mango_v4::state::{PlaceOrderType, SelfTradeBehavior, Side};
 
 mod save_snapshot;
 mod test_oracles;
@@ -158,7 +158,7 @@ enum Command {
         #[clap(short, long)]
         output: String,
     },
-    PerpPlaceOrder(PerpPlaceOrder)
+    PerpPlaceOrder(PerpPlaceOrder),
 }
 
 impl Rpc {
@@ -281,32 +281,46 @@ async fn main() -> Result<(), anyhow::Error> {
             let account = pubkey_from_cli(&cmd.account);
             let owner = Arc::new(keypair_from_cli(&cmd.owner));
             let client = MangoClient::new_for_existing_account(client, account, owner).await?;
-            let market = client.context.perp_markets
+            let market = client
+                .context
+                .perp_markets
                 .iter()
-                .find(|p| p.1.name == cmd.market_name).unwrap().1;
+                .find(|p| p.1.name == cmd.market_name)
+                .unwrap()
+                .1;
 
             fn native(x: f64, b: u32) -> i64 {
                 (x * (10_i64.pow(b)) as f64) as i64
             }
 
-            let price_lots = native(cmd.price, 6) * market.base_lot_size / (market.quote_lot_size * 10_i64.pow(market.base_decimals.into()));
-            let max_base_lots = native(cmd.quantity, market.base_decimals.into()) / market.base_lot_size;
+            let price_lots = native(cmd.price, 6) * market.base_lot_size
+                / (market.quote_lot_size * 10_i64.pow(market.base_decimals.into()));
+            let max_base_lots =
+                native(cmd.quantity, market.base_decimals.into()) / market.base_lot_size;
 
             let txsig = client
-            .perp_place_order(
-                market.perp_market_index,
-                if cmd.side.to_lowercase() == "bid" { Side::Bid } else { Side::Ask },
-                price_lots,
-                max_base_lots,
-                i64::max_value(),
-                SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
-                PlaceOrderType::Limit,
-                false,
-                if cmd.expiry > 0 { SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + cmd.expiry } else { 0 },
-                10,
-                SelfTradeBehavior::AbortTransaction
-            )
-            .await?;
+                .perp_place_order(
+                    market.perp_market_index,
+                    if cmd.side.to_lowercase() == "bid" {
+                        Side::Bid
+                    } else {
+                        Side::Ask
+                    },
+                    price_lots,
+                    max_base_lots,
+                    i64::max_value(),
+                    SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
+                    PlaceOrderType::Limit,
+                    false,
+                    if cmd.expiry > 0 {
+                        SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + cmd.expiry
+                    } else {
+                        0
+                    },
+                    10,
+                    SelfTradeBehavior::AbortTransaction,
+                )
+                .await?;
             println!("{}", txsig);
         }
     };

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -1,3 +1,4 @@
+use clap::clap_derive::ArgEnum;
 use clap::{Args, Parser, Subcommand};
 use mango_v4::state::{PlaceOrderType, SelfTradeBehavior, Side};
 use mango_v4_client::{
@@ -90,6 +91,13 @@ struct JupiterSwap {
     rpc: Rpc,
 }
 
+#[derive(ArgEnum, Clone, Debug)]
+#[repr(u8)]
+pub enum CliSide {
+    Bid = 0,
+    Ask = 1,
+}
+
 #[derive(Args, Debug, Clone)]
 struct PerpPlaceOrder {
     #[clap(long)]
@@ -102,8 +110,8 @@ struct PerpPlaceOrder {
     #[clap(long)]
     market_name: String,
 
-    #[clap(long)]
-    side: String,
+    #[clap(long, value_enum)]
+    side: CliSide,
 
     #[clap(short, long)]
     price: f64,
@@ -301,10 +309,9 @@ async fn main() -> Result<(), anyhow::Error> {
             let txsig = client
                 .perp_place_order(
                     market.perp_market_index,
-                    if cmd.side.to_lowercase() == "bid" {
-                        Side::Bid
-                    } else {
-                        Side::Ask
+                    match cmd.side {
+                        CliSide::Bid => Side::Bid,
+                        CliSide::Ask => Side::Ask,
                     },
                     price_lots,
                     max_base_lots,

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -6,7 +6,7 @@ use solana_sdk::pubkey::Pubkey;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use mango_v4::state::{PerpMarketIndex, PlaceOrderType, SelfTradeBehavior, Side};
+use mango_v4::state::{PlaceOrderType, SelfTradeBehavior, Side};
 
 mod save_snapshot;
 mod test_oracles;

--- a/lib/client/src/client.rs
+++ b/lib/client/src/client.rs
@@ -1238,11 +1238,6 @@ impl MangoClient {
         market_index: PerpMarketIndex
     ) -> anyhow::Result<PreparedInstructions> {
         let perp = self.context.perp(market_index);
-        let mango_account = &self.mango_account().await?;
-
-        let (health_check_metas, health_cu) = self
-            .derive_health_check_remaining_account_metas(mango_account, vec![], vec![], vec![])
-            .await?;
 
         let ixs = PreparedInstructions::from_single(
             Instruction {
@@ -1257,14 +1252,13 @@ impl MangoClient {
                         },
                         None,
                     );
-                    ams.extend(health_check_metas.into_iter());
                     ams
                 },
                 data: anchor_lang::InstructionData::data(
                     &mango_v4::instruction::PerpDeactivatePosition {},
                 ),
             },
-            self.instruction_cu(health_cu),
+            self.context.compute_estimates.cu_per_mango_instruction,
         );
         Ok(ixs)
     }

--- a/lib/client/src/client.rs
+++ b/lib/client/src/client.rs
@@ -49,7 +49,6 @@ use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::sysvar;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signer::Signer};
-use mango_v4::error::MangoError;
 
 pub const MAX_ACCOUNTS_PER_TRANSACTION: usize = 64;
 
@@ -1243,7 +1242,7 @@ impl MangoClient {
             Instruction {
                 program_id: mango_v4::id(),
                 accounts: {
-                    let mut ams = anchor_lang::ToAccountMetas::to_account_metas(
+                    let ams = anchor_lang::ToAccountMetas::to_account_metas(
                         &mango_v4::accounts::PerpDeactivatePosition {
                             group: self.group(),
                             account: self.mango_account_address,

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -1198,15 +1198,15 @@ impl<
     }
 
     pub fn find_first_unused_perp_position(&self) -> Option<&PerpPosition> {
-        let first_unused_position_opt = self.all_perp_positions()
-            .find(|p| p.is_active()
+        let first_unused_position_opt = self.all_perp_positions().find(|p| {
+            p.is_active()
                 && p.base_position_lots == 0
                 && p.quote_position_native == 0
                 && p.bids_base_lots == 0
                 && p.asks_base_lots == 0
                 && p.taker_base_lots == 0
                 && p.taker_quote_lots == 0
-            );
+        });
         first_unused_position_opt
     }
 

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -1155,6 +1155,7 @@ impl<
         }
     }
 
+    // Only used in unit tests
     pub fn deactivate_perp_position(
         &mut self,
         perp_market_index: PerpMarketIndex,
@@ -1194,6 +1195,19 @@ impl<
         settle_token_position.decrement_in_use();
 
         Ok(())
+    }
+
+    pub fn find_first_unused_perp_position(&self) -> Option<&PerpPosition> {
+        let first_unused_position_opt = self.all_perp_positions()
+            .find(|p| p.is_active()
+                && p.base_position_lots == 0
+                && p.quote_position_native == 0
+                && p.bids_base_lots == 0
+                && p.asks_base_lots == 0
+                && p.taker_base_lots == 0
+                && p.taker_quote_lots == 0
+            );
+        first_unused_position_opt
     }
 
     pub fn add_perp_order(
@@ -1850,10 +1864,11 @@ impl<'a, 'info: 'a> MangoAccountLoader<'a> for &'a AccountLoader<'info, MangoAcc
 
 #[cfg(test)]
 mod tests {
+    use anchor_lang::error::Error::AnchorError;
     use bytemuck::Zeroable;
     use itertools::Itertools;
 
-    use crate::state::PostOrderType;
+    use crate::state::{PostOrderType};
 
     use super::*;
 
@@ -2807,5 +2822,35 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_perp_auto_close_first_unused() {
+        let mut account = make_test_account();
+
+        // Fill all perp slots
+        assert_eq!(account.header.perp_count, 4);
+        account.ensure_perp_position(1, 0).unwrap();
+        account.ensure_perp_position(2, 0).unwrap();
+        account.ensure_perp_position(3, 0).unwrap();
+        account.ensure_perp_position(4, 0).unwrap();
+        assert_eq!(account.active_perp_positions().count(), 4);
+
+        // Force usage of some perp slot (leaves 3 unused)
+        account.perp_position_mut(1).unwrap().taker_base_lots = 10;
+        account.perp_position_mut(2).unwrap().base_position_lots = 10;
+        account.perp_position_mut(4).unwrap().quote_position_native = I80F48::from_num(10);
+        assert!(account.perp_position(3).ok().is_some());
+
+        // Should not succeed anymore
+        {
+            let e = account.ensure_perp_position(5, 0);
+            assert!(e.is_anchor_error_with_code(MangoError::NoFreePerpPositionIndex.error_code()));
+        }
+
+        // Act
+        let to_be_closed_account_opt = account.find_first_unused_perp_position();
+
+        assert_eq!(to_be_closed_account_opt.unwrap().market_index, 3)
     }
 }

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -1197,7 +1197,7 @@ impl<
         Ok(())
     }
 
-    pub fn find_first_unused_perp_position(&self) -> Option<&PerpPosition> {
+    pub fn find_first_active_unused_perp_position(&self) -> Option<&PerpPosition> {
         let first_unused_position_opt = self.all_perp_positions().find(|p| {
             p.is_active()
                 && p.base_position_lots == 0
@@ -2848,7 +2848,7 @@ mod tests {
         }
 
         // Act
-        let to_be_closed_account_opt = account.find_first_unused_perp_position();
+        let to_be_closed_account_opt = account.find_first_active_unused_perp_position();
 
         assert_eq!(to_be_closed_account_opt.unwrap().market_index, 3)
     }

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -1864,11 +1864,10 @@ impl<'a, 'info: 'a> MangoAccountLoader<'a> for &'a AccountLoader<'info, MangoAcc
 
 #[cfg(test)]
 mod tests {
-    use anchor_lang::error::Error::AnchorError;
     use bytemuck::Zeroable;
     use itertools::Itertools;
 
-    use crate::state::{PostOrderType};
+    use crate::state::PostOrderType;
 
     use super::*;
 


### PR DESCRIPTION
Auto close first unused perp account _if_ it's needed to place a new order because all slots are currently allocated

This is done on the client side because we need health data to be correct on the program side when processing the place order

*Example tx:*
[3j5cZZcmc7MEXwNAsdoWKZRgea8SAXKs5gE2jxuXi2Pzgmxang9ZrgKwTL5fXPHaJchJ1e7wDNobJHSPBdEqpTz3](https://explorer.solana.com/tx/3j5cZZcmc7MEXwNAsdoWKZRgea8SAXKs5gE2jxuXi2Pzgmxang9ZrgKwTL5fXPHaJchJ1e7wDNobJHSPBdEqpTz3)