### PR TITLE
Security Fix: Flash loan swap fee bypass via SwapWithoutFee

### DIFF
--- a/programs/mango-v4/src/instructions/flash_loan.rs
+++ b/programs/mango-v4/src/instructions/flash_loan.rs
@@ -279,6 +279,14 @@ pub fn flash_loan_end<'key, 'accounts, 'remaining, 'info>(
         MangoError::SomeError
     );
 
+    // SECURITY FIX: SwapWithoutFee is caller-selectable with no access control,
+    // making swap fees completely unenforceable. Coerce it to Swap to enforce fees.
+    let flash_loan_type = if flash_loan_type == FlashLoanType::SwapWithoutFee {
+        FlashLoanType::Swap
+    } else {
+        flash_loan_type
+    };
+
     let group = account.fixed.group;
 
     let remaining_len = ctx.remaining_accounts.len();


### PR DESCRIPTION
## Security Finding

### [MEDIUM] Flash Loan Swap Fee Bypass
**File:** `programs/mango-v4/src/instructions/flash_loan.rs:265`

**Issue:**
`FlashLoanType` is passed by the caller with no access control. Users can select `FlashLoanType::SwapWithoutFee` instead of `FlashLoanType::Swap` to completely bypass the `flash_loan_swap_fee_rate`, making swap fees unenforceable.

**Impact:** Protocol loses swap fee revenue on all flash loan swaps where users choose the fee-free variant.

**Fix:** Coerce `SwapWithoutFee` to `Swap` so fees are always enforced regardless of caller's choice.

---
*Found during a Solana security audit*