### PR TITLE
switchboard crank improvements

### DIFF
--- a/ts/client/scripts/sb-on-demand-crank.ts
+++ b/ts/client/scripts/sb-on-demand-crank.ts
@@ -137,7 +137,7 @@ async function setupBackgroundRefresh(
       const startedAt = Date.now();
       const [block, slot] = await Promise.all([
         client.connection.getLatestBlockhash('finalized'),
-        client.connection.getSlot('finalized'),
+        client.connection.getSlot('processed'),
       ]);
 
       await updateFilteredOraclesAis(
@@ -373,8 +373,7 @@ async function filterForStaleOracles(
       // maxStaleness will usually be 250 (=100s)
       // one iteration takes 10s, retry is every 20s
       // this allows for 2 retries until the oracle becomes stale
-      slot - res.lastUpdatedSlot >
-      item.decodedPullFeed.maxStaleness * 0.3
+      diff > item.decodedPullFeed.maxStaleness * 0.3
     ) {
       console.log(
         `[filter stale] ${item.oracle.name}, candidate, ${item.decodedPullFeed.maxStaleness}, ${slot}, ${res.lastUpdatedSlot}, ${diff}`,

--- a/ts/client/scripts/sb-on-demand-crank.ts
+++ b/ts/client/scripts/sb-on-demand-crank.ts
@@ -187,7 +187,7 @@ interface OracleInterface {
                 );
               },
               onError: function (e, notProcessedTransactions, originalProps) {
-
+                console.error("[tx send] num transactions:", notProcessedTransactions.length, e);
               },
             },
           });

--- a/ts/client/src/accounts/healthCache.ts
+++ b/ts/client/src/accounts/healthCache.ts
@@ -949,7 +949,7 @@ export class HealthCache {
     // - be careful about finding the minFnValue: the function isn't convex
 
     const initialRatio = this.healthRatio(HealthType.init);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
 
     const healthCacheClone: HealthCache = deepClone<HealthCache>(this);
     const sourceIndex = healthCacheClone.getOrCreateTokenInfoIndex(sourceBank);


### PR DESCRIPTION
- dont retry oracle updates to prevent writing old state
- submit all oracle updates in parallel to prevent writing old state
- reduce average latency by 1s through prefetching of shared results
- reduce p90 latency by 1m through async refresh of mango group & oracle definitions
- handle promise rejection on tx submission
- improved logging