### PR TITLE
program: remove delegate account withdrawal limit

### DIFF
--- a/programs/mango-v4/src/instructions/token_withdraw.rs
+++ b/programs/mango-v4/src/instructions/token_withdraw.rs
@@ -13,8 +13,6 @@ use crate::logs::{
     emit_stack, LoanOriginationFeeInstruction, TokenBalanceLog, WithdrawLoanLog, WithdrawLog,
 };
 
-const DELEGATE_WITHDRAW_MAX: i64 = 100_000; // $0.1
-
 pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bool) -> Result<()> {
     require_msg!(amount > 0, "withdraw amount must be positive");
 
@@ -142,13 +140,6 @@ pub fn token_withdraw(ctx: Context<TokenWithdraw>, amount: u64, allow_borrow: bo
         require!(
             !withdraw_result.position_is_active,
             MangoError::DelegateWithdrawMustClosePosition
-        );
-
-        // Delegates can't withdraw too much
-        require_gte!(
-            DELEGATE_WITHDRAW_MAX,
-            amount_usd,
-            MangoError::DelegateWithdrawSmall
         );
     }
 


### PR DESCRIPTION
This is necessary for new liquidator feature of rebalancing using limit orders: 
We need to close the token and market slot so that it's available for new liquidation, but at the same time, it's possible that the min order quantity for a given market is still bigger than allowed max withdrawal.