### PR TITLE
Fix price impact for USDC pairs

### DIFF
--- a/ts/client/src/accounts/group.ts
+++ b/ts/client/src/accounts/group.ts
@@ -604,9 +604,15 @@ export class Group {
   public getPriceImpactByTokenIndex(
     tokenIndex: TokenIndex,
     usdcAmountUi: number,
+    side: 'bid' | 'ask' | undefined = undefined,
   ): number {
     const bank = this.getFirstBankByTokenIndex(tokenIndex);
-    const pisBps = computePriceImpactOnJup(this.pis, usdcAmountUi, bank.name);
+    const pisBps = computePriceImpactOnJup(
+      this.pis,
+      usdcAmountUi,
+      bank.name,
+      side,
+    );
     return (pisBps * 100) / 10000;
   }
 

--- a/ts/client/src/accounts/mangoAccount.ts
+++ b/ts/client/src/accounts/mangoAccount.ts
@@ -2250,18 +2250,32 @@ export class TokenConditionalSwap {
       liqorTcsChunkSizeInUsd = 1000;
     }
 
-    const buyTokenPriceImpact = group.getPriceImpactByTokenIndex(
-      buyBank.tokenIndex,
-      liqorTcsChunkSizeInUsd,
-    );
-    const sellTokenPriceImpact = group.getPriceImpactByTokenIndex(
-      sellBank.tokenIndex,
-      liqorTcsChunkSizeInUsd,
-    );
+    const buyTokenPriceImpact =
+      buyBank.tokenIndex == 0
+        ? group.getPriceImpactByTokenIndex(
+            sellBank.tokenIndex,
+            liqorTcsChunkSizeInUsd,
+            'ask',
+          )
+        : group.getPriceImpactByTokenIndex(
+            buyBank.tokenIndex,
+            liqorTcsChunkSizeInUsd,
+          );
+    const sellTokenPriceImpact =
+      sellBank.tokenIndex == 0
+        ? group.getPriceImpactByTokenIndex(
+            buyBank.tokenIndex,
+            liqorTcsChunkSizeInUsd,
+            'bid',
+          )
+        : group.getPriceImpactByTokenIndex(
+            buyBank.tokenIndex,
+            liqorTcsChunkSizeInUsd,
+          );
 
     if (buyTokenPriceImpact <= 0 || sellTokenPriceImpact <= 0) {
       throw new Error(
-        `Error compitong slippage/premium for token conditional swap!`,
+        `Error computing slippage/premium for token conditional swap!`,
       );
     }
 

--- a/ts/client/src/client.ts
+++ b/ts/client/src/client.ts
@@ -4624,14 +4624,28 @@ export class MangoClient {
 
     // TODO: The max premium should likely be computed differently
     if (!maxPricePremiumPercent) {
-      const buyTokenPriceImpact = group.getPriceImpactByTokenIndex(
-        buyBank.tokenIndex,
-        liqorTcsChunkSizeInUsd,
-      );
-      const sellTokenPriceImpact = group.getPriceImpactByTokenIndex(
-        sellBank.tokenIndex,
-        liqorTcsChunkSizeInUsd,
-      );
+      const buyTokenPriceImpact =
+        buyBank.tokenIndex == 0
+          ? group.getPriceImpactByTokenIndex(
+              sellBank.tokenIndex,
+              liqorTcsChunkSizeInUsd,
+              'ask',
+            )
+          : group.getPriceImpactByTokenIndex(
+              buyBank.tokenIndex,
+              liqorTcsChunkSizeInUsd,
+            );
+      const sellTokenPriceImpact =
+        sellBank.tokenIndex == 0
+          ? group.getPriceImpactByTokenIndex(
+              buyBank.tokenIndex,
+              liqorTcsChunkSizeInUsd,
+              'bid',
+            )
+          : group.getPriceImpactByTokenIndex(
+              buyBank.tokenIndex,
+              liqorTcsChunkSizeInUsd,
+            );
 
       if (buyTokenPriceImpact <= 0 || sellTokenPriceImpact <= 0) {
         throw new Error(

--- a/ts/client/src/risk.ts
+++ b/ts/client/src/risk.ts
@@ -81,6 +81,9 @@ export function computePriceImpactOnJup(
     if (tokenName == 'ETH (Portal)') {
       tokenName = 'ETH';
     }
+    if (tokenName == 'WIF') {
+      tokenName = '$WIF';
+    }
     const filteredPis: PriceImpact[] = pis.filter(
       (pi) => pi.symbol == tokenName && pi.target_amount == closestTo,
     );

--- a/ts/client/src/risk.ts
+++ b/ts/client/src/risk.ts
@@ -70,6 +70,7 @@ export function computePriceImpactOnJup(
   pis: PriceImpact[],
   usdcAmount: number,
   tokenName: string,
+  side: 'bid' | 'ask' | undefined = undefined,
 ): number {
   try {
     const closestTo = [
@@ -85,7 +86,10 @@ export function computePriceImpactOnJup(
       tokenName = '$WIF';
     }
     const filteredPis: PriceImpact[] = pis.filter(
-      (pi) => pi.symbol == tokenName && pi.target_amount == closestTo,
+      (pi) =>
+        pi.symbol == tokenName &&
+        pi.target_amount == closestTo &&
+        (side !== undefined ? pi.side == side : true),
     );
     if (filteredPis.length > 0) {
       return (filteredPis[0].p90 * 10000) / 100;


### PR DESCRIPTION
Calculating price impact fails for pairs including USDC, which prevents TCS orders from being created in the UI.
This change uses the available information in the API response, given all tokens are quoted in USDC there, to give correct price impacts for USDC.

New branch based on deploy with commits cherry picked from `pan/fix-usdc-price-impact`

Lint & Test jobs already failing on base branch