### PR TITLE
liquidator: fix withdraws on rebalance

### DIFF
--- a/bin/liquidator/src/main.rs
+++ b/bin/liquidator/src/main.rs
@@ -17,7 +17,6 @@ use mango_v4_client::{
 use itertools::Itertools;
 use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signer::Signer;
 use tracing::*;
 
 pub mod cli_args;
@@ -105,11 +104,6 @@ async fn main() -> anyhow::Result<()> {
         .fetch_fresh_mango_account(&cli.liqor_mango_account)
         .await?;
     let mango_group = mango_account.fixed.group;
-
-    let signer_is_owner = mango_account.fixed.owner == liqor_owner.pubkey();
-    if cli.rebalance == BoolArg::True && !signer_is_owner {
-        warn!("rebalancing on delegated accounts will be unable to free token positions reliably, withdraw dust manually");
-    }
 
     let group_context = MangoGroupContext::new_from_rpc(client.rpc_async(), mango_group).await?;
 
@@ -246,7 +240,7 @@ async fn main() -> anyhow::Result<()> {
         alternate_jupiter_route_tokens: cli
             .rebalance_alternate_jupiter_route_tokens
             .unwrap_or_default(),
-        allow_withdraws: signer_is_owner,
+        allow_withdraws: true,
     };
     rebalance_config.validate(&mango_client.context);
 

--- a/bin/liquidator/src/rebalance.rs
+++ b/bin/liquidator/src/rebalance.rs
@@ -295,11 +295,12 @@ impl Rebalancer {
             // Imagine SOL at 0.04 USDC-native per SOL-native: Any amounts below 25 SOL-native
             // would not be worth a single USDC-native.
             //
-            // To avoid errors, we consider all amounts below 2 * (1/oracle) dust and don't try
+            // To avoid errors, we consider all amounts below 1000 * (1/oracle) dust and don't try
             // to sell them. Instead they will be withdrawn at the end.
             // Purchases will aim to purchase slightly more than is needed, such that we can
             // again withdraw the dust at the end.
-            let dust_threshold = I80F48::from(2) / token_price;
+            // 1000 USD-native is $0.001; note that delegates are allowed to withdraw up to DELEGATE_WITHDRAW_MAX ($0.1)
+            let dust_threshold = I80F48::from(1_000) / token_price;
 
             // Some rebalancing can actually change non-USDC positions (rebalancing to SOL)
             // So re-fetch the current token position amount


### PR DESCRIPTION
- always allow them, now that v0.22 is deployed and delegates can withdraw small token amounts to the owner's ata
- increase the dust amount to $0.001 to avoid issues where the logic is a few lamports off