### PR TITLE
ci: bind deploy inputs via env before shell

### DIFF
--- a/.github/workflows/ci-docker-fly-deploy.yml
+++ b/.github/workflows/ci-docker-fly-deploy.yml
@@ -31,4 +31,7 @@ jobs:
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
-        run: flyctl deploy -c cd/${{ inputs.imageName }}.toml -a ${{ inputs.appName }}
+        env:
+          IMAGE_NAME: ${{ inputs.imageName }}
+          APP_NAME: ${{ inputs.appName }}
+        run: flyctl deploy -c "cd/${IMAGE_NAME}.toml" -a "$APP_NAME"

--- a/.github/workflows/ci-docker-heroku-deploy.yml
+++ b/.github/workflows/ci-docker-heroku-deploy.yml
@@ -32,9 +32,14 @@ jobs:
       - name: Push
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: heroku container:push ${{ inputs.imageName }} -a ${{ inputs.appName }} --recursive --arg BASE_TAG=${{ inputs.imageTag }}
+          IMAGE_NAME: ${{ inputs.imageName }}
+          APP_NAME: ${{ inputs.appName }}
+          IMAGE_TAG: ${{ inputs.imageTag }}
+        run: heroku container:push "$IMAGE_NAME" -a "$APP_NAME" --recursive --arg BASE_TAG="$IMAGE_TAG"
 
       - name: Release
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: heroku container:release ${{ inputs.imageName }} -a ${{ inputs.appName }}
+          IMAGE_NAME: ${{ inputs.imageName }}
+          APP_NAME: ${{ inputs.appName }}
+        run: heroku container:release "$IMAGE_NAME" -a "$APP_NAME"


### PR DESCRIPTION
## Summary
Bind `inputs.imageName`, `inputs.appName`, and `inputs.imageTag` into step `env:` before use in the `run:` deploy commands of `ci-docker-heroku-deploy.yml` and `ci-docker-fly-deploy.yml`.

Keeps `${{ }}` expansions out of shell commands.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: dry-run the heroku/fly deploy workflows

Made with [Cursor](https://cursor.com)