### PR TITLE
wip: unlendable deposits?

### DIFF
--- a/programs/mango-v4/src/error.rs
+++ b/programs/mango-v4/src/error.rs
@@ -147,6 +147,8 @@ pub enum MangoError {
     TokenAssetLiquidationDisabled,
     #[msg("for borrows the bank must be in the health account list")]
     BorrowsRequireHealthAccountBank,
+    #[msg("perp settle token position does not support borrows")]
+    PerpSettleTokenPositionMustSupportBorrows,
 }
 
 impl MangoError {

--- a/programs/mango-v4/src/instructions/admin_perp_withdraw_fees.rs
+++ b/programs/mango-v4/src/instructions/admin_perp_withdraw_fees.rs
@@ -6,10 +6,16 @@ use crate::{accounts_ix::*, group_seeds};
 pub fn admin_perp_withdraw_fees(ctx: Context<AdminPerpWithdrawFees>) -> Result<()> {
     let group = ctx.accounts.group.load()?;
     let mut perp_market = ctx.accounts.perp_market.load_mut()?;
+    let bank = ctx.accounts.bank.load()?;
 
     let group_seeds = group_seeds!(group);
     let fees = perp_market.fees_settled.floor().to_num::<u64>() - perp_market.fees_withdrawn;
-    let amount = fees.min(ctx.accounts.vault.amount);
+    let amount = fees.min(
+        ctx.accounts
+            .vault
+            .amount
+            .saturating_sub(bank.unlendable_deposits),
+    );
     token::transfer(
         ctx.accounts.transfer_ctx().with_signer(&[group_seeds]),
         amount,

--- a/programs/mango-v4/src/instructions/admin_token_withdraw_fees.rs
+++ b/programs/mango-v4/src/instructions/admin_token_withdraw_fees.rs
@@ -9,7 +9,12 @@ pub fn admin_token_withdraw_fees(ctx: Context<AdminTokenWithdrawFees>) -> Result
 
     let group_seeds = group_seeds!(group);
     let fees = bank.collected_fees_native.floor().to_num::<u64>() - bank.fees_withdrawn;
-    let amount = fees.min(ctx.accounts.vault.amount);
+    let amount = fees.min(
+        ctx.accounts
+            .vault
+            .amount
+            .saturating_sub(bank.unlendable_deposits),
+    );
     token::transfer(
         ctx.accounts.transfer_ctx().with_signer(&[group_seeds]),
         amount,

--- a/programs/mango-v4/src/instructions/serum3_place_order.rs
+++ b/programs/mango-v4/src/instructions/serum3_place_order.rs
@@ -331,6 +331,14 @@ pub fn serum3_place_order(
         )?
     };
 
+    // Verify that the no-lending amount on the vault remains. If the acting account
+    // itself had a no-lending position, the unlendable_deposits has already been reduced.
+    require_gte!(
+        after_vault,
+        payer_bank.unlendable_deposits,
+        MangoError::InsufficentBankVaultFunds
+    );
+
     // Deposit limit check, receiver side:
     // Placing an order can always increase the receiver bank deposits on fill.
     {

--- a/programs/mango-v4/src/instructions/token_force_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_force_withdraw.rs
@@ -36,11 +36,12 @@ pub fn token_force_withdraw(ctx: Context<TokenForceWithdraw>) -> Result<()> {
     let position_is_active = bank.withdraw_without_fee(position, amount_i80f48, now_ts)?;
 
     // Provide a readable error message in case the vault doesn't have enough tokens
-    if ctx.accounts.vault.amount < amount {
+    // Note that unlendable_deposits has already been reduced above.
+    if ctx.accounts.vault.amount < bank.unlendable_deposits + amount {
         return err!(MangoError::InsufficentBankVaultFunds).with_context(|| {
             format!(
-                "bank vault does not have enough tokens, need {} but have {}",
-                amount, ctx.accounts.vault.amount
+                "bank vault does not have enough tokens, need {} but have {} ({} unlendable)",
+                amount, ctx.accounts.vault.amount, bank.unlendable_deposits
             )
         });
     }

--- a/programs/mango-v4/src/instructions/token_register.rs
+++ b/programs/mango-v4/src/instructions/token_register.rs
@@ -133,7 +133,9 @@ pub fn token_register(
         collected_liquidation_fees: I80F48::ZERO,
         collected_collateral_fees: I80F48::ZERO,
         collateral_fee_per_day,
-        reserved: [0; 1900],
+        padding2: Default::default(),
+        unlendable_deposits: 0,
+        reserved: [0; 1888],
     };
 
     let oracle_ref = &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?;

--- a/programs/mango-v4/src/instructions/token_register_trustless.rs
+++ b/programs/mango-v4/src/instructions/token_register_trustless.rs
@@ -111,7 +111,9 @@ pub fn token_register_trustless(
         collected_liquidation_fees: I80F48::ZERO,
         collected_collateral_fees: I80F48::ZERO,
         collateral_fee_per_day: 0.0, // TODO
-        reserved: [0; 1900],
+        padding2: Default::default(),
+        unlendable_deposits: 0,
+        reserved: [0; 1888],
     };
     let oracle_ref = &AccountInfoRef::borrow(ctx.accounts.oracle.as_ref())?;
     if let Ok(oracle_price) = bank.oracle_price(&OracleAccountInfos::from_reader(oracle_ref), None)

--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -91,11 +91,12 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
     let bank = ctx.accounts.bank.load()?;
 
     // Provide a readable error message in case the vault doesn't have enough tokens
-    if ctx.accounts.vault.amount < amount {
+    // Note that unlendable_deposits has already been reduced above.
+    if ctx.accounts.vault.amount < bank.unlendable_deposits + amount {
         return err!(MangoError::InsufficentBankVaultFunds).with_context(|| {
             format!(
-                "bank vault does not have enough tokens, need {} but have {}",
-                amount, ctx.accounts.vault.amount
+                "bank vault does not have enough tokens, need {} but have {} ({} unlendable)",
+                amount, ctx.accounts.vault.amount, bank.unlendable_deposits
             )
         });
     }

--- a/programs/mango-v4/src/state/mango_account.rs
+++ b/programs/mango-v4/src/state/mango_account.rs
@@ -1012,6 +1012,7 @@ impl<
                     indexed_position: I80F48::ZERO,
                     token_index,
                     in_use_count: 0,
+                    disable_lending: 0,
                     cumulative_deposit_interest: 0.0,
                     cumulative_borrow_interest: 0.0,
                     previous_index: I80F48::ZERO,
@@ -1161,6 +1162,13 @@ impl<
                 perp_position.market_index = perp_market_index;
 
                 let settle_token_position = self.ensure_token_position(settle_token_index)?.0;
+                // no-lending positions can't have negative balances can't work with perps:
+                // settlement must be able to move the position arbitrarily
+                require_msg_typed!(
+                    settle_token_position.allow_lending(),
+                    MangoError::PerpSettleTokenPositionMustSupportBorrows,
+                    "the account's settle token position (index {settle_token_index}) is a no-lending position, unsuitable for perps"
+                );
                 settle_token_position.increment_in_use();
             }
         }


### PR DESCRIPTION
- for sanity, the liquidator likely must have lendable positions too
- instruction for creating and closing an unlendable position
- heaps of tests, rs client changes, ts client changes :/

Done:
- when dealing with the vault, always keep unlendable_deposits in the vault (unless withdrawing a no-lending position)
- no-lending positions can't work as settle token positions for perps