### PR TITLE
service-mango-health: use jemalloc

### DIFF
--- a/bin/service-mango-health/src/main.rs
+++ b/bin/service-mango-health/src/main.rs
@@ -16,6 +16,11 @@ use crate::processors::health::HealthProcessor;
 use crate::processors::logger::LoggerProcessor;
 use crate::processors::persister::PersisterProcessor;
 
+// jemalloc seems to be better at keeping the memory footprint reasonable over
+// longer periods of time
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();


### PR DESCRIPTION
This should help with memory issue while running the health monitoring service