### PR TITLE
Rust client: auto close spot account if needed to place a new order 

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -429,7 +429,8 @@ async fn main() -> Result<(), anyhow::Error> {
             // coin_lot_size = base lot size ?
             // cf priceNumberToLots
             let price_lots = native(cmd.price, quote_token.decimals as u32) * market.coin_lot_size
-                / native(market.pc_lot_size as f64, base_token.decimals as u32);
+                / native(1.0, base_token.decimals as u32)
+                * market.pc_lot_size;
 
             // cf baseSizeNumberToLots
             let max_base_lots =

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -144,6 +144,22 @@ struct Serum3CreateOpenOrders {
 }
 
 #[derive(Args, Debug, Clone)]
+struct Serum3CloseOpenOrders {
+    #[clap(long)]
+    account: String,
+
+    /// also pays for everything
+    #[clap(short, long)]
+    owner: String,
+
+    #[clap(long)]
+    market_name: String,
+
+    #[clap(flatten)]
+    rpc: Rpc,
+}
+
+#[derive(Args, Debug, Clone)]
 struct Serum3PlaceOrder {
     #[clap(long)]
     account: String,
@@ -209,6 +225,7 @@ enum Command {
         output: String,
     },
     PerpPlaceOrder(PerpPlaceOrder),
+    Serum3CloseOpenOrders(Serum3CloseOpenOrders),
     Serum3CreateOpenOrders(Serum3CreateOpenOrders),
     Serum3PlaceOrder(Serum3PlaceOrder),
 }
@@ -384,6 +401,15 @@ async fn main() -> Result<(), anyhow::Error> {
             let client = MangoClient::new_for_existing_account(client, account, owner).await?;
 
             let txsig = client.serum3_create_open_orders(&cmd.market_name).await?;
+            println!("{}", txsig);
+        }
+        Command::Serum3CloseOpenOrders(cmd) => {
+            let client = cmd.rpc.client(Some(&cmd.owner))?;
+            let account = pubkey_from_cli(&cmd.account);
+            let owner = Arc::new(keypair_from_cli(&cmd.owner));
+            let client = MangoClient::new_for_existing_account(client, account, owner).await?;
+
+            let txsig = client.serum3_close_open_orders(&cmd.market_name).await?;
             println!("{}", txsig);
         }
         Command::Serum3PlaceOrder(cmd) => {

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -429,8 +429,7 @@ async fn main() -> Result<(), anyhow::Error> {
             // coin_lot_size = base lot size ?
             // cf priceNumberToLots
             let price_lots = native(cmd.price, quote_token.decimals as u32) * market.coin_lot_size
-                / native(1.0, base_token.decimals as u32)
-                * market.pc_lot_size;
+                / (native(1.0, base_token.decimals as u32) * market.pc_lot_size);
 
             // cf baseSizeNumberToLots
             let max_base_lots =

--- a/lib/client/src/client.rs
+++ b/lib/client/src/client.rs
@@ -692,7 +692,7 @@ impl MangoClient {
                     &mango_v4::instruction::Serum3CloseOpenOrders {},
                 ),
             },
-            self.context.compute_estimates.health_cu_per_serum,
+            self.context.compute_estimates.cu_per_mango_instruction,
         )
     }
 
@@ -771,9 +771,6 @@ impl MangoClient {
         client_order_id: u64,
         limit: u16,
     ) -> anyhow::Result<PreparedInstructions> {
-        let mut ixs = PreparedInstructions::new();
-        let account = account.clone();
-
         let s3 = self.context.serum3(market_index);
         let base = self.context.serum3_base_token(market_index);
         let quote = self.context.serum3_quote_token(market_index);
@@ -796,7 +793,7 @@ impl MangoClient {
             )
             .await?;
 
-        ixs.push(
+        let ixs = PreparedInstructions::from_single(
             Instruction {
                 program_id: mango_v4::id(),
                 accounts: {
@@ -908,7 +905,7 @@ impl MangoClient {
 
             ixs.push(
                 self.serum3_create_open_orders_instruction(market_index),
-                self.context.compute_estimates.health_cu_per_serum,
+                self.context.compute_estimates.cu_per_mango_instruction,
             );
 
             let created_open_orders = self.serum3_create_open_orders_address(market_index);

--- a/lib/client/src/client.rs
+++ b/lib/client/src/client.rs
@@ -779,10 +779,7 @@ impl MangoClient {
             Serum3Side::Ask => (&base, &quote),
         };
 
-        let open_orders = account
-            .serum3_orders(market_index)
-            .map(|x| x.open_orders)
-            .expect("oo is created");
+        let open_orders = account.serum3_orders(market_index).map(|x| x.open_orders)?;
 
         let (health_check_metas, health_cu) = self
             .derive_health_check_remaining_account_metas(


### PR DESCRIPTION
Example tx:
https://explorer.solana.com/tx/FNjZpELFjhqCh9sxcfUNt2YtNTRjkvkWvt7hguAQ4RePKHWcsmrv5PUAvngCECz2BmbRWpod2DESvg6myoKedZK

When placing a new serum3 order, if needed:
1/ try to close unused token to free slots for new order base/quote tokens
2/ try to close unused spot market to free slot for new order
3/ if 1 failed, try again (closing one market reduce token usage count)
4/ try to create the new spot market slot
